### PR TITLE
proposal: form field expansion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install client dependencies
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Publish to npm

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -1,7 +1,25 @@
 <template>
   <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
     <div class="max-w-3xl mx-auto">
-      <ComponentLayout title="Base Input">
+      <ComponentLayout title="Input HTML Attributes" :show-badge="false">
+        <template v-slot:description>
+          <div class="mt-4">
+            Generally, all of these inputs will support common html attributes
+            such as <code>disabled</code> and <code>required</code> or input
+            specific attributes like <code>rows</code> for textareas. You can
+            even use the <code>class</code> attribute as needed to apply
+            additional classes.
+          </div>
+
+          <div class="mt-4">
+            Out of the box they will support a dynamically generated id
+            attribute which is used for accessibility concerns with labels and
+            help text.
+          </div>
+        </template>
+      </ComponentLayout>
+
+      <ComponentLayout class="mt-8" title="Base Input">
         <template v-slot:description>
           Covers many of the most common <code>&lt;input&gt;</code> fields with
           a <code>type="${type}"</code> attribute. Checkout the list of common
@@ -57,6 +75,23 @@
               v-model="customInputTypeVal"
             ></BaseInput>
             <div class="mt-4"><b>Value:</b> {{ customInputTypeVal }}</div>
+            <PropsTable :props="baseInputProps" />
+          </div>
+        </div>
+      </ComponentLayout>
+
+      <ComponentLayout class="mt-8" title="Textarea">
+        <template v-slot:description>
+          A common and consistent textarea input.
+        </template>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="textareaCopy" />
+          </label>
+          <div class="mt-1">
+            <TextArea v-model="textarea" />
+            <PropsTable :props="textareaProps" />
           </div>
         </div>
       </ComponentLayout>
@@ -98,37 +133,6 @@
           <div class="mt-1">
             <DateRangePicker v-model="dateRange" />
             <PropsTable :props="dateRangePickerProps" />
-          </div>
-        </div>
-      </ComponentLayout>
-
-      <ComponentLayout class="mt-8" :css-component="true" title="Input">
-        <template v-slot:description>
-          These aren't using any extra magic other than css. They are styled
-          based off <code>type="text"</code> or one of the
-          <a
-            href="https://developer.mozilla.org/en-US/docs/Learn/Forms/HTML5_input_types"
-            class="xy-link"
-            target="_blank"
-            >input variations</a
-          >. Errors can be styled with <code>.xy-input-error</code>.
-        </template>
-
-        <div>
-          <label class="block text-sm font-medium text-gray-700">
-            <ClickToCopy :value="inputCopy" />
-          </label>
-          <div class="mt-1">
-            <input type="text" placeholder="It's good to be alive" />
-          </div>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium text-gray-700">
-            <ClickToCopy :value="inputErrorCopy" />
-          </label>
-          <div class="mt-1">
-            <input type="text" placeholder="Broken" class="xy-input-error" />
           </div>
         </div>
       </ComponentLayout>
@@ -180,13 +184,7 @@
             <ClickToCopy :value="selectCopy" />
           </label>
           <div class="mt-1">
-            <Select
-              :options="options"
-              label="A really important decision"
-              help="Are you up for this?"
-              placeholder="Select an option that you fancy"
-              v-model="selected"
-            />
+            <Select :options="options" v-model="selected" />
             <PropsTable :props="selectProps" />
           </div>
         </div>
@@ -208,6 +206,40 @@
           </div>
         </div>
       </ComponentLayout>
+
+      <ComponentLayout class="mt-8" title="Input Lable">
+        <template v-slot:description>
+          For whenever you just need a consistent label for a custom layout. Use
+          the tag property for a custom html element like legend.
+        </template>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="inputLabelCopy" />
+          </label>
+          <div class="mt-1">
+            <InputLabel label="I'm labeling somthing..." />
+            <PropsTable :props="inputLabelProps" />
+          </div>
+        </div>
+      </ComponentLayout>
+
+      <ComponentLayout class="mt-8" title="Input Help">
+        <template v-slot:description>
+          For whenever you just need a consistent help text component. Use the
+          tag property for a custom html element like legend.
+        </template>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="inputHelpCopy" />
+          </label>
+          <div class="mt-1">
+            <InputHelp text="I'm just here to hint" />
+            <PropsTable :props="inputHelpProps" />
+          </div>
+        </div>
+      </ComponentLayout>
     </div>
   </div>
 </template>
@@ -217,13 +249,15 @@ import { Options, Vue } from "vue-property-decorator";
 
 @Options({ name: "Forms" })
 export default class Forms extends Vue {
+  commonProps = [
+    { name: "label", required: false, type: "string" },
+    { name: "help", required: false, type: "string" },
+  ];
   checked = false;
   checkboxCopy = `<Checkbox label="I'm here to party!" v-model="checked" />`;
   checkboxProps = [
-    { name: "disabled", required: false, type: "boolean" },
     { name: "emphasis", required: false, type: "boolean" },
     { name: "label", required: false, type: "string" },
-    { name: "required", required: false, type: "boolean" },
     { name: "modelValue", required: true, type: "boolean" },
   ];
   dateRange = { maxRange: 0, minRange: 0 };
@@ -235,9 +269,10 @@ export default class Forms extends Vue {
       type: "{ minDate: number; maxDate: number; }",
     },
     { name: "startDate", required: false, type: "number" },
+    ...this.commonProps,
   ];
