### PR TITLE
feat: Popover Component

### DIFF
--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref } from "vue"
 import { CheckIcon } from "@heroicons/vue/outline"
+import { ExclamationIcon } from "@heroicons/vue/outline"
+import { PopoverPosition } from "@/lib-components/overlays/Popover/Popover.vue"
 
 const contentModalCopy = `<ContentModal v-model="open" :content="content" :title="title"></ContentModal>`
 
@@ -42,6 +44,35 @@ const spinner = function (): void {
     window.VueBus.emit("Spinner-hide")
   }, 15000)
 }
+
+const popoverPositions: PopoverPosition[] = [
+  "top-left",
+  "top-center",
+  "top-right",
+  "bottom-left",
+  "bottom-center",
+  "bottom-right",
+  "left",
+  "right",
+]
+
+const popoverProps = [
+  { name: "text", required: false, type: 'string - default: ""' },
+  { name: "triggerText", required: false, type: 'string - default: ""' },
+  {
+    name: "triggerIcon",
+    required: false,
+    type: "RenderFunction - default: InformationCircleIcon",
+  },
+  {
+    name: "position",
+    required: false,
+    type: "PopoverPosition - default: top-center",
+  },
+]
+
+const simplePopoverCopy = `<Popover text="This is a simple Popover."></Popover>`
+const advancedPopoverCopy = `<Popover><PopoverContent>This is an advanced Popover.</PopoverContent></Popover>`
 </script>
 
 <template>
