### PR TITLE
dateRangePicker emits beginning & end of UTC day 

### DIFF
--- a/src/lib-components/forms/DateRangePicker.vue
+++ b/src/lib-components/forms/DateRangePicker.vue
@@ -36,9 +36,9 @@ export default class DateRangePicker extends Vue {
       onClose: (selectedDates) => {
         if (selectedDates.length === 2) {
           this.updateModelValue({
-            minDate: selectedDates[0].getTime() / 1000,
+            minDate: selectedDates[0].setUTCHours(0, 0, 0, 0) / 1000,
             maxDate: Math.floor(
-              selectedDates[1].setHours(23, 59, 59, 999) / 1000
+              selectedDates[1].setUTCHours(23, 59, 59, 999) / 1000
             ),
           });
         } else if (selectedDates.length === 0) {


### PR DESCRIPTION
In short, this component emitted dates in the middle of the day in Unix time (which is UTC), unless the user's browser was in UTC as well, instead of the beginning & end of the day as intended.

If conversion to another timezone needs to happen, that should occur on the server-side. Otherwise, the timestamp alone does not indicate the originating timezone so some guesswork would have to occur.