### PR TITLE
proposal: v0.3.2

### DIFF
--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -177,6 +177,18 @@
         <template v-slot:description>
           Similar to checkboxes, these are wrapped in a vue component given
           their nested structure so that we are consistent across all projects.
+          <br /><br />Note that the
+          <a
+            class="xy-link"
+            href="https://v3.vuejs.org/guide/forms.html#value-bindings"
+            >Value Bindings</a
+          >
+          section of the Vue docs states that binding values for selects are
+          usually static strings. Use the <b>v-model.number </b>
+          <a class="xy-link" href="https://v3.vuejs.org/guide/forms.html#number"
+            >modifier</a
+          >
+          if you need the binding to be typecast as a number.
         </template>
 
         <div>
@@ -319,7 +331,7 @@ export default class Forms extends Vue {
     {
       name: "options",
       required: true,
-      type: "Array<{ label: string; value: string }>",
+      type: "Array<{ label: string; value: string | number }>",
     },
     { name: "placeholder", required: false, type: "string" },
     { name: "modelValue", required: true, type: "string" },
@@ -328,10 +340,12 @@ export default class Forms extends Vue {
   options = [
     { label: "You could select this", value: "val1" },
     { label: "This is an option", value: "val2" },
-    { label: "Feeling good about this one?", value: "val3" },
-    { label: "This is the LAST option", value: "val4" },
+    { label: "Feeling good about this one?", value: 3 },
+    { label: "This is the LAST option", value: 4 },
   ];
-  selected = "";
+
+  selected: string | number = "";
+
   yesOrNoRadioCopy = `<YesOrNoRadio v-model="selected" />`;
   yesOrNoRadioSelection = false;
   yesOrNoRadioProps = [

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -207,6 +207,24 @@
         </div>
       </ComponentLayout>
 
+      <ComponentLayout class="mt-8" title="Toggle">
+        <template v-slot:description>
+          Just a another toggle for boolean switches. A great UI alternative to
+          checkboxes and boolean value radio button pairs. Currently does not
+          support a label property. Bring your own label.
+        </template>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="toggleCopy" />
+          </label>
+          <div class="mt-1">
+            <Toggle v-model="toggleValue"></Toggle>
+            <PropsTable :props="toggleProps" />
+          </div>
+        </div>
+      </ComponentLayout>
+
       <ComponentLayout class="mt-8" title="Input Label">
         <template v-slot:description>
           For whenever you just need a consistent label for a custom layout. Use
@@ -218,7 +236,7 @@
             <ClickToCopy :value="inputLabelCopy" />
           </label>
           <div class="mt-1">
-            <InputLabel label="I'm labeling somthing..." />
+            <InputLabel label="I'm labeling something..." />
             <PropsTable :props="inputLabelProps" />
           </div>
         </div>
@@ -373,5 +391,8 @@ export default class Forms extends Vue {
     { name: "text", required: false, type: "string" },
     { name: "tag", required: false, type: "string" },
   ];
+  toggleValue = false;
+  toggleCopy = `<Toggle v-model="toggleValue"></Toggle>`;
+  toggleProps = [{ name: "modelValue", required: true, type: "string" }];
 }
 </script>

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -105,6 +105,48 @@
           </div>
         </div>
       </ComponentLayout>
+      <ComponentLayout class="mt-8" title="Slideover">
+        <template v-slot:description>
+          A sidebar like content container that "slides over" your main content
+          on a trigger. It has a default slot for the primary content of the
+          sidebar. Use the @close event to fire of any actions you might need to
+          hook into when the slideover closes.
+        </template>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="slideoverCopy" />
+          </label>
+          <div class="mt-1">
+            <button type="button" class="xy-btn" @click="slideoverOpen = true">
+              Show Me
+            </button>
+            <Slideover
+              v-model="slideoverOpen"
+              header="Slideover Header"
+              description="A very helpful slideover description"
+            >
+              <div class="prose">
+                <p>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Quisque id nibh consequat, semper odio et, porta ex. Sed
+                  dapibus eu massa vel ultrices. Mauris mattis nisi sem, vel
+                  dictum odio pretium ullamcorper. Fusce suscipit nulla in felis
+                  cursus consectetur.
+                </p>
+                <p>
+                  Vestibulum ante ipsum primis in faucibus orci luctus et
+                  ultrices posuere cubilia curae; Morbi massa dui, commodo non
+                  sem vel, laoreet dictum est. Integer fermentum pretium erat
+                  vitae ultrices. Aenean eu maximus mi, in congue ipsum. Vivamus
+                  dignissim iaculis dolor, a sollicitudin metus tincidunt ac.
+                </p>
+              </div>
+            </Slideover>
+            <PropsTable :props="slideoverProps"></PropsTable>
+          </div>
+        </div>
+      </ComponentLayout>
     </div>
   </div>
 </template>
@@ -132,6 +174,14 @@ export default class Overlays extends Vue {
   ];
   open = false;
   spinnerCopy = `window.VueBus.emit("Spinner-show"); window.setTimeout(() => { window.VueBus.emit("Spinner-hide"); }, 3000);`;
+  slideoverOpen = false;
+  slideoverCopy = `<Slideover v-model="slideoverOpen" header="Slideover Header" description="A very helpful slideover description"></Slideover>`;
+  slideoverProps = [
+    { name: "v-model", required: true, type: "boolean" },
+    { name: "header", required: false, type: "string" },
+    { name: "description", required: false, type: "description" },
+    { name: "@close", required: false, type: "function(modelValue)" },
+  ];
 
   flash(): void {
     window.VueBus.emit("Flash-show-generic-error", "support@trees.com");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -6,14 +6,10 @@ import axios, {
 } from "axios";
 import API from "../types/api";
 
+const env = import.meta.env || {};
 const apiAxiosInstance = axios.create({
   baseURL:
-    (import.meta.env &&
-      typeof import.meta.env.VITE_APP_BASE_API_URL === "string" &&
-      import.meta.env.VITE_APP_BASE_API_URL) ||
-    (typeof process.env.VUE_APP_BASE_API_URL === "string" &&
-      process.env.VUE_APP_BASE_API_URL) ||
-    "/api/v1",
+    env.VITE_APP_BASE_API_URL || process.env.VUE_APP_BASE_API_URL || "/api/v1",
   responseType: "json",
   withCredentials: true,
 });

--- a/src/lib-components/forms/Select.vue
+++ b/src/lib-components/forms/Select.vue
@@ -45,11 +45,14 @@ export default class Select extends Vue {
   @Prop({ type: String, required: false }) help?: string;
   @Prop({ type: Array, required: true }) options!: Array<{
     label: string;
-    value: string;
+    value: string | number;
   }>;
   @Prop({ type: String, required: false, default: "Select an option" })
   placeholder?: string;
-  @Prop({ type: String, required: true }) modelValue!: string | undefined;
+  @Prop({ type: [String, Number], required: true }) modelValue!:
+    | string
+    | number
+    | undefined;
 
   uuid = (this.$attrs.id as string) || Uniques.CreateIdAttribute();
 

--- a/src/lib-components/overlays/Slideover.vue
+++ b/src/lib-components/overlays/Slideover.vue
@@ -83,9 +83,10 @@ export default class Slideover extends Vue {
   @Prop({ type: String, required: true }) description!: string;
   @Prop({ type: Boolean, required: true }) modelValue!: boolean;
 
-  @Emit()
-  close(): void {
-    return;
+  @Emit("close")
+  @Emit("update:modelValue")
+  close(): boolean {
+    return false;
   }
 }
 </script>


### PR DESCRIPTION
# what this does

- fixes import.meta usage for vite support and maintains process.env support for vue-cli
- adds a default close handler to the slideover component - avoiding the need for an @click handler by the consumer
- updates the docs with slideover and toggle components 
- fixes docs typo
- adds number type support to select

## TODO:

- [x] bump version number to v0.3.2