-  inputCopy = `<input type="text" placeholder="It's good to be alive" />`;
-  inputErrorCopy = `<input type="text" placeholder="Broken" class="xy-input-error" />`;
+  inputCopy = `<BaseInput type="text" label="What's your lide moto?" help="No wrong ansswers here." placeholder="It's good to be alive"/>`;
+  inputErrorCopy = `<BaseInput type="text" placeholder="Broken" class="xy-input-error" />`;
   multiCheckboxCopy = `<MultiCheckboxes :options="options" v-model="selected" />`;
   multiCheckboxProps = [
     {
@@ -246,18 +281,18 @@ export default class Forms extends Vue {
       type: "Array<{ label: string; value: string }>",
     },
     { name: "modelValue", required: true, type: "string" },
+    { name: "legend", required: false, type: "string" },
   ];
   multiCheckboxSelection = [];
   radioCopy = `<Radio :options="options" v-model="selected" />`;
   radioProps = [
-    { name: "disabled", required: false, type: "boolean" },
     {
       name: "options",
       required: true,
       type: "Array<{ label: string; value: string }>",
     },
-    { name: "required", required: false, type: "boolean" },
     { name: "modelValue", required: true, type: "string" },
+    { name: "legend", required: false, type: "boolean" },
   ];
   radioSelection = "";
   selectCopy = `<Select :options="options" placeholder="Select an option that you fancy" />`;
@@ -270,6 +305,7 @@ export default class Forms extends Vue {
     },
     { name: "placeholder", required: false, type: "string" },
     { name: "modelValue", required: true, type: "string" },
+    ...this.commonProps,
   ];
   options = [
     { label: "You could select this", value: "val1" },
@@ -281,9 +317,22 @@ export default class Forms extends Vue {
   yesOrNoRadioCopy = `<YesOrNoRadio v-model="selected" />`;
   yesOrNoRadioSelection = false;
   yesOrNoRadioProps = [
-    { name: "disabled", required: false, type: "boolean" },
-    { name: "required", required: false, type: "boolean" },
+    { name: "legend", required: false, type: "string" },
+    { name: "name", required: false, type: "string" },
     { name: "modelValue", required: false, type: "boolean" },
+  ];
+
+  textarea = "";
+  textareaProps = [
+    { name: "modelValue", required: false, type: "string" },
+    ...this.commonProps,
+  ];
+  textareaCopy = `<TextArea v-model="textarea" />`;
+
+  baseInputProps = [
+    { name: "type", required: true, type: "string" },
+    { name: "modelValue", required: false, type: "string | number" },
+    ...this.commonProps,
   ];
 
   inputTypes = [
@@ -312,5 +361,17 @@ export default class Forms extends Vue {
 
   inputTypeSelected = "text";
   customInputTypeVal = "";
+
+  inputLabelCopy = `<InputLable lable="I'm labeling something..." />`;
+  inputLabelProps = [
+    { name: "label", required: false, type: "string" },
+    { name: "tag", required: false, type: "string" },
+  ];
+
+  inputHelpCopy = `<InputHelp text="I'm just here to hint." />`;
+  inputHelpProps = [
+    { name: "text", required: false, type: "string" },
+    { name: "tag", required: false, type: "string" },
+  ];
 }
 </script>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -35,14 +35,12 @@
           <label class="block text-sm font-medium text-gray-700">
             <ClickToCopy :value="inputCopy" />
           </label>
-          <Checkbox v-model="testRequired" label="Test Required" />
           <div class="mt-1">
             <BaseInput
               help="No wrong answers here."
               type="text"
               label="What's your life moto?"
               placeholder="It's good to be alive"
-              :required="testRequired"
             ></BaseInput>
           </div>
         </div>
@@ -375,7 +373,5 @@ export default class Forms extends Vue {
     { name: "text", required: false, type: "string" },
     { name: "tag", required: false, type: "string" },
   ];
-
-  testRequired = false;
 }
 </script>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -54,7 +54,9 @@
               :type="inputTypeSelected"
               :label="`Here's an example of an <input type='${inputTypeSelected}'>`"
               :placeholder="`A placeholder for a ${inputTypeSelected}`"
+              v-model="customInputTypeVal"
             ></BaseInput>
+            <div class="mt-4"><b>Value:</b> {{ customInputTypeVal }}</div>
           </div>
         </div>
       </ComponentLayout>
@@ -309,5 +311,6 @@ export default class Forms extends Vue {
   });
 
   inputTypeSelected = "text";
+  customInputTypeVal = "";
 }
 </script>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -35,12 +35,14 @@
           <label class="block text-sm font-medium text-gray-700">
             <ClickToCopy :value="inputCopy" />
           </label>
+          <Checkbox v-model="testRequired" label="Test Required" />
           <div class="mt-1">
             <BaseInput
               help="No wrong answers here."
               type="text"
               label="What's your life moto?"
               placeholder="It's good to be alive"
+              :required="testRequired"
             ></BaseInput>
           </div>
         </div>
@@ -373,5 +375,7 @@ export default class Forms extends Vue {
     { name: "text", required: false, type: "string" },
     { name: "tag", required: false, type: "string" },
   ];
+
+  testRequired = false;
 }
 </script>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -1,7 +1,47 @@
 <template>
   <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
     <div class="max-w-3xl mx-auto">
-      <ComponentLayout title="Checkbox">
+      <ComponentLayout title="Base Input">
+        <template v-slot:description>
+          Covers many of the most common <code>&lt;input&gt;</code> fields with
+          a <code>type="${type}"</code> attribute. Checkout the list of common
+          <a
+            href="https://developer.mozilla.org/en-US/docs/Learn/Forms/HTML5_input_types"
+            class="xy-link"
+            target="_blank"
+            >input variations</a
+          >. Errors can be styled with <code>.xy-input-error</code>.
+        </template>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="inputCopy" />
+          </label>
+          <div class="mt-1">
+            <BaseInput
+              help="No wrong answers"
+              type="text"
+              label="What's your life moto?"
+              placeholder="It's good to be alive"
+            ></BaseInput>
+          </div>
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="inputErrorCopy" />
+          </label>
+          <div class="mt-1">
+            <BaseInput
+              type="text"
+              label="Broken"
+              class="xy-input-error"
+            ></BaseInput>
+          </div>
+        </div>
+      </ComponentLayout>
+
+      <ComponentLayout class="mt-8" title="Checkbox">
         <template v-slot:description>
           Checkboxes are a wrapped component given that they have a complex
           structure.

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -19,7 +19,7 @@
           </label>
           <div class="mt-1">
             <BaseInput
-              help="No wrong answers"
+              help="No wrong answers here."
               type="text"
               label="What's your life moto?"
               placeholder="It's good to be alive"
@@ -36,6 +36,24 @@
               type="text"
               label="Broken"
               class="xy-input-error"
+            ></BaseInput>
+          </div>
+        </div>
+
+        <div>
+          <div class="border-t pt-4 mt-4">
+            <Select
+              :options="inputTypes"
+              label="Try out some common input types"
+              placeholder="Select an input type"
+              v-model="inputTypeSelected"
+              class="mb-8"
+            />
+            <BaseInput
+              :help="`Some help text for a ${inputTypeSelected}`"
+              :type="inputTypeSelected"
+              :label="`Here's an example of an <input type='${inputTypeSelected}'>`"
+              :placeholder="`A placeholder for a ${inputTypeSelected}`"
             ></BaseInput>
           </div>
         </div>
@@ -162,6 +180,8 @@
           <div class="mt-1">
             <Select
               :options="options"
+              label="A really important decision"
+              help="Are you up for this?"
               placeholder="Select an option that you fancy"
               v-model="selected"
             />
@@ -263,5 +283,31 @@ export default class Forms extends Vue {
     { name: "required", required: false, type: "boolean" },
     { name: "modelValue", required: false, type: "boolean" },
   ];
+
+  inputTypes = [
+    "color",
+    "date",
+    "datetime-local",
+    "email",
+    "file",
+    "hidden",
+    "month",
+    "number",
+    "password",
+    "range",
+    "search",
+    "tel",
+    "text",
+    "time",
+    "url",
+    "week",
+  ].map((type: string) => {
+    return {
+      label: type,
+      value: type,
+    };
+  });
+
+  inputTypeSelected = "text";
 }
 </script>

--- a/dev/helpers/ComponentLayout.vue
+++ b/dev/helpers/ComponentLayout.vue
@@ -15,7 +15,7 @@
             <slot name="description"></slot>
           </p>
         </div>
-        <div class="ml-4 mt-4 flex-shrink-0">
+        <div v-if="showBadge" class="ml-4 mt-4 flex-shrink-0">
           <span v-if="cssComponent" class="xy-badge-yellow">
             CSS Class Component
           </span>
