### PR TITLE
feat: popover auto position

### DIFF
--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -333,8 +333,8 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
           </div>
           -->
 
-          <div class="flex justify-end">
-            <div class="transform -translate-x-24">
+          <div class="flex justify-center ml-1">
+            <div class="transform">
               <Tooltip position="auto">
                 This is a simple tooltip. This is a simple tooltip. This is a
                 simple tooltip. This is a simple tooltip. This is a simple

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -328,9 +328,7 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
             <div class="flex justify-center">{{ position }}</div>
             <div class="flex justify-center">
               <Tooltip :position="position">
-                This is a simple tooltip. This is a simple tooltip. This is a
-                simple tooltip. This is a simple tooltip. This is a simple
-                tooltip.
+                This is a simple tooltip.
               </Tooltip>
             </div>
           </div>

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -234,7 +234,9 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
           The popover content is heavily customizable in the default slot. Use
           the PopoverContent component for basic initial wrapper styling.
           Positioning is absolute and subject to parent container overflow
-          rules.
+          rules. You're responsible for managing the width of your popover
+          content. Generally, popovers should be narrow and start with a
+          max-w-sm class.
         </template>
 
         <div>
@@ -318,27 +320,53 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
             <ClickToCopy :value="tooltipCopy" />
           </label>
 
-          <!--
           <div
             v-for="(position, index) in popoverPositions"
             :key="index"
             class="mt-8"
           >
             <div class="flex justify-center">{{ position }}</div>
-            <div class="flex justify-end">
+            <div class="flex justify-center">
               <Tooltip :position="position">
-                This is a simple tooltip.
+                This is a simple tooltip. This is a simple tooltip. This is a
+                simple tooltip. This is a simple tooltip. This is a simple
+                tooltip.
               </Tooltip>
             </div>
           </div>
-          -->
+        </div>
 
-          <div class="flex justify-center ml-1">
-            <div class="transform">
+        <div class="mt-8">
+          <p class="mb-4">
+            <strong>Auto positioning</strong> favors left to right positioning.
+            i.e. if there appears to be space available to the right of the
+            trigger the tooltip content will flow toward the right. Top and
+            bottom positioning is prioritized by the current viewport, giving
+            preference where more visible space currently exists.
+          </p>
+          <div class="flex justify-between">
+            <div>
+              <div>auto</div>
               <Tooltip position="auto">
                 This is a simple tooltip. This is a simple tooltip. This is a
                 simple tooltip. This is a simple tooltip. This is a simple
-                tooltip. This is a simple tooltip. This is a simple tooltip.
+                tooltip.
+              </Tooltip>
+            </div>
+            <div>
+              <div>auto</div>
+              <Tooltip position="auto">
+                This is a simple tooltip. This is a simple tooltip. This is a
+                simple tooltip. This is a simple tooltip. This is a simple
+                tooltip.
+              </Tooltip>
+            </div>
+            <div>
+              <div>auto</div>
+              <Tooltip position="auto">
+                This is a simple tooltip. This is a simple tooltip. This is a
+                simple tooltip. This is a simple tooltip. This is a simple
+                tooltip.
               </Tooltip>
             </div>
           </div>

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -226,7 +226,7 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
         </div>
       </ComponentLayout>
 
-      <ComponentLayout class="mt-8" title="Popover" v-if="false">
+      <ComponentLayout class="mt-8" title="Popover">
         <template v-slot:description>
           This component wraps the headless ui Popover, PopoverButton, and
           PopoverPanel components. It provides a #button and default slot for
@@ -254,7 +254,7 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
                 </div>
               </template>
               <div
-                class="max-w-xs rounded-lg bg-white border border-gray-100 shadow-md text-sm leading-tight font-medium"
+                class="w-full max-w-xs rounded-lg bg-white border border-gray-100 shadow-md text-sm leading-tight font-medium"
               >
                 <div
                   v-for="n in 3"
@@ -351,6 +351,24 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
                 tooltip.
               </Tooltip>
             </div>
+            <div>
+              <div>auto</div>
+              <Tooltip position="auto">
+                This is a simple tooltip. This is a simple tooltip. This is a
+                simple tooltip. This is a simple tooltip. This is a simple
+                tooltip.
+              </Tooltip>
+            </div>
+
+            <div>
+              <div>auto</div>
+              <Tooltip position="auto">
+                This is a simple tooltip. This is a simple tooltip. This is a
+                simple tooltip. This is a simple tooltip. This is a simple
+                tooltip.
+              </Tooltip>
+            </div>
+
             <div>
               <div>auto</div>
               <Tooltip position="auto">

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -226,7 +226,7 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
         </div>
       </ComponentLayout>
 
