### PR TITLE
fix: missing name attribute on radio buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.2.58",
+      "version": "0.2.59",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -11,6 +11,7 @@
           :checked="modelValue === option.value"
           class="w-4 h-4 border-gray-300 focus:ring-blue-500 text-xy-blue"
           :id="`${uuid}-${index}`"
+          :name="uuid"
           type="radio"
           :value="option.value"
           v-bind="{

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -10,6 +10,7 @@
         type="radio"
         class="w-4 h-4 border-gray-300 focus:ring-blue-500 text-xy-blue"
         :id="`${hasNameAttr ? name : uuid}-true`"
+        :name="hasNameAttr ? name : uuid"
         :value="true"
         :checked="modelValue === true"
         v-bind="{
@@ -32,6 +33,7 @@
         type="radio"
         class="w-4 h-4 border-gray-300 focus:ring-blue-500 text-xy-blue"
         :id="`${hasNameAttr ? name : uuid}-false`"
+        :name="hasNameAttr ? name : uuid"
         :value="false"
         :checked="modelValue === false"
         v-bind="{


### PR DESCRIPTION
# what this does

- adds the name attribute to radio button/button groups which should fix html5 required validation issues
- bumps trees to v0.2.59

## notes:

- it's not entirely clear why merging attrs with v-bind on the radio group allows for custom name attributes, but does not work similarly on the yes/no.  this is why the name attribute on yes/no radios uses an inline conditional for setting the custom or generated name attribute.