@@ -191,6 +222,104 @@ const spinner = function (): void {
             </Slideover>
             <PropsTable :props="slideoverProps"></PropsTable>
           </div>
+        </div>
+      </ComponentLayout>
+
+      <ComponentLayout class="mt-8" title="Popover">
+        <template v-slot:description>
+          This component wraps the headless ui Popover, PopoverButton, and
+          PopoverPanel components and provides bare bones styling and
+          positioning options. The popover content is heavily customizable when
+          you supply your own PopoverContent component in the default slot. It
+          is designed to handle the most common case where a tooltip like UI is
+          required. Positioning is absolute and subject to parent container
+          overflow rules.
+        </template>
+
+        <div>
+          <label
+            class="block text-sm font-medium text-gray-700 text-center flex flex-inline justify-center"
+          >
+            <h3 class="mr-2">Basic Popovers - By Position</h3>
+            <ClickToCopy :value="simplePopoverCopy" />
+          </label>
+
+          <div
+            v-for="(position, index) in popoverPositions"
+            :key="index"
+            class="mt-8"
+          >
+            <div class="flex justify-center">{{ position }}</div>
+            <div class="flex justify-center">
+              <Popover :position="position" text="This is a simple Popover." />
+            </div>
+          </div>
+
+          <label
+            class="block text-sm font-medium text-gray-700 text-center flex flex-inline justify-center mt-8"
+          >
+            <h3 class="mr-2">
+              Advanced Popovers - Custom content and triggers
+            </h3>
+            <ClickToCopy :value="advancedPopoverCopy" />
+          </label>
+
+          <div class="mt-2 flex justify-center">
+            <Popover :button-icon="ExclamationIcon">
+              <PopoverContent>
+                <div class="flex items-center">
+                  <ExclamationIcon class="w-5 h-5 mr-2" />
+                  <div>
+                    You see that post on
+                    <a
+                      class="xy-link"
+                      href="https://news.ycombinator.com/
+              "
+                      >Hacker News</a
+                    >
+                    today?
+                  </div>
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          <div class="mt-2 flex justify-center">
+            <Popover>
+              <PopoverContent
+                class="bg-xy-blue text-white border-0 w-screen lg:max-w-md"
+              >
+                <div class="text-base p-4">
+                  Hi, hello, nice to meet you in the flesh I've only seen you
+                  from the neck up, it's weird to see your legs Low key, I know
+                  I'm shorter than what all of y'all expected It's awkward when
+                  you look me up and down but don't address it Handshakes, all
+                  sweat, what to do next… How are people supposed to act in the
+                  office? I forget Pull my phone out my pocket act like I just
+                  got a text But I didn't, I just move my thumb around for a sec
+                  Out of habit I check Slack, like it's any other day Then
+                  remember everyone is here, like 6 feet away I gotta talk, like
+                  with my mouth, if I wanna communicate But if I can't send
+                  memes and gifs, I ain't got nothing to say I miss my cat, I
+                  miss my dog, I'm ready to leave I miss my bed sheets, and
+                  farting when I please I should've told my boss I had somewhere
+                  to be Damn, this is gonna be a long a** week
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          <div class="mt-2 flex justify-center">
+            <Popover text="A custom button trigger!">
+              <template #button>
+                <div class="xy-badge">
+                  Badge <ExclamationIcon class="w-4 h-4 ml-1" />
+                </div>
+              </template>
+            </Popover>
+          </div>
+
+          <PropsTable :props="popoverProps"></PropsTable>
         </div>
       </ComponentLayout>
     </div>

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -280,10 +280,8 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
               <template #button>
                 <span class="xy-btn">Hi, hello, nice to meet you...</span>
               </template>
-              <PopoverContent
-                class="bg-xy-blue text-white border-0 w-screen lg:max-w-md"
-              >
-                <div class="text-base p-4">
+              <PopoverContent class="bg-xy-blue border-0 w-screen lg:max-w-md">
+                <div class="text-white text-base font-medium p-8">
                   Hi, hello, nice to meet you in the flesh I've only seen you
                   from the neck up, it's weird to see your legs Low key, I know
                   I'm shorter than what all of y'all expected It's awkward when

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -57,13 +57,6 @@ const popoverPositions: PopoverPosition[] = [
 ]
 
 const popoverProps = [
-  { name: "text", required: false, type: 'string - default: ""' },
-  { name: "triggerText", required: false, type: 'string - default: ""' },
-  {
-    name: "triggerIcon",
-    required: false,
-    type: "RenderFunction - default: InformationCircleIcon",
-  },
   {
     name: "position",
     required: false,
@@ -71,8 +64,16 @@ const popoverProps = [
   },
 ]
 
-const simplePopoverCopy = `<Popover text="This is a simple Popover."></Popover>`
+const tooltipProps = [
+  {
+    name: "position",
+    required: false,
+    type: "PopoverPosition - default: top-center",
+  },
+]
+
 const advancedPopoverCopy = `<Popover><PopoverContent>This is an advanced Popover.</PopoverContent></Popover>`
+const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
 </script>
 
 <template>
@@ -228,47 +229,37 @@ const advancedPopoverCopy = `<Popover><PopoverContent>This is an advanced Popove
       <ComponentLayout class="mt-8" title="Popover">
         <template v-slot:description>
           This component wraps the headless ui Popover, PopoverButton, and
-          PopoverPanel components and provides bare bones styling and
-          positioning options. The popover content is heavily customizable when
-          you supply your own PopoverContent component in the default slot. It
-          is designed to handle the most common case where a tooltip like UI is
-          required. Positioning is absolute and subject to parent container
-          overflow rules.
+          PopoverPanel components. It provides a #button and default slot for
+          customizing the trigger and content while offering a positioning prop.
+          The popover content is heavily customizable in the default slot. Use
+          the PopoverContent component for basic initial wrapper styling.
+          Positioning is absolute and subject to parent container overflow
+          rules.
         </template>
 
         <div>
           <label
-            class="block text-sm font-medium text-gray-700 text-center flex flex-inline justify-center"
-          >
-            <h3 class="mr-2">Basic Popovers - By Position</h3>
-            <ClickToCopy :value="simplePopoverCopy" />
-          </label>
-
-          <div
-            v-for="(position, index) in popoverPositions"
-            :key="index"
-            class="mt-8"
-          >
-            <div class="flex justify-center">{{ position }}</div>
-            <div class="flex justify-center">
-              <Popover :position="position" text="This is a simple Popover." />
-            </div>
-          </div>
-
-          <label
             class="block text-sm font-medium text-gray-700 text-center flex flex-inline justify-center mt-8"
           >
-            <h3 class="mr-2">
-              Advanced Popovers - Custom content and triggers
-            </h3>
             <ClickToCopy :value="advancedPopoverCopy" />
           </label>
 
           <div class="mt-2 flex justify-center">
-            <Popover :button-icon="ExclamationIcon">
-              <PopoverContent>
-                <div class="flex items-center">
-                  <ExclamationIcon class="w-5 h-5 mr-2" />
+            <Popover>
+              <template #button>
+                <div class="xy-badge">
+                  Badge <ExclamationIcon class="w-4 h-4 ml-1" />
+                </div>
+              </template>
+              <div
+                class="max-w-xs rounded-lg bg-white border border-gray-100 shadow-md text-sm leading-tight font-medium"
+              >
+                <div
+                  v-for="n in 3"
+                  :key="n"
+                  class="flex items-center p-4 border-b"
+                >
+                  <ExclamationIcon class="w-7 h-7 mr-2 text-yellow-500" />
                   <div>
                     You see that post on
                     <a
@@ -280,12 +271,15 @@ const advancedPopoverCopy = `<Popover><PopoverContent>This is an advanced Popove
                     today?
                   </div>
                 </div>
-              </PopoverContent>
+              </div>
             </Popover>
           </div>
 
-          <div class="mt-2 flex justify-center">
+          <div class="mt-8 flex justify-center">
             <Popover>
+              <template #button>
+                <span class="xy-btn">Hi, hello, nice to meet you...</span>
+              </template>
               <PopoverContent
                 class="bg-xy-blue text-white border-0 w-screen lg:max-w-md"
               >
@@ -309,18 +303,37 @@ const advancedPopoverCopy = `<Popover><PopoverContent>This is an advanced Popove
             </Popover>
           </div>
 
-          <div class="mt-2 flex justify-center">
-            <Popover text="A custom button trigger!">
-              <template #button>
-                <div class="xy-badge">
-                  Badge <ExclamationIcon class="w-4 h-4 ml-1" />
-                </div>
-              </template>
-            </Popover>
-          </div>
-
           <PropsTable :props="popoverProps"></PropsTable>
         </div>
+      </ComponentLayout>
+
+      <ComponentLayout class="mt-8" title="Tooltip">
+        <template v-slot:description>
+          A simple tooltip component. Triggered by a single universally
+          understood icon. Your tooltip content is supplied in the default slot.
+        </template>
+
+        <div>
+          <label
+            class="block text-sm font-medium text-gray-700 text-center flex flex-inline justify-center"
+          >
+            <ClickToCopy :value="tooltipCopy" />
+          </label>
+
+          <div
+            v-for="(position, index) in popoverPositions"
+            :key="index"
+            class="mt-8"
+          >
+            <div class="flex justify-center">{{ position }}</div>
+            <div class="flex justify-center">
+              <Tooltip :position="position">
+                This is a simple tooltip.
+              </Tooltip>
+            </div>
+          </div>
+        </div>
+        <PropsTable :props="tooltipProps"></PropsTable>
       </ComponentLayout>
     </div>
   </div>

--- a/dev/helpers/ComponentLayout.vue
+++ b/dev/helpers/ComponentLayout.vue
@@ -12,9 +12,7 @@ withDefaults(
 )
 </script>
 <template>
-  <div
-    class="bg-white overflow-hidden shadow rounded-lg divide-y divide-gray-200"
-  >
+  <div class="bg-white shadow rounded-lg divide-y divide-gray-200">
     <div class="px-4 py-5 border-b border-gray-200 sm:px-6">
       <div
         class="-ml-4 -mt-4 flex justify-between items-center flex-wrap sm:flex-nowrap"

--- a/dev/helpers/PropsTable.vue
+++ b/dev/helpers/PropsTable.vue
@@ -9,7 +9,7 @@ defineProps<{
 </script>
 <template>
   <div
-    class="mt-4 align-middle inline-block min-w-full border-b border-gray-200"
+    class="mt-4 align-middle inline-block min-w-full border-b border-gray-200 overflow-x-scroll w-full"
   >
     <table class="min-w-full">
       <thead>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -10,6 +10,9 @@ import { default as DownloadCell } from "./lists/DownloadCell.vue"
 import { default as Flash } from "./overlays/Flash.vue"
 import { default as Modal } from "./overlays/Modal.vue"
 import { default as SidebarLayout } from "./layout/SidebarLayout.vue"
+import { default as Popover } from "./overlays/Popover/Popover.vue"
+import { default as PopoverPosition } from "./overlays/Popover/Popover.vue"
+import { default as PopoverContent } from "./overlays/Popover/PopoverContent.vue"
 import { default as Slideover } from "./overlays/Slideover.vue"
 import { default as StackedLayout } from "./layout/StackedLayout.vue"
 import { default as Paginator } from "./navigation/Paginator.vue"
@@ -44,6 +47,9 @@ export {
   SidebarLayout,
   Slideover,
   StackedLayout,
+  Popover,
+  PopoverContent,
+  PopoverPosition, // Type export
   Paginator,
   Spinner,
   StaticTable,
@@ -77,6 +83,8 @@ export interface TreesComponents {
   Modal: typeof Modal
   SidebarLayout: typeof SidebarLayout
   Slideover: typeof Slideover
+  Popover: typeof Popover
+  PopoverContent: typeof PopoverContent
   StackedLayout: typeof StackedLayout
   Paginator: typeof Paginator
   Spinner: typeof Spinner

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -14,6 +14,7 @@ import { default as Popover } from "./overlays/Popover/Popover.vue"
 import { default as PopoverPosition } from "./overlays/Popover/Popover.vue"
 import { default as PopoverContent } from "./overlays/Popover/PopoverContent.vue"
 import { default as Slideover } from "./overlays/Slideover.vue"
+import { default as Tooltip } from "./overlays/Tooltip.vue"
 import { default as StackedLayout } from "./layout/StackedLayout.vue"
 import { default as Paginator } from "./navigation/Paginator.vue"
 import { default as Spinner } from "./overlays/Spinner.vue"
@@ -57,6 +58,7 @@ export {
   Table,
   Tabs,
   Toggle,
+  Tooltip,
   BaseInput,
   Checkbox,
   DateRangePicker,
@@ -93,6 +95,7 @@ export interface TreesComponents {
   Table: typeof Table
   Tabs: typeof Tabs
   Toggle: typeof Toggle
+  Tooltip: typeof Tooltip
   BaseInput: typeof BaseInput
   Checkbox: typeof Checkbox
   DateRangePicker: typeof DateRangePicker

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -22,14 +22,14 @@ import PopoverContent from "./PopoverContent.vue"
 const props = withDefaults(
   defineProps<{
     text?: string
-    buttonText?: string
-    buttonIcon?: RenderFunction
+    triggerText?: string
+    triggerIcon?: RenderFunction
     position?: PopoverPosition
   }>(),
   {
     text: "",
-    buttonText: "",
-    buttonIcon: InformationCircleIcon,
+    triggerText: "",
+    triggerIcon: InformationCircleIcon,
     position: "top-center",
   }
 )
@@ -90,8 +90,8 @@ const positionClasses = computed(() => {
       <HeadlessPopoverButton>
         <slot name="button" :open="open" :close="close">
           <span class="inline-flex items-center justify-center"
-            ><span v-if="buttonText" class="mr-1">{{ buttonText }}</span>
-            <component :is="buttonIcon" class="w-5 h-5" />
+            ><span v-if="triggerText" class="mr-1">{{ triggerText }}</span>
+            <component :is="triggerIcon" class="w-5 h-5" />
           </span>
         </slot>
       </HeadlessPopoverButton>
@@ -104,7 +104,7 @@ const positionClasses = computed(() => {
         leave-from-class="opacity-100"
         leave-to-class="opacity-0"
       >
-        <!--NOTE: use prop "static" for dev work to keep the tooptip visible during-->
+        <!--NOTE: use prop "static" for dev work to keep the tooptip visible-->
         <HeadlessPopoverPanel>
           <!--positioning wrappers-->
           <div

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -1,0 +1,128 @@
+<script lang="ts">
+export type PopoverPosition =
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right"
+  | "left"
+  | "right"
+</script>
+<script lang="ts" setup>
+import {
+  Popover as HeadlessPopover,
+  PopoverButton as HeadlessPopoverButton,
+  PopoverPanel as HeadlessPopoverPanel,
+} from "@headlessui/vue"
+import { InformationCircleIcon } from "@heroicons/vue/outline"
+import { computed, RenderFunction } from "vue"
+import PopoverContent from "./PopoverContent.vue"
+
+const props = withDefaults(
+  defineProps<{
+    text?: string
+    buttonText?: string
+    buttonIcon?: RenderFunction
+    position?: PopoverPosition
+  }>(),
+  {
+    text: "",
+    buttonText: "",
+    buttonIcon: InformationCircleIcon,
+    position: "top-center",
+  }
+)
+
+const positionClasses = computed(() => {
+  // NOTE: by always pushing the screen width wrapper classes to the left we can avoid overflow scrolling
+
+  let wrapperClasses = ""
+  let contentClasses = ""
+
+  switch (props.position) {
+    case "top-left":
+      wrapperClasses =
+        "top-0 left-0 -translate-y-full -translate-x-full justify-end"
+      break
+    case "top-center":
+      wrapperClasses =
+        "top-0 -translate-y-full -translate-x-full left-1/2 justify-end"
+      contentClasses = "translate-x-1/2"
+      break
+    case "top-right":
+      wrapperClasses = "top-0 -translate-y-full right-0 justify-end"
+      contentClasses = "translate-x-full"
+      break
+    case "bottom-left":
+      wrapperClasses = "top-full left-0 -translate-x-full justify-end"
+      break
+    case "bottom-center":
+      wrapperClasses = "top-full -translate-x-full left-1/2 justify-end"
+      contentClasses = "translate-x-1/2"
+      break
+    case "bottom-right":
+      wrapperClasses = "top-full right-0 justify-end"
+      contentClasses = "translate-x-full"
+      break
+    case "left":
+      wrapperClasses =
+        "top-1/2 left-0 -translate-y-1/2 -translate-x-full justify-end"
+      break
+    case "right":
+      wrapperClasses = "top-1/2 -translate-y-1/2 right-0 justify-end"
+      contentClasses = "translate-x-full"
+      break
+  }
+
+  return {
+    wrapper: wrapperClasses,
+    content: contentClasses,
+  }
+})
+
+// TODO: maybe auto positioning - dynamic based on button location and closed overflow hidden container?
+</script>
+
+<template>
+  <div class="flex">
+    <HeadlessPopover v-slot="{ open, close }" class="relative leading-none">
+      <HeadlessPopoverButton>
+        <slot name="button" :open="open" :close="close">
+          <span class="inline-flex items-center justify-center"
+            ><span v-if="buttonText" class="mr-1">{{ buttonText }}</span>
+            <component :is="buttonIcon" class="w-5 h-5" />
+          </span>
+        </slot>
+      </HeadlessPopoverButton>
+
+      <transition
+        enter-active-class="transition-opacity transition-faster ease-out-quad"
+        leave-active-class="transition-opacity transition-faster ease-in-quad"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <!--NOTE: use prop "static" for dev work to keep the tooptip visible during-->
+        <HeadlessPopoverPanel>
+          <!--positioning wrappers-->
+          <div
+            class="absolute z-10 transform w-screen flex"
+            :class="positionClasses.wrapper"
+          >
+            <div :class="positionClasses.content">
+              <slot :open="open" :close="close">
+                <PopoverContent>
+                  {{ text }}
+                </PopoverContent>
+              </slot>
+            </div>
+          </div>
+        </HeadlessPopoverPanel>
+      </transition>
+    </HeadlessPopover>
+  </div>
+</template>
+
+<style></style>

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -15,21 +15,13 @@ import {
   PopoverButton as HeadlessPopoverButton,
   PopoverPanel as HeadlessPopoverPanel,
 } from "@headlessui/vue"
-import { InformationCircleIcon } from "@heroicons/vue/outline"
-import { computed, RenderFunction } from "vue"
-import PopoverContent from "./PopoverContent.vue"
+import { computed } from "vue"
 
 const props = withDefaults(
   defineProps<{
-    text?: string
-    triggerText?: string
-    triggerIcon?: RenderFunction
     position?: PopoverPosition
   }>(),
   {
-    text: "",
-    triggerText: "",
-    triggerIcon: InformationCircleIcon,
     position: "top-center",
   }
 )
@@ -88,12 +80,7 @@ const positionClasses = computed(() => {
   <div class="flex">
     <HeadlessPopover v-slot="{ open, close }" class="relative leading-none">
       <HeadlessPopoverButton>
-        <slot name="button" :open="open" :close="close">
-          <span class="inline-flex items-center justify-center"
-            ><span v-if="triggerText" class="mr-1">{{ triggerText }}</span>
-            <component :is="triggerIcon" class="w-5 h-5" />
-          </span>
-        </slot>
+        <slot name="button" :open="open" :close="close"></slot>
       </HeadlessPopoverButton>
 
       <transition
@@ -112,11 +99,7 @@ const positionClasses = computed(() => {
             :class="positionClasses.wrapper"
           >
             <div :class="positionClasses.content">
-              <slot :open="open" :close="close">
-                <PopoverContent>
-                  {{ text }}
-                </PopoverContent>
-              </slot>
+              <slot :open="open" :close="close"></slot>
             </div>
           </div>
         </HeadlessPopoverPanel>
@@ -124,5 +107,3 @@ const positionClasses = computed(() => {
     </HeadlessPopover>
   </div>
 </template>
-
-<style></style>

--- a/src/lib-components/overlays/Popover/PopoverContent.vue
+++ b/src/lib-components/overlays/Popover/PopoverContent.vue
@@ -1,7 +1,7 @@
 <template>
   <!--styling wrapper - top level element will merge attrs for class overrides -->
   <div
-    class="max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs leading-tight font-medium"
+    class="max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md"
   >
     <slot></slot>
   </div>

--- a/src/lib-components/overlays/Popover/PopoverContent.vue
+++ b/src/lib-components/overlays/Popover/PopoverContent.vue
@@ -1,0 +1,8 @@
+<template>
+  <!--styling wrapper - top level element will merge attrs for class overrides -->
+  <div
+    class="xy-tooltip-content max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs leading-tight font-medium"
+  >
+    <slot></slot>
+  </div>
+</template>

--- a/src/lib-components/overlays/Popover/PopoverContent.vue
+++ b/src/lib-components/overlays/Popover/PopoverContent.vue
@@ -1,7 +1,7 @@
 <template>
   <!--styling wrapper - top level element will merge attrs for class overrides -->
   <div
-    class="xy-tooltip-content max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs leading-tight font-medium"
+    class="max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs leading-tight font-medium"
   >
     <slot></slot>
   </div>

--- a/src/lib-components/overlays/Tooltip.vue
+++ b/src/lib-components/overlays/Tooltip.vue
@@ -1,0 +1,31 @@
+<script lang="ts" setup>
+import Popover, { PopoverPosition } from "./Popover/Popover.vue"
+import { InformationCircleIcon } from "@heroicons/vue/outline"
+import PopoverContent from "./Popover/PopoverContent.vue"
+
+withDefaults(
+  defineProps<{
+    position: PopoverPosition
+  }>(),
+  {
+    position: "top-center",
+  }
+)
+</script>
+
+<template>
+  <Popover :position="position">
+    <template #button>
+      <div class="relative">
+        <!--creates a larger clickable surface area-->
+        <div
+          class="p-4 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+        ></div>
+        <InformationCircleIcon class="w-4 h-4" />
+      </div>
+    </template>
+    <PopoverContent class="text-xs leading-tight font-medium">
+      <slot></slot>
+    </PopoverContent>
+  </Popover>
+</template>


### PR DESCRIPTION
# What this does

- Implements a bare bones version of the headless ui popover.
- Provides convenience props for trigger text/icon for most commonly expected trigger use cases.
- Provides convenience text prop for simple tooltip like popovers.
- Adds positioning prop for flexible positioning.
- Keeps presentation styles minimal leaving it mostly up to the PositionContent slot to do whatever it needs.

@profsmallpine something for us to consider as we add features like this is how opinionated and convenient they should be.  Example we could strip out the triggerText and triggerIcon props and instead use those in more highly opinionated components such as "Tooltip" where the styling would be more opinionated for that specific use case.


https://user-images.githubusercontent.com/3856703/153058513-bcaf9947-486d-4e74-80f0-ced0158abc6d.mov

# TODO

- [x] bump version number