-      <ComponentLayout class="mt-8" title="Popover">
+      <ComponentLayout class="mt-8" title="Popover" v-if="false">
         <template v-slot:description>
           This component wraps the headless ui Popover, PopoverButton, and
           PopoverPanel components. It provides a #button and default slot for
@@ -318,19 +318,32 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
             <ClickToCopy :value="tooltipCopy" />
           </label>
 
+          <!--
           <div
             v-for="(position, index) in popoverPositions"
             :key="index"
             class="mt-8"
           >
             <div class="flex justify-center">{{ position }}</div>
-            <div class="flex justify-center">
+            <div class="flex justify-end">
               <Tooltip :position="position">
                 This is a simple tooltip.
               </Tooltip>
             </div>
           </div>
+          -->
+
+          <div class="flex justify-end">
+            <div class="transform -translate-x-24">
+              <Tooltip position="auto">
+                This is a simple tooltip. This is a simple tooltip. This is a
+                simple tooltip. This is a simple tooltip. This is a simple
+                tooltip. This is a simple tooltip. This is a simple tooltip.
+              </Tooltip>
+            </div>
+          </div>
         </div>
+
         <PropsTable :props="tooltipProps"></PropsTable>
       </ComponentLayout>
     </div>

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -60,7 +60,7 @@ const popoverProps = [
   {
     name: "position",
     required: false,
-    type: "PopoverPosition - default: top-center",
+    type: "PopoverPosition - default: auto",
   },
 ]
 
@@ -68,7 +68,7 @@ const tooltipProps = [
   {
     name: "position",
     required: false,
-    type: "PopoverPosition - default: top-center",
+    type: "PopoverPosition - default: auto",
   },
 ]
 
@@ -345,7 +345,7 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
           <div class="grid gap-4 grid-cols-5">
             <div v-for="index in 5" :key="index">
               <div class="flex justify-center">
-                <Tooltip position="auto">
+                <Tooltip>
                   This is a simple tooltip. This is a simple tooltip. This is a
                   simple tooltip. This is a simple tooltip. This is a simple
                   tooltip.</Tooltip

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -342,48 +342,15 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
             bottom positioning is prioritized by the current viewport, giving
             preference where more visible space currently exists.
           </p>
