### PR TITLE
SidebarLayout: if not item.openInTab, target='_self'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/src/lib-components/layout/SidebarLayout.vue
+++ b/src/lib-components/layout/SidebarLayout.vue
@@ -65,7 +65,7 @@
                       : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
                     'group flex items-center px-2 py-2 text-base font-medium rounded-md',
                   ]"
-                  :target="item.openInTab ? '_blank' : false"
+                  :target="item.openInTab ? '_blank' : '_self'"
                 >
                   <component
                     :is="item.icon"
@@ -111,7 +111,7 @@
                     : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
                   'group flex items-center px-2 py-2 text-sm font-medium rounded-md',
                 ]"
-                :target="item.openInTab ? '_blank' : false"
+                :target="item.openInTab ? '_blank' : '_self'"
               >
                 <component
                   :is="item.icon"


### PR DESCRIPTION
The sidebar was opening links in a new tab when it should not have been. Setting `<a target="_self">` instead of `<a target=false>` resolves that.