@@ -35,6 +35,7 @@ import { ClipboardCopyIcon } from "@heroicons/vue/outline";
 
 @Options({ components: { ClipboardCopyIcon }, name: "ComponentLayout" })
 export default class ComponentLayout extends Vue {
+  @Prop({ type: Boolean, required: false, default: true }) showBadge?: boolean;
   @Prop({ type: Boolean, required: false }) cssComponent?: boolean;
   @Prop({ type: String, required: true }) title!: string;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/src/helpers/Uniques.ts
+++ b/src/helpers/Uniques.ts
@@ -1,0 +1,13 @@
+const CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+const CreateIdAttribute = (length = 8): string => {
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += CHARS.charAt(Math.floor(Math.random() * CHARS.length));
+  }
+  return result;
+};
+
+export default {
+  CreateIdAttribute,
+};

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -37,7 +37,7 @@ import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
 
 @Options({ name: "BaseInput" })
-export default class InputText extends Vue {
+export default class BaseInput extends Vue {
   @Prop({ type: String, required: true }) type?: string;
   @Prop({ type: String, required: false }) label?: string;
   @Prop({ type: String, required: false }) help?: string;

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -35,8 +35,10 @@
 <script lang="ts">
 import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
+import InputLabel from "./InputLabel.vue";
+import InputHelp from "./InputHelp.vue";
 
-@Options({ name: "BaseInput" })
+@Options({ name: "BaseInput", components: { InputLabel, InputHelp } })
 export default class BaseInput extends Vue {
   @Prop({ type: String, required: true }) type?: string;
   @Prop({ type: String, required: false }) label?: string;

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -45,7 +45,7 @@ export default class BaseInput extends Vue {
   @Prop({ type: String, required: false }) help?: string;
   @Prop({ type: [String, Number], required: false }) modelValue?: string;
 
-  uuid = Uniques.CreateIdAttribute();
+  uuid = (this.$attrs.id as string) || Uniques.CreateIdAttribute();
 
   /**
    * common text based inputs

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -1,9 +1,27 @@
 <template>
-  <InputLabel :id="`${uuid}-label`" :for="uuid" :label="label"></InputLabel>
+  <InputLabel
+    class="block"
+    :id="`${uuid}-label`"
+    :for="uuid"
+    :label="label"
+  ></InputLabel>
   <input
-    class="my-2 shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md"
     :aria-labelledby="label ? `${uuid}-label` : undefined"
     :aria-describedby="help ? `${uuid}-help` : undefined"
+    :class="[
+      ...['mt-1', 'sm:text-sm'],
+      ...(isTextType
+        ? [
+            'block',
+            'shadow-sm',
+            'focus:ring-blue-500',
+            'focus:border-blue-500',
+            'border-gray-300',
+            'rounded-md',
+            'w-full',
+          ]
+        : []),
+    ]"
     :id="uuid"
     :placeholder="label"
     :type="type"
@@ -18,7 +36,7 @@
 import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
 
-@Options({ name: "BaseText" })
+@Options({ name: "BaseInput" })
 export default class InputText extends Vue {
   @Prop({ type: String, required: true }) type?: string;
   @Prop({ type: String, required: false }) label?: string;
@@ -27,7 +45,31 @@ export default class InputText extends Vue {
 
   uuid = Uniques.CreateIdAttribute();
 
-  // TODO: modify class output based on text like input fields vs. widget fields
-  // TODO: include a basic help text prop as well.
+  /**
+   * common text based inputs
+   */
+  textInputTypes = [
+    "date",
+    "datetime-local",
+    "email",
+    "month",
+    "number",
+    "password",
+    "search",
+    "tel",
+    "text",
+    "time",
+    "url",
+    "week",
+  ];
+
+  /**
+   * determine if this input is a common text based input
+   */
+  get isTextType(): boolean {
+    return (
+      typeof this.type === "string" && this.textInputTypes.includes(this.type)
+    );
+  }
 }
 </script>

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -1,0 +1,33 @@
+<template>
+  <InputLabel :id="`${uuid}-label`" :for="uuid" :label="label"></InputLabel>
+  <input
+    class="my-2 shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md"
+    :aria-labelledby="label ? `${uuid}-label` : undefined"
+    :aria-describedby="help ? `${uuid}-help` : undefined"
+    :id="uuid"
+    :placeholder="label"
+    :type="type"
+    :value="modelValue"
+    @input="$emit('update:modelValue', $event.target.value)"
+    v-bind="$attrs"
+  />
+  <InputHelp :id="`${uuid}-help`" :text="help"></InputHelp>
+</template>
+
+<script lang="ts">
+import Uniques from "@/helpers/Uniques";
+import { Options, Prop, Vue } from "vue-property-decorator";
+
+@Options({ name: "BaseText" })
+export default class InputText extends Vue {
+  @Prop({ type: String, required: true }) type?: string;
+  @Prop({ type: String, required: false }) label?: string;
+  @Prop({ type: String, required: false }) help?: string;
+  @Prop({ type: [String, Number], required: false }) modelValue?: string;
+
+  uuid = Uniques.CreateIdAttribute();
+
+  // TODO: modify class output based on text like input fields vs. widget fields
+  // TODO: include a basic help text prop as well.
+}
+</script>

--- a/src/lib-components/forms/Checkbox.vue
+++ b/src/lib-components/forms/Checkbox.vue
@@ -19,8 +19,7 @@
       <label
         :id="`${uuid}-label`"
         :for="uuid"
-        class="text-gray-500"
-        :class="{ 'font-medium': emphasis }"
+        :class="{ 'font-semibold': emphasis }"
         v-text="label"
       ></label>
     </div>

--- a/src/lib-components/forms/Checkbox.vue
+++ b/src/lib-components/forms/Checkbox.vue
@@ -2,16 +2,23 @@
   <div class="relative flex items-start">
     <div class="h-5 flex items-center">
       <input
-        type="checkbox"
-        class="focus:ring-blue-500 h-4 w-4 text-xy-blue border-gray-300 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+        :aria-labelledby="label ? `${uuid}-label` : undefined"
         :checked="modelValue"
-        :disabled="disabled"
-        @change="$emit('update:modelValue', $event.target.checked)"
-        :required="required"
+        class="focus:ring-blue-500 h-4 w-4 text-xy-blue border-gray-300 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+        :id="uuid"
+        type="checkbox"
+        v-bind="{
+          ...$attrs,
+          onChange: ($event) => {
+            $emit('update:modelValue', $event.target.checked);
+          },
+        }"
       />
     </div>
     <div class="ml-3 text-sm leading-5">
       <label
+        :id="`${uuid}-label`"
+        :for="uuid"
         class="text-gray-500"
         :class="{ 'font-medium': emphasis }"
         v-text="label"
@@ -21,14 +28,15 @@
 </template>
 
 <script lang="ts">
+import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
 
 @Options({ name: "Checkbox" })
 export default class Checkbox extends Vue {
-  @Prop({ type: Boolean, required: false }) disabled?: boolean;
   @Prop({ type: Boolean, required: false }) emphasis?: boolean;
   @Prop({ type: String, required: false }) label?: string;
-  @Prop({ type: Boolean, required: false }) required?: boolean;
   @Prop({ type: Boolean, required: true }) modelValue!: boolean;
+
+  uuid = Uniques.CreateIdAttribute();
 }
 </script>

--- a/src/lib-components/forms/Checkbox.vue
+++ b/src/lib-components/forms/Checkbox.vue
@@ -37,6 +37,6 @@ export default class Checkbox extends Vue {
   @Prop({ type: String, required: false }) label?: string;
   @Prop({ type: Boolean, required: true }) modelValue!: boolean;
 
-  uuid = Uniques.CreateIdAttribute();
+  uuid = (this.$attrs.id as string) || Uniques.CreateIdAttribute();
 }
 </script>

--- a/src/lib-components/forms/DateRangePicker.vue
+++ b/src/lib-components/forms/DateRangePicker.vue
@@ -14,8 +14,10 @@ import Uniques from "@/helpers/Uniques";
 import { Emit, Options, Prop, Vue } from "vue-property-decorator";
 import flatpickr from "flatpickr";
 import "flatpickr/dist/flatpickr.min.css";
+import InputLabel from "./InputLabel.vue";
+import InputHelp from "./InputHelp.vue";
 
-@Options({ name: "DateRangePicker" })
+@Options({ name: "DateRangePicker", components: { InputLabel, InputHelp } })
 export default class DateRangePicker extends Vue {
   @Prop({ type: Object, required: true }) modelValue!: {
     minDate: number;

--- a/src/lib-components/forms/DateRangePicker.vue
+++ b/src/lib-components/forms/DateRangePicker.vue
@@ -14,10 +14,14 @@ import Uniques from "@/helpers/Uniques";
 import { Emit, Options, Prop, Vue } from "vue-property-decorator";
 import flatpickr from "flatpickr";
 import "flatpickr/dist/flatpickr.min.css";
+import BaseInput from "./BaseInput.vue";
 import InputLabel from "./InputLabel.vue";
 import InputHelp from "./InputHelp.vue";
 
-@Options({ name: "DateRangePicker", components: { InputLabel, InputHelp } })
+@Options({
+  name: "DateRangePicker",
+  components: { BaseInput, InputLabel, InputHelp },
+})
 export default class DateRangePicker extends Vue {
   @Prop({ type: Object, required: true }) modelValue!: {
     minDate: number;

--- a/src/lib-components/forms/DateRangePicker.vue
+++ b/src/lib-components/forms/DateRangePicker.vue
@@ -1,12 +1,11 @@
 <template>
-  <InputLabel
-    class="block"
-    :id="`${uuid}-label`"
-    :for="uuid"
+  <BaseInput
+    type="text"
+    placeholder="mm-dd-yyyy range"
+    :id="uuid"
     :label="label"
-  ></InputLabel>
-  <BaseInput type="text" placeholder="mm-dd-yyyy range" :id="uuid"></BaseInput>
-  <InputHelp :id="`${uuid}-help`" :text="help"></InputHelp>
+    :help="help"
+  ></BaseInput>
 </template>
 
 <script lang="ts">
@@ -15,12 +14,10 @@ import { Emit, Options, Prop, Vue } from "vue-property-decorator";
 import flatpickr from "flatpickr";
 import "flatpickr/dist/flatpickr.min.css";
 import BaseInput from "./BaseInput.vue";
-import InputLabel from "./InputLabel.vue";
-import InputHelp from "./InputHelp.vue";
 
 @Options({
   name: "DateRangePicker",
-  components: { BaseInput, InputLabel, InputHelp },
+  components: { BaseInput },
 })
 export default class DateRangePicker extends Vue {
   @Prop({ type: Object, required: true }) modelValue!: {
@@ -31,7 +28,7 @@ export default class DateRangePicker extends Vue {
   @Prop({ type: String, required: false }) label?: string;
   @Prop({ type: String, required: false }) help?: string;
 
-  uuid = Uniques.CreateIdAttribute();
+  uuid = (this.$attrs.id as string) || Uniques.CreateIdAttribute();
 
   @Emit("update:modelValue")
   updateModelValue(value: {

--- a/src/lib-components/forms/DateRangePicker.vue
+++ b/src/lib-components/forms/DateRangePicker.vue
@@ -1,12 +1,16 @@
 <template>
-  <input
-    type="text"
-    class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md"
-    placeholder="mm-dd-yyyy range"
-  />
+  <InputLabel
+    class="block"
+    :id="`${uuid}-label`"
+    :for="uuid"
+    :label="label"
+  ></InputLabel>
+  <BaseInput type="text" placeholder="mm-dd-yyyy range" :id="uuid"></BaseInput>
+  <InputHelp :id="`${uuid}-help`" :text="help"></InputHelp>
 </template>
 
 <script lang="ts">
+import Uniques from "@/helpers/Uniques";
 import { Emit, Options, Prop, Vue } from "vue-property-decorator";
 import flatpickr from "flatpickr";
 import "flatpickr/dist/flatpickr.min.css";
@@ -18,6 +22,10 @@ export default class DateRangePicker extends Vue {
     maxDate: number;
   };
   @Prop({ type: Number, required: false }) startDate?: number;
+  @Prop({ type: String, required: false }) label?: string;
+  @Prop({ type: String, required: false }) help?: string;
+
+  uuid = Uniques.CreateIdAttribute();
 
   @Emit("update:modelValue")
   updateModelValue(value: {
@@ -28,7 +36,7 @@ export default class DateRangePicker extends Vue {
   }
 
   mounted() {
-    flatpickr(this.$el, {
+    flatpickr(`#${this.uuid}`, {
       dateFormat: "m-d-Y",
       mode: "range",
       maxDate: new Date(), // So far, we cannot have options past today for ranges

--- a/src/lib-components/forms/InputHelp.vue
+++ b/src/lib-components/forms/InputHelp.vue
@@ -1,5 +1,6 @@
 <template>
-  <div
+  <component
+    :is="tag"
     v-if="text"
     v-bind="{
       ...$attrs,
@@ -7,7 +8,7 @@
     }"
   >
     {{ text }}
-  </div>
+  </component>
 </template>
 <script lang="ts">
 import { Options, Prop, Vue } from "vue-property-decorator";
@@ -15,5 +16,6 @@ import { Options, Prop, Vue } from "vue-property-decorator";
 @Options({ name: "InputHelp" })
 export default class InputHelp extends Vue {
   @Prop({ type: String, required: false }) text?: string;
+  @Prop({ type: String, required: false, default: "div" }) tag?: string;
 }
 </script>

--- a/src/lib-components/forms/InputHelp.vue
+++ b/src/lib-components/forms/InputHelp.vue
@@ -1,8 +1,10 @@
 <template>
   <div
-    class="my-2 text-sm leading-snug font-normal text-gray-500"
-    v-bind="$attrs"
     v-if="text"
+    v-bind="{
+      ...$attrs,
+      class: 'my-2 text-sm leading-snug font-normal text-gray-500',
+    }"
   >
     {{ text }}
   </div>

--- a/src/lib-components/forms/InputHelp.vue
+++ b/src/lib-components/forms/InputHelp.vue
@@ -1,0 +1,17 @@
+<template>
+  <div
+    class="my-2 text-sm leading-snug font-normal text-gray-500"
+    v-bind="$attrs"
+    v-if="text"
+  >
+    {{ text }}
+  </div>
+</template>
+<script lang="ts">
+import { Options, Prop, Vue } from "vue-property-decorator";
+
+@Options({ name: "InputHelp" })
+export default class InputHelp extends Vue {
+  @Prop({ type: String, required: false }) text?: string;
+}
+</script>

--- a/src/lib-components/forms/InputLabel.vue
+++ b/src/lib-components/forms/InputLabel.vue
@@ -4,7 +4,7 @@
     v-if="label"
     v-bind="{
       ...$attrs,
-      class: 'my-2 text-sm font-semibold leading-snug text-gray-900',
+      class: 'block my-2 text-sm font-semibold leading-snug text-gray-900',
     }"
     >{{ label }}</component
   >

--- a/src/lib-components/forms/InputLabel.vue
+++ b/src/lib-components/forms/InputLabel.vue
@@ -1,9 +1,12 @@
 <template>
-  <label
-    class="my-2 text-sm font-semibold leading-snug text-gray-900"
-    v-bind="$attrs"
+  <component
+    :is="type"
     v-if="label"
-    >{{ label }}</label
+    v-bind="{
+      ...$attrs,
+      class: 'my-2 text-sm font-semibold leading-snug text-gray-900',
+    }"
+    >{{ label }}</component
   >
 </template>
 <script lang="ts">
@@ -12,5 +15,6 @@ import { Options, Prop, Vue } from "vue-property-decorator";
 @Options({ name: "InputLabel" })
 export default class InputText extends Vue {
   @Prop({ type: String, required: false }) label?: string;
+  @Prop({ type: String, required: false, default: "label" }) type?: string;
 }
 </script>

--- a/src/lib-components/forms/InputLabel.vue
+++ b/src/lib-components/forms/InputLabel.vue
@@ -1,0 +1,16 @@
+<template>
+  <label
+    class="my-2 text-sm font-semibold leading-snug text-gray-900"
+    v-bind="$attrs"
+    v-if="label"
+    >{{ label }}</label
+  >
+</template>
+<script lang="ts">
+import { Options, Prop, Vue } from "vue-property-decorator";
+
+@Options({ name: "InputLabel" })
+export default class InputText extends Vue {
+  @Prop({ type: String, required: false }) label?: string;
+}
+</script>

--- a/src/lib-components/forms/InputLabel.vue
+++ b/src/lib-components/forms/InputLabel.vue
@@ -13,7 +13,7 @@
 import { Options, Prop, Vue } from "vue-property-decorator";
 
 @Options({ name: "InputLabel" })
-export default class InputText extends Vue {
+export default class InputLabel extends Vue {
   @Prop({ type: String, required: false }) label?: string;
   @Prop({ type: String, required: false, default: "label" }) tag?: string;
 }

--- a/src/lib-components/forms/InputLabel.vue
+++ b/src/lib-components/forms/InputLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <component
-    :is="type"
+    :is="tag"
     v-if="label"
     v-bind="{
       ...$attrs,
@@ -15,6 +15,6 @@ import { Options, Prop, Vue } from "vue-property-decorator";
 @Options({ name: "InputLabel" })
 export default class InputText extends Vue {
   @Prop({ type: String, required: false }) label?: string;
-  @Prop({ type: String, required: false, default: "label" }) type?: string;
+  @Prop({ type: String, required: false, default: "label" }) tag?: string;
 }
 </script>

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -41,7 +41,7 @@ export default class MultiCheckboxes extends Vue {
 
   model: string[] = [];
 
-  uuid = Uniques.CreateIdAttribute();
+  uuid = (this.$attrs.id as string) || Uniques.CreateIdAttribute();
 
   @Watch("model")
   onModelChanged(val: string[]): void {

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -1,6 +1,6 @@
 <template>
   <fieldset>
-    <InputLabel class="block mb-0" :label="legend" type="legend"></InputLabel>
+    <InputLabel class="block mb-0" :label="legend" tag="legend"></InputLabel>
     <div class="mt-4" v-for="(option, index) in options" :key="option.value">
       <div class="flex items-start">
         <div class="flex items-center h-5">

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -28,8 +28,9 @@
 <script lang="ts">
 import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue, Watch } from "vue-property-decorator";
+import InputLabel from "./InputLabel.vue";
 
-@Options({ name: "MultiCheckboxes" })
+@Options({ name: "MultiCheckboxes", components: { InputLabel } })
 export default class MultiCheckboxes extends Vue {
   @Prop({ type: Array, required: true }) options!: Array<{
     label: string;

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -14,11 +14,7 @@
           />
         </div>
         <div class="ml-3 text-sm leading-5">
-          <label
-            class="text-gray-500"
-            :for="`${uuid}-${index}`"
-            v-text="option.label"
-          ></label>
+          <label :for="`${uuid}-${index}`" v-text="option.label"></label>
         </div>
       </div>
     </div>

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -1,17 +1,24 @@
 <template>
   <fieldset>
-    <div class="mt-4" v-for="option in options" :key="option.value">
+    <InputLabel class="block mb-0" :label="legend" type="legend"></InputLabel>
+    <div class="mt-4" v-for="(option, index) in options" :key="option.value">
       <div class="flex items-start">
         <div class="flex items-center h-5">
           <input
             type="checkbox"
             class="focus:ring-blue-500 h-4 w-4 text-xy-blue border-gray-300 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+            :id="`${uuid}-${index}`"
             :value="option.value"
             v-model="model"
+            v-bind="$attrs"
           />
         </div>
         <div class="ml-3 text-sm leading-5">
-          <label class="text-gray-500" v-text="option.label"></label>
+          <label
+            class="text-gray-500"
+            :for="`${uuid}-${index}`"
+            v-text="option.label"
+          ></label>
         </div>
       </div>
     </div>
@@ -19,6 +26,7 @@
 </template>
 
 <script lang="ts">
+import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue, Watch } from "vue-property-decorator";
 
 @Options({ name: "MultiCheckboxes" })
@@ -27,9 +35,12 @@ export default class MultiCheckboxes extends Vue {
     label: string;
     value: string;
   }>;
+  @Prop({ type: String, required: false }) legend?: string;
   @Prop({ type: Array, required: true }) modelValue!: string[];
 
   model: string[] = [];
+
+  uuid = Uniques.CreateIdAttribute();
 
   @Watch("model")
   onModelChanged(val: string[]): void {

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -42,6 +42,6 @@ export default class Radio extends Vue {
   @Prop({ type: String, required: false }) legend?: string;
   @Prop({ type: String, required: false }) modelValue?: string;
 
-  uuid = Uniques.CreateIdAttribute();
+  uuid = (this.$attrs.id as string) || Uniques.CreateIdAttribute();
 }
 </script>

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -31,8 +31,9 @@
 <script lang="ts">
 import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
+import InputLabel from "./InputLabel.vue";
 
-@Options({ name: "Radio" })
+@Options({ name: "Radio", components: { InputLabel } })
 export default class Radio extends Vue {
   @Prop({ type: Array, required: true }) options!: Array<{
     label: string;

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -1,19 +1,24 @@
 <template>
   <fieldset class="mt-1 space-y-2">
-    <div v-for="option in options" :key="option.value">
+    <InputLabel class="block" :label="legend" type="legend"></InputLabel>
+    <div v-for="(option, index) in options" :key="option.value">
       <label
         class="inline-flex items-center"
-        :class="{ 'cursor-not-allowed': disabled }"
+        :class="{ 'cursor-not-allowed': $attrs.disabled }"
+        :for="`${uuid}-${index}`"
       >
         <input
-          type="radio"
-          class="w-4 h-4 border-gray-300 focus:ring-blue-500 text-xy-blue"
-          :disabled="disabled"
-          :name="option.label"
-          :value="option.value"
           :checked="modelValue === option.value"
-          @change="$emit('update:modelValue', $event.target.value)"
-          :required="required"
+          class="w-4 h-4 border-gray-300 focus:ring-blue-500 text-xy-blue"
+          :id="`${uuid}-${index}`"
+          type="radio"
+          :value="option.value"
+          v-bind="{
+            ...$attrs,
+            onChange: ($event) => {
+              $emit('update:modelValue', $event.target.value);
+            },
+          }"
         />
         <span class="block ml-2 text-sm font-medium text-gray-700 leading-5">
           {{ option.label }}
@@ -24,16 +29,18 @@
 </template>
 
 <script lang="ts">
+import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
 
 @Options({ name: "Radio" })
 export default class Radio extends Vue {
-  @Prop({ type: Boolean, required: false }) disabled?: boolean;
   @Prop({ type: Array, required: true }) options!: Array<{
     label: string;
     value: string;
   }>;
-  @Prop({ type: Boolean, required: false }) required?: boolean;
+  @Prop({ type: String, required: false }) legend?: string;
   @Prop({ type: String, required: false }) modelValue?: string;
+
+  uuid = Uniques.CreateIdAttribute();
 }
 </script>

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -1,6 +1,6 @@
 <template>
   <fieldset class="mt-1 space-y-2">
-    <InputLabel class="block" :label="legend" type="legend"></InputLabel>
+    <InputLabel class="block" :label="legend" tag="legend"></InputLabel>
     <div v-for="(option, index) in options" :key="option.value">
       <label
         class="inline-flex items-center"

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -20,7 +20,7 @@
             },
           }"
         />
-        <span class="block ml-2 text-sm font-medium text-gray-700 leading-5">
+        <span class="block ml-2 text-sm font-medium leading-5">
           {{ option.label }}
         </span>
       </label>

--- a/src/lib-components/forms/Select.vue
+++ b/src/lib-components/forms/Select.vue
@@ -1,8 +1,17 @@
 <template>
+  <InputLabel :id="`${uuid}-label`" :for="uuid" :label="label"></InputLabel>
   <select
+    :aria-labelledby="label ? `${uuid}-label` : undefined"
+    :aria-describedby="help ? `${uuid}-help` : undefined"
     :class="classes"
+    :id="uuid"
     :value="modelValue"
-    @change="$emit('update:modelValue', $event.target.value)"
+    v-bind="{
+      ...$attrs,
+      onChange: ($event) => {
+        $emit('update:modelValue', $event.target.value);
+      },
+    }"
   >
     <option
       value=""
@@ -20,14 +29,18 @@
       :key="option.value"
     ></option>
   </select>
+  <InputHelp :id="`${uuid}-help`" :text="help"></InputHelp>
 </template>
 
 <script lang="ts">
+import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
 
 @Options({ name: "Select" })
 export default class Select extends Vue {
   @Prop({ type: String, required: false }) design?: string;
+  @Prop({ type: String, required: false }) label?: string;
+  @Prop({ type: String, required: false }) help?: string;
   @Prop({ type: Array, required: true }) options!: Array<{
     label: string;
     value: string;
@@ -35,6 +48,8 @@ export default class Select extends Vue {
   @Prop({ type: String, required: false, default: "Select an option" })
   placeholder?: string;
   @Prop({ type: String, required: true }) modelValue!: string | undefined;
+
+  uuid = Uniques.CreateIdAttribute();
 
   get classes(): string {
     const design = this.design ? this.design : "undefined";

--- a/src/lib-components/forms/Select.vue
+++ b/src/lib-components/forms/Select.vue
@@ -51,7 +51,7 @@ export default class Select extends Vue {
   placeholder?: string;
   @Prop({ type: String, required: true }) modelValue!: string | undefined;
 
-  uuid = Uniques.CreateIdAttribute();
+  uuid = (this.$attrs.id as string) || Uniques.CreateIdAttribute();
 
   get classes(): string {
     const design = this.design ? this.design : "undefined";

--- a/src/lib-components/forms/Select.vue
+++ b/src/lib-components/forms/Select.vue
@@ -4,7 +4,15 @@
     :value="modelValue"
     @change="$emit('update:modelValue', $event.target.value)"
   >
-    <option value="" disabled selected v-if="placeholder" :placeholder="placeholder">{{ placeholder }}</option>
+    <option
+      value=""
+      disabled
+      selected
+      v-if="placeholder"
+      :placeholder="placeholder"
+    >
+      {{ placeholder }}
+    </option>
     <option
       v-for="option in options"
       :value="option.value"

--- a/src/lib-components/forms/Select.vue
+++ b/src/lib-components/forms/Select.vue
@@ -35,8 +35,10 @@
 <script lang="ts">
 import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
+import InputLabel from "./InputLabel.vue";
+import InputHelp from "./InputHelp.vue";
 
-@Options({ name: "Select" })
+@Options({ name: "Select", components: { InputLabel, InputHelp } })
 export default class Select extends Vue {
   @Prop({ type: String, required: false }) design?: string;
   @Prop({ type: String, required: false }) label?: string;

--- a/src/lib-components/forms/TextArea.vue
+++ b/src/lib-components/forms/TextArea.vue
@@ -42,6 +42,6 @@ export default class TextArea extends Vue {
   @Prop({ type: String, required: false }) help?: string;
   @Prop({ type: [String, Number], required: false }) modelValue?: string;
 
-  uuid = Uniques.CreateIdAttribute();
+  uuid = (this.$attrs.id as string) || Uniques.CreateIdAttribute();
 }
 </script>

--- a/src/lib-components/forms/TextArea.vue
+++ b/src/lib-components/forms/TextArea.vue
@@ -21,7 +21,6 @@
     ]"
     :id="uuid"
     :placeholder="label"
-    :type="type"
     :value="modelValue"
     @input="$emit('update:modelValue', $event.target.value)"
     v-bind="$attrs"
@@ -37,7 +36,6 @@ import InputHelp from "./InputHelp.vue";
 
 @Options({ name: "TextArea", components: { InputLabel, InputHelp } })
 export default class TextArea extends Vue {
-  @Prop({ type: String, required: true }) type?: string;
   @Prop({ type: String, required: false }) label?: string;
   @Prop({ type: String, required: false }) help?: string;
   @Prop({ type: [String, Number], required: false }) modelValue?: string;

--- a/src/lib-components/forms/TextArea.vue
+++ b/src/lib-components/forms/TextArea.vue
@@ -20,7 +20,6 @@
       'w-full',
     ]"
     :id="uuid"
-    :placeholder="label"
     :value="modelValue"
     @input="$emit('update:modelValue', $event.target.value)"
     v-bind="$attrs"

--- a/src/lib-components/forms/TextArea.vue
+++ b/src/lib-components/forms/TextArea.vue
@@ -32,8 +32,10 @@
 <script lang="ts">
 import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
+import InputLabel from "./InputLabel.vue";
+import InputHelp from "./InputHelp.vue";
 
-@Options({ name: "TextArea" })
+@Options({ name: "TextArea", components: { InputLabel, InputHelp } })
 export default class TextArea extends Vue {
   @Prop({ type: String, required: true }) type?: string;
   @Prop({ type: String, required: false }) label?: string;

--- a/src/lib-components/forms/TextArea.vue
+++ b/src/lib-components/forms/TextArea.vue
@@ -1,0 +1,45 @@
+<template>
+  <InputLabel
+    class="block"
+    :id="`${uuid}-label`"
+    :for="uuid"
+    :label="label"
+  ></InputLabel>
+  <textarea
+    :aria-labelledby="label ? `${uuid}-label` : undefined"
+    :aria-describedby="help ? `${uuid}-help` : undefined"
+    :class="[
+      'mt-1',
+      'sm:text-sm',
+      'block',
+      'shadow-sm',
+      'focus:ring-blue-500',
+      'focus:border-blue-500',
+      'border-gray-300',
+      'rounded-md',
+      'w-full',
+    ]"
+    :id="uuid"
+    :placeholder="label"
+    :type="type"
+    :value="modelValue"
+    @input="$emit('update:modelValue', $event.target.value)"
+    v-bind="$attrs"
+  />
+  <InputHelp :id="`${uuid}-help`" :text="help"></InputHelp>
+</template>
+
+<script lang="ts">
+import Uniques from "@/helpers/Uniques";
+import { Options, Prop, Vue } from "vue-property-decorator";
+
+@Options({ name: "TextArea" })
+export default class TextArea extends Vue {
+  @Prop({ type: String, required: true }) type?: string;
+  @Prop({ type: String, required: false }) label?: string;
+  @Prop({ type: String, required: false }) help?: string;
+  @Prop({ type: [String, Number], required: false }) modelValue?: string;
+
+  uuid = Uniques.CreateIdAttribute();
+}
+</script>

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -1,6 +1,6 @@
 <template>
   <fieldset>
-    <InputLabel class="block" :label="legend" type="legend"></InputLabel>
+    <InputLabel class="block" :label="legend" tag="legend"></InputLabel>
     <label
       class="inline-flex items-center"
       :class="{ 'cursor-not-allowed': $attrs.disabled }"

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -59,7 +59,7 @@ export default class YesOrNoRadio extends Vue {
   @Prop({ type: String, required: false }) legend?: string;
   @Prop({ type: String, required: false, default: "" }) name?: string;
 
-  uuid = Uniques.CreateIdAttribute();
+  uuid = (this.$attrs.id as string) || Uniques.CreateIdAttribute();
 
   get hasNameAttr(): boolean {
     return typeof this.name === "string" && this.name !== "";

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -51,8 +51,9 @@
 <script lang="ts">
 import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
+import InputLabel from "./InputLabel.vue";
 
-@Options({ name: "YesOrNoRadio" })
+@Options({ name: "YesOrNoRadio", components: { InputLabel } })
 export default class YesOrNoRadio extends Vue {
   @Prop({ type: Boolean, required: false }) modelValue?: boolean;
   @Prop({ type: String, required: false }) legend?: string;

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -41,9 +41,7 @@
           },
         }"
       />
-      <span class="block ml-2 text-sm font-medium text-gray-700 leading-5"
-        >No</span
-      >
+      <span class="block ml-2 text-sm font-medium leading-5">No</span>
     </label>
   </fieldset>
 </template>

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -46,6 +46,6 @@ export default class YesOrNoRadio extends Vue {
   @Prop({ type: Boolean, required: false }) disabled?: boolean;
   @Prop({ type: Boolean, required: false }) required?: boolean;
   @Prop({ type: Boolean, required: false }) modelValue?: boolean;
-  @Prop({ type: String, required: false, default:"yesNoRadio" }) name?: string;
+  @Prop({ type: String, required: false, default: "yesNoRadio" }) name?: string;
 }
 </script>

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -1,18 +1,23 @@
 <template>
   <fieldset>
+    <InputLabel class="block" :label="legend" type="legend"></InputLabel>
     <label
       class="inline-flex items-center"
-      :class="{ 'cursor-not-allowed': disabled }"
+      :class="{ 'cursor-not-allowed': $attrs.disabled }"
+      :for="`${hasNameAttr ? name : uuid}-true`"
     >
       <input
-        :name="name"
         type="radio"
         class="w-4 h-4 border-gray-300 focus:ring-blue-500 text-xy-blue"
-        :disabled="disabled"
+        :id="`${hasNameAttr ? name : uuid}-true`"
         :value="true"
         :checked="modelValue === true"
-        @change="$emit('update:modelValue', $event.target.value === 'true')"
-        :required="required"
+        v-bind="{
+          ...$attrs,
+          onChange: ($event) => {
+            $emit('update:modelValue', $event.target.value === 'true');
+          },
+        }"
       />
       <span class="block ml-2 text-sm font-medium text-gray-700 leading-5"
         >Yes</span
@@ -20,16 +25,21 @@
     </label>
     <label
       class="inline-flex items-center ml-6"
-      :class="{ 'cursor-not-allowed': disabled }"
+      :class="{ 'cursor-not-allowed': $attrs.disabled }"
+      :for="`${hasNameAttr ? name : uuid}-false`"
     >
       <input
-        :name="name"
         type="radio"
         class="w-4 h-4 border-gray-300 focus:ring-blue-500 text-xy-blue"
-        :disabled="disabled"
+        :id="`${hasNameAttr ? name : uuid}-false`"
         :value="false"
         :checked="modelValue === false"
-        @change="$emit('update:modelValue', $event.target.value === 'true')"
+        v-bind="{
+          ...$attrs,
+          onChange: ($event) => {
+            $emit('update:modelValue', $event.target.value === 'true');
+          },
+        }"
       />
       <span class="block ml-2 text-sm font-medium text-gray-700 leading-5"
         >No</span
@@ -39,13 +49,19 @@
 </template>
 
 <script lang="ts">
+import Uniques from "@/helpers/Uniques";
 import { Options, Prop, Vue } from "vue-property-decorator";
 
 @Options({ name: "YesOrNoRadio" })
 export default class YesOrNoRadio extends Vue {
-  @Prop({ type: Boolean, required: false }) disabled?: boolean;
-  @Prop({ type: Boolean, required: false }) required?: boolean;
   @Prop({ type: Boolean, required: false }) modelValue?: boolean;
-  @Prop({ type: String, required: false, default: "yesNoRadio" }) name?: string;
+  @Prop({ type: String, required: false }) legend?: string;
+  @Prop({ type: String, required: false, default: "" }) name?: string;
+
+  uuid = Uniques.CreateIdAttribute();
+
+  get hasNameAttr(): boolean {
+    return typeof this.name === "string" && this.name !== "";
+  }
 }
 </script>

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -22,6 +22,9 @@ export { default as Tabs } from "./navigation/Tabs.vue";
 // Form components
 export { default as Checkbox } from "./forms/Checkbox.vue";
 export { default as DateRangePicker } from "./forms/DateRangePicker.vue";
+export { default as InputHelp } from "./forms/InputHelp.vue";
+export { default as InputLabel } from "./forms/InputLabel.vue";
+export { default as BaseInput } from "./forms/BaseInput.vue";
 export { default as MultiCheckboxes } from "./forms/MultiCheckboxes.vue";
 export { default as Radio } from "./forms/Radio.vue";
 export { default as Select } from "./forms/Select.vue";

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -20,12 +20,13 @@ export { default as Table } from "./lists/Table.vue";
 export { default as Tabs } from "./navigation/Tabs.vue";
 
 // Form components
+export { default as BaseInput } from "./forms/BaseInput.vue";
 export { default as Checkbox } from "./forms/Checkbox.vue";
 export { default as DateRangePicker } from "./forms/DateRangePicker.vue";
 export { default as InputHelp } from "./forms/InputHelp.vue";
 export { default as InputLabel } from "./forms/InputLabel.vue";
-export { default as BaseInput } from "./forms/BaseInput.vue";
 export { default as MultiCheckboxes } from "./forms/MultiCheckboxes.vue";
 export { default as Radio } from "./forms/Radio.vue";
 export { default as Select } from "./forms/Select.vue";
+export { default as TextArea } from "./forms/TextArea.vue";
 export { default as YesOrNoRadio } from "./forms/YesOrNoRadio.vue";

--- a/tailwind.css
+++ b/tailwind.css
@@ -24,7 +24,7 @@
     @apply text-sm font-medium text-gray-900 leading-5;
   }
 
-  /* Forms */
+  /* Forms: here for backward compatibility.  Use <BaseInput> instead. */
   [type=text], [type=email], [type=password], [type=number], [type=search], [type=tel], textarea {
     @apply mt-1 shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md;
   }

--- a/tailwind.css
+++ b/tailwind.css
@@ -70,11 +70,6 @@
     @apply inline-flex justify-center items-center px-4 py-2 border border-xy-blue shadow-md text-sm font-medium rounded-md text-xy-blue bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
-  /* Forms */
-  .xy-input-error {
-    @apply focus:ring-red-500 focus:border-red-500 text-red-900 placeholder-red-300 border-red-300;
-  }
-
   /* Header classes */
   .xy-h1-extra-flair {
     @apply text-3xl font-extrabold text-gray-900 leading-9 tracking-tight sm:text-4xl sm:leading-10;
@@ -105,5 +100,10 @@
   
   .max-h-screen-1\/2 {
     max-height: 50vh;
+  }
+
+  /* Forms */
+  .xy-input-error {
+    @apply focus:ring-red-500 focus:border-red-500 text-red-900 placeholder-red-300 border-red-300;
   }
 }

--- a/trees.d.ts
+++ b/trees.d.ts
@@ -7,6 +7,7 @@ declare const Trees: Exclude<Plugin["install"], undefined>;
 export default Trees;
 
 export const ActionsDropdown: DefineComponent<{}, {}, any>;
+export const BaseInput: DefineComponent<{}, {}, any>;
 export const Cards: DefineComponent<{}, {}, any>;
 export const Checkbox: DefineComponent<{}, {}, any>;
 export const ContentModal: DefineComponent<{}, {}, any>;
@@ -15,8 +16,8 @@ export const DateRangePicker: DefineComponent<{}, {}, any>;
 export const DetailList: DefineComponent<{}, {}, any>;
 export const DownloadCell: DefineComponent<{}, {}, any>;
 export const Flash: DefineComponent<{}, {}, any>;
+export const InputHelp: DefineComponent<{}, {}, any>;
 export const InputLabel: DefineComponent<{}, {}, any>;
-export const InputText: DefineComponent<{}, {}, any>;
 export const MultiCheckboxes: DefineComponent<{}, {}, any>;
 export const Modal: DefineComponent<{}, {}, any>;
 export const Paginator: DefineComponent<{}, {}, any>;

--- a/trees.d.ts
+++ b/trees.d.ts
@@ -15,6 +15,8 @@ export const DateRangePicker: DefineComponent<{}, {}, any>;
 export const DetailList: DefineComponent<{}, {}, any>;
 export const DownloadCell: DefineComponent<{}, {}, any>;
 export const Flash: DefineComponent<{}, {}, any>;
+export const InputLabel: DefineComponent<{}, {}, any>;
+export const InputText: DefineComponent<{}, {}, any>;
 export const MultiCheckboxes: DefineComponent<{}, {}, any>;
 export const Modal: DefineComponent<{}, {}, any>;
 export const Paginator: DefineComponent<{}, {}, any>;


### PR DESCRIPTION
# What this does.

- Expands on the current set of input fields.
- Includes/exposes a `<BaseInput>` component for the most common text like inputs.
- includes/exposes an `<InputLabel>` component for custom use.
- Includes/exposes an `<InputHelp>` component for custom use.
- Simplifies adding labels and help text to most input types that can support them via optional props.
- Removes the redundancy of using props for common input attributes like required and disabled by using $attrs.
- Adds basic A11y support to all current input types with no consumer configuration by using a dynamic UUID.
- Should maintain compatibility with current usage.

This is part 1 of a multi-phase plan for expanding on form fields and form handling in general.  Primary goal in this round was to expand on the current fields to make them easier to use, particularly with labels and help text, as well as, adding some zero config accessibility features and reducing the need for composable styles written in css outside of the templates.

Future rounds will focus on the form, fieldset, and legend components and their A11y concerns, as well as for validation and accessible error display for inputs.

## TODO:

- [x] add a textarea component consistent with the other fields
- [x] test changes on college try
- [ ] test changes on archive
- [x] update the docs, specifically props and the use of attributes like required and disabled.  Left as is to verify compatibility with current usage.
- [x] need to import InputLabel and InputHelper into the field components that use them as components for situations where the consumer only includes select components from trees

## NPM Link notes

When testing on college try or archive and using npm link on trees you may need to delete the node_modules directory in trees to avoid resolving two different instances of vue.