-          <div class="flex justify-between">
-            <div>
-              <div>auto</div>
-              <Tooltip position="auto">
-                This is a simple tooltip. This is a simple tooltip. This is a
-                simple tooltip. This is a simple tooltip. This is a simple
-                tooltip.
-              </Tooltip>
-            </div>
-            <div>
-              <div>auto</div>
-              <Tooltip position="auto">
-                This is a simple tooltip. This is a simple tooltip. This is a
-                simple tooltip. This is a simple tooltip. This is a simple
-                tooltip.
-              </Tooltip>
-            </div>
-
-            <div>
-              <div>auto</div>
-              <Tooltip position="auto">
-                This is a simple tooltip. This is a simple tooltip. This is a
-                simple tooltip. This is a simple tooltip. This is a simple
-                tooltip.
-              </Tooltip>
-            </div>
-
-            <div>
-              <div>auto</div>
-              <Tooltip position="auto">
-                This is a simple tooltip. This is a simple tooltip. This is a
-                simple tooltip. This is a simple tooltip. This is a simple
-                tooltip.
-              </Tooltip>
-            </div>
-            <div>
-              <div>auto</div>
-              <Tooltip position="auto">
-                This is a simple tooltip. This is a simple tooltip. This is a
-                simple tooltip. This is a simple tooltip. This is a simple
-                tooltip.
-              </Tooltip>
+          <div class="grid gap-4 grid-cols-5">
+            <div v-for="index in 5" :key="index">
+              <div class="flex justify-center">
+                <Tooltip position="auto">
+                  This is a simple tooltip. This is a simple tooltip. This is a
+                  simple tooltip. This is a simple tooltip. This is a simple
+                  tooltip.</Tooltip
+                >
+              </div>
             </div>
           </div>
         </div>

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -58,6 +58,11 @@ const popoverPositions: PopoverPosition[] = [
 
 const popoverProps = [
   {
+    name: "as",
+    required: false,
+    type: "string - default: div",
+  },
+  {
     name: "position",
     required: false,
     type: "PopoverPosition - default: auto",
@@ -65,6 +70,11 @@ const popoverProps = [
 ]
 
 const tooltipProps = [
+  {
+    name: "as",
+    required: false,
+    type: "string - default: span",
+  },
   {
     name: "position",
     required: false,

--- a/src/helpers/Debounce.ts
+++ b/src/helpers/Debounce.ts
@@ -1,0 +1,10 @@
+export function debounce(func: () => void, timeout = 500): () => void {
+  let timer: NodeJS.Timer
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (...args: any[]) => {
+    clearTimeout(timer)
+    timer = setTimeout(() => {
+      func.apply(args)
+    }, timeout)
+  }
+}

--- a/src/helpers/Throttle.ts
+++ b/src/helpers/Throttle.ts
@@ -1,0 +1,11 @@
+export function throttle(func: () => void, timeout = 100) {
+  let inThrottle: boolean
+
+  return (...args: any[]) => {
+    if (!inThrottle) {
+      func.apply(args)
+      inThrottle = true
+      setTimeout(() => (inThrottle = false), timeout)
+    }
+  }
+}

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -11,6 +11,7 @@ export type PopoverPosition =
   | "auto"
 </script>
 <script lang="ts" setup>
+import { throttle } from "@/helpers/Throttle"
 import {
   Popover as HeadlessPopover,
   PopoverButton as HeadlessPopoverButton,
@@ -90,6 +91,7 @@ const wrapperPosition = computed(() => {
   const { vw, vh } = viewport.value
   const wrapRect = wrapper.value.el.getBoundingClientRect()
   const distToBottom = vh - anchorRect.value.bottom
+  //NOTE: edge case - there may be more space bellow in viewport, but less document space for display
   const positionAbove = anchorRect.value.top > distToBottom
   const distToRight = vw - anchorRect.value.right
   const positionLeft = anchorRect.value.left > distToRight
@@ -137,19 +139,18 @@ function getViewportDimensions() {
   }
 }
 
+const throttledSetPositions = throttle(setPositions)
+
 onMounted(() => {
   setPositions()
-  // TODO: throttle - or is this even necessary?
-  window.addEventListener("resize", setPositions)
-  window.addEventListener("scroll", setPositions)
+  window.addEventListener("resize", throttledSetPositions)
+  window.addEventListener("scroll", throttledSetPositions)
 })
 
 onUnmounted(() => {
-  window.removeEventListener("resize", setPositions)
-  window.removeEventListener("scroll", setPositions)
+  window.removeEventListener("resize", throttledSetPositions)
+  window.removeEventListener("scroll", throttledSetPositions)
 })
-
-// TODO: maybe auto positioning - dynamic based on button location and closed overflow hidden container?
 </script>
 
 <template>
@@ -175,9 +176,7 @@ onUnmounted(() => {
         >
           <!--positioning wrappers-->
           <div>
-            <div class="bg-gray-200">
-              <slot :open="open" :close="close"></slot>
-            </div>
+            <slot :open="open" :close="close"></slot>
           </div>
         </HeadlessPopoverPanel>
       </transition>

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -9,7 +9,7 @@ export type PopoverPosition =
   | "left"
   | "right"
   | "auto"
-  | "none" // TODO: this could be useful in edge cases
+  | "none"
 </script>
 <script lang="ts" setup>
 import { throttle } from "@/helpers/Throttle"
@@ -29,42 +29,80 @@ const props = withDefaults(
   }
 )
 
+const getViewportDimensions = () => {
+  return {
+    vw: document.documentElement.clientWidth,
+    vh: document.documentElement.clientHeight,
+  }
+}
+
+const trigger = ref<typeof HeadlessPopoverButton>()
+const wrapper = ref<typeof HeadlessPopoverPanel>()
+const viewport = ref<{ vw: number; vh: number }>(getViewportDimensions())
+const anchorRect = ref<DOMRect | undefined>()
+
+const classes = computed(() => {
+  const classes = {
+    wrapper: "",
+    content: "",
+  }
+
+  if (props.position === "none") {
+    return classes
+  }
+
+  // defaults classes when positioning
+  classes.wrapper = "absolute z-10 h-0 flex w-screen"
+  classes.content = "absolute"
+
+  // merge static positioning classes
+  if (props.position !== "auto") {
+    classes.wrapper += ` ${staticPosition.value.wrapper}`
+    classes.content += ` ${staticPosition.value.content}`
+  }
+
+  return classes
+})
+
 const staticPosition = computed(() => {
   let wrapperClasses = ""
   let contentClasses = ""
 
   switch (props.position) {
     case "top-left":
-      wrapperClasses =
-        "top-0 left-0 -translate-y-full -translate-x-full justify-end"
+      wrapperClasses = "top-0 right-0 -translate-y-full justify-end"
+      contentClasses = "bottom-full"
       break
     case "top-center":
       wrapperClasses =
         "top-0 -translate-y-full -translate-x-full left-1/2 justify-end"
-      contentClasses = "translate-x-1/2"
+      contentClasses = "bottom-full translate-x-1/2"
       break
     case "top-right":
-      wrapperClasses = "top-0 -translate-y-full right-0 justify-end"
-      contentClasses = "translate-x-full"
+      wrapperClasses =
+        "top-0 -translate-y-full left-0 -translate-x-full justify-end"
+      contentClasses = "bottom-full translate-x-full"
       break
     case "bottom-left":
-      wrapperClasses = "top-full left-0 -translate-x-full justify-end"
+      wrapperClasses = "top-full right-0 justify-end"
+      contentClasses = "top-full"
       break
     case "bottom-center":
       wrapperClasses = "top-full -translate-x-full left-1/2 justify-end"
-      contentClasses = "translate-x-1/2"
+      contentClasses = "top-full translate-x-1/2"
       break
     case "bottom-right":
-      wrapperClasses = "top-full right-0 justify-end"
-      contentClasses = "translate-x-full"
+      wrapperClasses = "top-full left-0 -translate-x-full justify-end"
+      contentClasses = "top-full translate-x-full"
       break
     case "left":
       wrapperClasses =
         "top-1/2 left-0 -translate-y-1/2 -translate-x-full justify-end"
+      contentClasses = "-translate-y-1/2"
       break
     case "right":
       wrapperClasses = "top-1/2 -translate-y-1/2 right-0 justify-end"
-      contentClasses = "translate-x-full"
+      contentClasses = "translate-x-full -translate-y-1/2"
       break
   }
 
@@ -73,11 +111,6 @@ const staticPosition = computed(() => {
     content: contentClasses,
   }
 })
-
-const trigger = ref<typeof HeadlessPopoverButton>()
-const wrapper = ref<typeof HeadlessPopoverPanel>()
-const viewport = ref<{ vw: number; vh: number }>(getViewportDimensions())
-const anchorRect = ref<DOMRect>()
 
 const autoPosition = computed(() => {
   if (
@@ -90,7 +123,6 @@ const autoPosition = computed(() => {
   const { vw, vh } = viewport.value
 
   const offset = 10 // avoid bumping up against the edge of the browser when possible
-  const wrapRect: DOMRect = wrapper.value.el.getBoundingClientRect()
   const contentRect: DOMRect =
     wrapper.value.el.firstChild.getBoundingClientRect()
   const distToBottom = vh - anchorRect.value.bottom
@@ -142,44 +174,42 @@ const autoPosition = computed(() => {
   }
 })
 
-const setPositions = () => {
-  if (trigger.value === undefined) return
-  anchorRect.value = trigger.value.el.getBoundingClientRect()
+if (props.position === "auto") {
+  const setPositions = () => {
+    if (trigger.value === undefined) return
+    anchorRect.value = trigger.value.el.getBoundingClientRect()
 
-  viewport.value = getViewportDimensions()
-}
-
-function getViewportDimensions() {
-  return {
-    vw: document.documentElement.clientWidth,
-    vh: document.documentElement.clientHeight,
+    viewport.value = getViewportDimensions()
   }
+
+  const throttledSetPositions = throttle(setPositions)
+
+  onMounted(() => {
+    setPositions()
+    window.addEventListener("resize", throttledSetPositions)
+    window.addEventListener("scroll", throttledSetPositions)
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener("resize", throttledSetPositions)
+    window.removeEventListener("scroll", throttledSetPositions)
+  })
 }
-
-const throttledSetPositions = throttle(setPositions)
-
-onMounted(() => {
-  setPositions()
-  window.addEventListener("resize", throttledSetPositions)
-  window.addEventListener("scroll", throttledSetPositions)
-})
-
-onUnmounted(() => {
-  window.removeEventListener("resize", throttledSetPositions)
-  window.removeEventListener("scroll", throttledSetPositions)
-})
 </script>
 
 <template>
-  <div class="flex">
-    <HeadlessPopover v-slot="{ open, close }" class="relative leading-none">
+  <div>
+    <HeadlessPopover
+      v-slot="{ open, close }"
+      class="flex relative leading-none"
+    >
       <HeadlessPopoverButton ref="trigger">
         <slot name="button" :open="open" :close="close"></slot>
       </HeadlessPopoverButton>
 
       <transition
         enter-active-class="transition-opacity transition-faster ease-out-quad"
-        leave-active-class="transition-opacity transition-faster ease-in-quad"
+        leave-active-class="transition-opacity transition-fastest ease-in-quad"
         enter-from-class="opacity-0"
         enter-to-class="opacity-100"
         leave-from-class="opacity-100"
@@ -187,13 +217,11 @@ onUnmounted(() => {
       >
         <HeadlessPopoverPanel
           ref="wrapper"
-          class="absolute z-10 h-0 flex w-screen"
-          :class="position === 'auto' ? '' : staticPosition.wrapper"
+          :class="classes.wrapper"
           :style="position === 'auto' ? autoPosition.wrapper : {}"
         >
           <div
-            class="absolute"
-            :class="position === 'auto' ? `` : staticPosition.content"
+            :class="classes.content"
             :style="position === 'auto' ? autoPosition.content : {}"
           >
             <slot :open="open" :close="close"></slot>

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -96,38 +96,44 @@ const autoPosition = computed(() => {
   // the inverse could also be true - but very rare
   const positionAbove = anchorRect.value.top > distToBottom
   const distToRight = vw - anchorRect.value.right
-  const positionLeft = anchorRect.value.left > distToRight
 
-  console.log(wrapRect, contentRect, anchorRect.value, vw)
+  // this doesn't actually work quite right.  the width of the trigger f's it up
+  // TODO: should probably find a centering position
+
+  const flowLeft = anchorRect.value.left > distToRight
+
+  console.log(flowLeft)
 
   let xPos = 0
-  if (positionLeft) {
-    xPos = anchorRect.value.left * -1
-    if (xPos < contentRect.width * -1) {
-      xPos = (contentRect.width - anchorRect.value.width) * -1
+  if (flowLeft) {
+    xPos = anchorRect.value.right + anchorRect.value.width - contentRect.width
+
+    if (contentRect.width > anchorRect.value.right + anchorRect.value.width) {
+      xPos = xPos + (contentRect.width - anchorRect.value.right)
     }
   } else {
-    xPos = (contentRect.width - distToRight) * -1
+    xPos = anchorRect.value.left
+
+    if (contentRect.width > vw - anchorRect.value.left) {
+      xPos = xPos + (vw - anchorRect.value.left - contentRect.width)
+    }
 
     console.log(xPos)
-    /*
-    if (xPos < wrapRect.width * -1) {
-      xPos = wrapRect.width * -1
-    } else if (xPos > 0) {
-      xPos = 0
-    }
-    */
   }
 
   return {
     wrapper: {
       top: positionAbove ? "auto" : `100%`,
       bottom: positionAbove ? "100%" : `auto`,
-      transform: `translate3d(${anchorRect.value.left * -1}px, 0, 0)`,
-      // left: `${anchorRect.value.left * -1}px`,
+
+      // TODO: this is still a little off.
+      // TODO: also look at z-index and click off ability. - maybe set a height on container
+      transform: `translate3d(${
+        (vw - (vw - anchorRect.value.left)) * -1
+      }px, 0, 0)`, // pin to left of window
     },
     content: {
-      transform: `translate3d(${positionLeft ? xPos : xPos}px, 0, 0)`,
+      transform: `translate3d(${xPos}px, 0, 0)`,
     },
   }
 })
@@ -140,16 +146,9 @@ const setPositions = () => {
 }
 
 function getViewportDimensions() {
-  console.log(document.documentElement.clientWidth || 0, window.innerWidth || 0)
   return {
-    vw: Math.max(
-      document.documentElement.clientWidth || 0,
-      window.innerWidth || 0
-    ),
-    vh: Math.max(
-      document.documentElement.clientHeight || 0,
-      window.innerHeight || 0
-    ),
+    vw: Math.max(window.innerWidth),
+    vh: Math.max(window.innerHeight),
   }
 }
 
@@ -185,12 +184,12 @@ onUnmounted(() => {
         <!--NOTE: use prop "static" for dev work to keep the tooptip visible-->
         <HeadlessPopoverPanel
           ref="wrapper"
-          class="absolute z-10 transform w-screen flex px-4"
-          :class="position === 'auto' ? '' : staticPosition.wrapper"
+          class="absolute z-10 transform w-screen flex"
+          :class="position === 'auto' ? 'px-2' : staticPosition.wrapper"
           :style="position === 'auto' ? autoPosition.wrapper : {}"
         >
           <div
-            :class="position === 'auto' ? `left-0` : staticPosition.content"
+            :class="position === 'auto' ? `` : staticPosition.content"
             :style="position === 'auto' ? autoPosition.content : {}"
           >
             <slot :open="open" :close="close"></slot>

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -22,9 +22,11 @@ import { computed, onMounted, onUnmounted, ref } from "vue"
 
 const props = withDefaults(
   defineProps<{
+    as?: string
     position?: PopoverPosition
   }>(),
   {
+    as: "div",
     position: "auto",
   }
 )
@@ -196,34 +198,32 @@ if (props.position === "auto") {
 </script>
 
 <template>
-  <div>
-    <HeadlessPopover v-slot="{ open, close }" class="relative leading-none">
-      <HeadlessPopoverButton ref="trigger">
-        <slot name="button" :open="open" :close="close"></slot>
-      </HeadlessPopoverButton>
+  <HeadlessPopover v-slot="{ open, close }" class="relative" :as="as">
+    <HeadlessPopoverButton ref="trigger">
+      <slot name="button" :open="open" :close="close"></slot>
+    </HeadlessPopoverButton>
 
-      <transition
-        enter-active-class="transition-opacity transition-faster ease-out-quad"
-        leave-active-class="transition-opacity transition-fastest ease-in-quad"
-        enter-from-class="opacity-0"
-        enter-to-class="opacity-100"
-        leave-from-class="opacity-100"
-        leave-to-class="opacity-0"
+    <transition
+      enter-active-class="transition-opacity transition-faster ease-out-quad"
+      leave-active-class="transition-opacity transition-fastest ease-in-quad"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <HeadlessPopoverPanel
+        ref="wrapper"
+        class="absolute z-10"
+        :class="classes.wrapper"
+        :style="position === 'auto' ? autoPosition.wrapper : {}"
       >
-        <HeadlessPopoverPanel
-          ref="wrapper"
-          class="absolute z-10"
-          :class="classes.wrapper"
-          :style="position === 'auto' ? autoPosition.wrapper : {}"
+        <div
+          :class="classes.content"
+          :style="position === 'auto' ? autoPosition.content : {}"
         >
-          <div
-            :class="classes.content"
-            :style="position === 'auto' ? autoPosition.content : {}"
-          >
-            <slot :open="open" :close="close"></slot>
-          </div>
-        </HeadlessPopoverPanel>
-      </transition>
-    </HeadlessPopover>
-  </div>
+          <slot :open="open" :close="close"></slot>
+        </div>
+      </HeadlessPopoverPanel>
+    </transition>
+  </HeadlessPopover>
 </template>

--- a/src/lib-components/overlays/Popover/PopoverContent.vue
+++ b/src/lib-components/overlays/Popover/PopoverContent.vue
@@ -1,7 +1,7 @@
 <template>
   <!--styling wrapper - top level element will merge attrs for class overrides -->
   <div
-    class="max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md"
+    class="w-full max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md"
   >
     <slot></slot>
   </div>

--- a/src/lib-components/overlays/Tooltip.vue
+++ b/src/lib-components/overlays/Tooltip.vue
@@ -4,10 +4,10 @@ import { InformationCircleIcon } from "@heroicons/vue/outline"
 
 withDefaults(
   defineProps<{
-    position: PopoverPosition
+    position?: PopoverPosition
   }>(),
   {
-    position: "top-center",
+    position: "auto",
   }
 )
 </script>
@@ -16,15 +16,15 @@ withDefaults(
   <Popover :position="position">
     <template #button>
       <div class="relative">
-        <!--creates a larger clickable surface area-->
+        <!--creates a larger clickable surface area 40 x 40-->
         <div
-          class="p-4 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+          class="p-5 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
         ></div>
         <InformationCircleIcon class="w-4 h-4" />
       </div>
     </template>
     <div
-      class="w-full max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs text-gray-700 leading-tight font-medium"
+      class="w-full max-w-xs bg-white rounded-md px-3 py-2 border border-gray-100 drop-shadow-md text-xs text-gray-900 leading-snug font-medium"
     >
       <slot></slot>
     </div>

--- a/src/lib-components/overlays/Tooltip.vue
+++ b/src/lib-components/overlays/Tooltip.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import Popover, { PopoverPosition } from "./Popover/Popover.vue"
 import { InformationCircleIcon } from "@heroicons/vue/outline"
-import PopoverContent from "./Popover/PopoverContent.vue"
 
 withDefaults(
   defineProps<{
@@ -25,7 +24,7 @@ withDefaults(
       </div>
     </template>
     <div
-      class="w-80 max-w-sm bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs text-gray-700 leading-tight font-medium"
+      class="max-w-sm bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs text-gray-700 leading-tight font-medium"
     >
       <slot></slot>
     </div>

--- a/src/lib-components/overlays/Tooltip.vue
+++ b/src/lib-components/overlays/Tooltip.vue
@@ -4,23 +4,25 @@ import { InformationCircleIcon } from "@heroicons/vue/outline"
 
 withDefaults(
   defineProps<{
+    as?: string
     position?: PopoverPosition
   }>(),
   {
+    as: "span",
     position: "auto",
   }
 )
 </script>
 
 <template>
-  <Popover :position="position">
+  <Popover :position="position" :as="as">
     <template #button>
-      <div class="relative">
+      <div class="leading-none w-4 h-4">
+        <InformationCircleIcon />
         <!--creates a larger clickable surface area 40 x 40-->
         <div
           class="p-5 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
         ></div>
-        <InformationCircleIcon class="w-4 h-4" />
       </div>
     </template>
     <div

--- a/src/lib-components/overlays/Tooltip.vue
+++ b/src/lib-components/overlays/Tooltip.vue
@@ -25,7 +25,7 @@ withDefaults(
       </div>
     </template>
     <div
-      class="max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs text-gray-700 leading-tight font-medium"
+      class="w-80 max-w-sm bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs text-gray-700 leading-tight font-medium"
     >
       <slot></slot>
     </div>

--- a/src/lib-components/overlays/Tooltip.vue
+++ b/src/lib-components/overlays/Tooltip.vue
@@ -24,7 +24,7 @@ withDefaults(
       </div>
     </template>
     <div
-      class="max-w-sm bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs text-gray-700 leading-tight font-medium"
+      class="w-full max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md text-xs text-gray-700 leading-tight font-medium"
     >
       <slot></slot>
     </div>


### PR DESCRIPTION
# What this does

- adds auto positioning for popovers and tooltips based on the trigger position and available viewport space
- includes position "none" option for no positioning help in popovers
- adds "as" prop to popovers and tooltips so the wrapper element can be changed easily (div vs span) is the most common use case - tooltips default to span
- basic throttle and debounce functions were added to helpers - throttle is used for auto positioning.  neither is exported to consumers yet (will consider later)
- tweaks static positioning anchor point - rather then top-left positioning on the far left of the trigger the popover flows left but anchors on the far right - this seems to be a more sensible use of space and plays nicely with wider triggers


__Basic Idea of Positioning__ - favor left to right on viewport space:

https://user-images.githubusercontent.com/3856703/154102823-97a8d02c-b6a4-4d18-9183-a721c3131e9c.mov

__Mobile width handling__ - using an absurdly narrow viewport it stays contained in the viewport:

<img width="297" alt="Screen Shot 2022-02-15 at 10 09 48 AM" src="https://user-images.githubusercontent.com/3856703/154103187-dadc7793-e60f-46ff-9134-1afdfc932736.png">

## Caveats

All positioning and popovers generally do not attempt to tackle parent overflow rules this seems outside of the scope of responsibility for the popover itself.  If it is being used inside a container with overflow hidden the use of overflow hidden should probably be examined first and the the use of a popover component should be questioned second as it may be the wrong choice.