### PR TITLE
fix: yes no colors and label spelling

### DIFF
--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -207,7 +207,7 @@
         </div>
       </ComponentLayout>
 
-      <ComponentLayout class="mt-8" title="Input Lable">
+      <ComponentLayout class="mt-8" title="Input Label">
         <template v-slot:description>
           For whenever you just need a consistent label for a custom layout. Use
           the tag property for a custom html element like legend.
@@ -362,7 +362,7 @@ export default class Forms extends Vue {
   inputTypeSelected = "text";
   customInputTypeVal = "";
 
-  inputLabelCopy = `<InputLable lable="I'm labeling something..." />`;
+  inputLabelCopy = `<InputLabel label="I'm labeling something..." />`;
   inputLabelProps = [
     { name: "label", required: false, type: "string" },
     { name: "tag", required: false, type: "string" },

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -20,7 +20,7 @@
           },
         }"
       />
-      <span class="block ml-2 text-sm font-medium text-gray-700 leading-5"
+      <span class="block ml-2 text-sm font-medium text-gray-900 leading-5"
         >Yes</span
       >
     </label>
@@ -43,7 +43,7 @@
           },
         }"
       />
-      <span class="block ml-2 text-sm font-medium leading-5">No</span>
+      <span class="block ml-2 text-sm font-medium text-gray-900 leading-5">No</span>
     </label>
   </fieldset>
 </template>


### PR DESCRIPTION
# what this does

- ensures consistent label colors on yes/no radio buttons inline with typical input label
- updates spelling of "label" in the site docs
- bumps to 0.2.60