### PR TITLE
proposal: 0.4.3

### DIFF
--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -148,8 +148,6 @@ const inputHelpProps = [
 const toggleValue = ref(false)
 const toggleCopy = `<Toggle v-model="toggleValue"></Toggle>`
 const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
-
-const showLegend = ref(false)
 </script>
 <template>
   <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
@@ -212,6 +210,16 @@ const showLegend = ref(false)
         </div>
 
         <div>
+          <div class="mt-1">
+            <BaseInput
+              :disabled="true"
+              type="text"
+              label="Disabled"
+            ></BaseInput>
+          </div>
+        </div>
+
+        <div>
           <div class="border-t pt-4 mt-4">
             <Select
               :options="inputTypes"
@@ -243,7 +251,20 @@ const showLegend = ref(false)
             <ClickToCopy :value="textareaCopy" />
           </label>
           <div class="mt-1">
-            <TextArea v-model="textarea" />
+            <TextArea
+              v-model="textarea"
+              label="How about it (disabled)?"
+              help="In your own words."
+            />
+
+            <div class="mt-4">
+              <TextArea
+                :disabled="true"
+                label="How about it (disabled)?"
+                help="In your own words."
+                v-model="textarea"
+              />
+            </div>
             <div class="mt-4"><b>Value:</b> {{ textarea }}</div>
             <PropsTable :props="textareaProps" />
           </div>
@@ -263,6 +284,13 @@ const showLegend = ref(false)
           <div class="mt-1 space-y-8">
             <Checkbox
               label="I'm here to party!"
+              help="Get notified when the party starts."
+              v-model="checked"
+            />
+
+            <Checkbox
+              :disabled="true"
+              label="I'm here to party! (disabled)"
               help="Get notified when the party starts."
               v-model="checked"
             />
@@ -441,7 +469,18 @@ const showLegend = ref(false)
             <ClickToCopy :value="yesOrNoRadioCopy" />
           </label>
           <div class="mt-1">
-            <YesOrNoRadio v-model="yesOrNoRadioSelection"></YesOrNoRadio>
+            <YesOrNoRadio
+              legend="Is this thing on?"
+              help="Only one way to find out."
+              v-model="yesOrNoRadioSelection"
+            ></YesOrNoRadio>
+            <div class="mt-2">
+              <YesOrNoRadio
+                legend="Is this thing on? (disabled)"
+                v-model="yesOrNoRadioSelection"
+                disabled
+              ></YesOrNoRadio>
+            </div>
             <div class="mt-4"><b>Value:</b> {{ yesOrNoRadioSelection }}</div>
             <PropsTable :props="yesOrNoRadioProps" />
           </div>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -41,12 +41,13 @@ const radioProps = [
   {
     name: "options",
     required: true,
-    type: "Array<{ label: string; value: string }>",
+    type: "Array<{ help?: string, label: string; value: number | string }>",
   },
   { name: "modelValue", required: true, type: "string" },
-  { name: "legend", required: false, type: "boolean" },
+  { name: "help", required: false, type: "string" },
+  { name: "legend", required: false, type: "string" },
 ]
-const radioSelection = ref("")
+const radioSelection = ref<string | number>("val2")
 const selectCopy = `<Select :options="options" placeholder="Select an option that you fancy" />`
 const selectProps = [
   { name: "design", required: false, type: "string" },
@@ -324,6 +325,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               legend="Make Complex Selections"
               help="Select all that apply."
               :options="options"
+              disabled
               v-model="multiCheckboxSelection"
             />
             <div class="mt-2"><b>Value:</b> {{ multiCheckboxSelection }}</div>
@@ -342,8 +344,36 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           <label class="block text-sm font-medium text-gray-700">
             <ClickToCopy :value="radioCopy" />
           </label>
-          <div class="mt-1">
-            <Radio :options="options" v-model="radioSelection" />
+          <div class="mt-1 space-y-8">
+            <Radio
+              legend="Make Basic Choice"
+              :options="
+                options.map((option) => ({
+                  label: option.label,
+                  value: option.value,
+                }))
+              "
+              v-model="radioSelection"
+            />
+
+            <Radio
+              legend="Make Complex Choice"
+              help="Only one - I know it's hard!"
+              :options="options"
+              disabled
+              v-model="radioSelection"
+            />
+
+            <div class="flex">
+              <Radio
+                legend="In A Grid Too"
+                help="Set the columns prop to 2 or 3"
+                :options="options"
+                disabled
+                v-model="radioSelection"
+                :columns="2"
+              />
+            </div>
             <div class="mt-4"><b>Value:</b> {{ radioSelection }}</div>
             <PropsTable :props="radioProps" />
           </div>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -6,7 +6,7 @@ const commonProps = [
   { name: "help", required: false, type: "string" },
 ]
 const checked = ref(false)
-const checkboxCopy = `<Checkbox label="I'm here to party!" v-model="checked" />`
+const checkboxCopy = `<Checkbox label="I'm here to party!" help="Get notified when the party starts." v-model="checked" />`
 const checkboxProps = [
   { name: "emphasis", required: false, type: "boolean" },
   { name: "label", required: false, type: "string" },
@@ -241,7 +241,11 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             <ClickToCopy :value="checkboxCopy" />
           </label>
           <div class="mt-1">
-            <Checkbox label="I'm here to party!" v-model="checked" />
+            <Checkbox
+              label="I'm here to party!"
+              help="Get notified when the party starts."
+              v-model="checked"
+            />
             <div class="mt-4"><b>Value:</b> {{ checked }}</div>
             <PropsTable :props="checkboxProps" />
           </div>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -5,7 +5,7 @@ const commonProps = [
   { name: "label", required: false, type: "string" },
   { name: "help", required: false, type: "string" },
 ]
-const checked = ref(false)
+const checked = ref(true)
 const checkboxCopy = `<Checkbox label="I'm here to party!" help="Get notified when the party starts." v-model="checked" />`
 const checkboxProps = [
   { name: "emphasis", required: false, type: "boolean" },
@@ -25,17 +25,17 @@ const dateRangePickerProps = [
 ]
 const inputCopy = `<BaseInput type="text" label="What's your lide moto?" help="No wrong ansswers here." placeholder="It's good to be alive"/>`
 const inputErrorCopy = `<BaseInput type="text" placeholder="Broken" class="xy-input-error" />`
-const multiCheckboxCopy = `<MultiCheckboxes :options="options" v-model="selected" />`
+const multiCheckboxCopy = `<MultiCheckboxes v-model="selected" legend="Make Some Selections" help="Select all that apply." :options="options" />`
 const multiCheckboxProps = [
   {
     name: "options",
     required: true,
-    type: "Array<{ label: string; value: string }>",
+    type: "Array<{ help?: string; label: string; value: number | string }>",
   },
   { name: "modelValue", required: true, type: "string" },
   { name: "legend", required: false, type: "string" },
 ]
-const multiCheckboxSelection = ref([])
+const multiCheckboxSelection = ref(["val2", 4])
 const radioCopy = `<Radio :options="options" v-model="selected" />`
 const radioProps = [
   {
@@ -60,10 +60,26 @@ const selectProps = [
   ...commonProps,
 ]
 const options = [
-  { label: "You could select this", value: "val1" },
-  { label: "This is an option", value: "val2" },
-  { label: "Feeling good about this one?", value: "val3" },
-  { label: "This is the LAST option", value: "val4" },
+  {
+    label: "You could select this",
+    help: "It's really quite nice.",
+    value: "val1",
+  },
+  {
+    label: "This is an option",
+    help: "Ah, indeed it is an option.",
+    value: "val2",
+  },
+  {
+    label: "Feeling good about this one?",
+    help: "Of course you are!",
+    value: 3,
+  },
+  {
+    label: "This is the LAST option",
+    help: "There's no turning back.",
+    value: 4,
+  },
 ]
 
 const selected = ref("")
@@ -240,12 +256,18 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           <label class="block text-sm font-medium text-gray-700">
             <ClickToCopy :value="checkboxCopy" />
           </label>
-          <div class="mt-1">
+          <div class="mt-1 space-y-8">
             <Checkbox
               label="I'm here to party!"
               help="Get notified when the party starts."
               v-model="checked"
             />
+
+            <Checkbox
+              label="I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party!"
+              v-model="checked"
+            />
+
             <div class="mt-4"><b>Value:</b> {{ checked }}</div>
             <PropsTable :props="checkboxProps" />
           </div>
@@ -286,12 +308,25 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           <label class="block text-sm font-medium text-gray-700">
             <ClickToCopy :value="multiCheckboxCopy" />
           </label>
-          <div class="mt-1">
+          <div class="mt-1 space-y-8">
             <MultiCheckboxes
+              legend="Make Basic Selections"
+              :options="
+                options.map((option) => ({
+                  label: option.label,
+                  value: option.value,
+                }))
+              "
+              v-model="multiCheckboxSelection"
+            />
+
+            <MultiCheckboxes
+              legend="Make Complex Selections"
+              help="Select all that apply."
               :options="options"
               v-model="multiCheckboxSelection"
             />
-            <div class="mt-4"><b>Value:</b> {{ multiCheckboxSelection }}</div>
+            <div class="mt-2"><b>Value:</b> {{ multiCheckboxSelection }}</div>
             <PropsTable :props="multiCheckboxProps" />
           </div>
         </div>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -30,7 +30,7 @@ const multiCheckboxProps = [
   {
     name: "options",
     required: true,
-    type: "Array<{ help?: string; label: string; value: number | string }>",
+    type: "Array<{ disabled?: boolean, help?: string; label: string; value: number | string }>",
   },
   { name: "modelValue", required: true, type: "string" },
   { name: "legend", required: false, type: "string" },
@@ -41,7 +41,7 @@ const radioProps = [
   {
     name: "options",
     required: true,
-    type: "Array<{ help?: string, label: string; value: number | string }>",
+    type: "Array<{ disabled?: boolean, help?: string, label: string; value: number | string }>",
   },
   { name: "modelValue", required: true, type: "string" },
   { name: "help", required: false, type: "string" },
@@ -89,6 +89,7 @@ const selected = ref("")
 const yesOrNoRadioCopy = `<YesOrNoRadio v-model="selected" />`
 const yesOrNoRadioSelection = ref(undefined)
 const yesOrNoRadioProps = [
+  { name: "help", required: false, type: "string" },
   { name: "legend", required: false, type: "string" },
   { name: "name", required: false, type: "string" },
   { name: "modelValue", required: false, type: "boolean" },

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -77,6 +77,7 @@ const options = [
     value: 3,
   },
   {
+    disabled: true,
     label: "This is the LAST option",
     help: "There's no turning back.",
     value: 4,
@@ -147,6 +148,8 @@ const inputHelpProps = [
 const toggleValue = ref(false)
 const toggleCopy = `<Toggle v-model="toggleValue"></Toggle>`
 const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
+
+const showLegend = ref(false)
 </script>
 <template>
   <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
@@ -314,6 +317,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               legend="Make Basic Selections"
               :options="
                 options.map((option) => ({
+                  disabled: option.disabled,
                   label: option.label,
                   value: option.value,
                 }))
@@ -328,6 +332,17 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               disabled
               v-model="multiCheckboxSelection"
             />
+
+            <div class="flex">
+              <MultiCheckboxes
+                :columns="2"
+                help="Set the columns prop to 2, 3, or 4"
+                :options="options"
+                v-model="multiCheckboxSelection"
+              >
+                <template #legend>In A Grid Too</template>
+              </MultiCheckboxes>
+            </div>
             <div class="mt-2"><b>Value:</b> {{ multiCheckboxSelection }}</div>
             <PropsTable :props="multiCheckboxProps" />
           </div>
@@ -349,6 +364,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               legend="Make Basic Choice"
               :options="
                 options.map((option) => ({
+                  disabled: option.disabled,
                   label: option.label,
                   value: option.value,
                 }))
@@ -366,13 +382,13 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
 
             <div class="flex">
               <Radio
-                legend="In A Grid Too"
-                help="Set the columns prop to 2 or 3"
+                help="Set the columns prop to 2, 3, or 4"
                 :options="options"
-                disabled
                 v-model="radioSelection"
                 :columns="2"
-              />
+              >
+                <template #legend>In A Grid Too</template>
+              </Radio>
             </div>
             <div class="mt-4"><b>Value:</b> {{ radioSelection }}</div>
             <PropsTable :props="radioProps" />

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -354,13 +354,11 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
           </p>
           <div class="grid gap-4 grid-cols-5">
             <div v-for="index in 5" :key="index">
-              <div class="flex justify-center">
-                <Tooltip>
-                  This is a simple tooltip. This is a simple tooltip. This is a
-                  simple tooltip. This is a simple tooltip. This is a simple
-                  tooltip.</Tooltip
-                >
-              </div>
+              <Tooltip>
+                This is a simple tooltip. This is a simple tooltip. This is a
+                simple tooltip. This is a simple tooltip. This is a simple
+                tooltip.</Tooltip
+              >
             </div>
           </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/src/helpers/Slots.ts
+++ b/src/helpers/Slots.ts
@@ -1,0 +1,21 @@
+import { Comment, Text, Slot, VNode } from "vue"
+
+export function hasSlotContent(
+  slot: Slot | undefined,
+  slotProps = {}
+): boolean {
+  if (!slot) return false
+
+  return slot(slotProps).some((vnode: VNode) => {
+    if (vnode.type === Comment) return false
+
+    console.log(vnode)
+
+    if (Array.isArray(vnode.children) && !vnode.children.length) return false
+
+    return (
+      vnode.type !== Text ||
+      (typeof vnode.children === "string" && vnode.children.trim() !== "")
+    )
+  })
+}

--- a/src/helpers/Slots.ts
+++ b/src/helpers/Slots.ts
@@ -9,8 +9,6 @@ export function hasSlotContent(
   return slot(slotProps).some((vnode: VNode) => {
     if (vnode.type === Comment) return false
 
-    console.log(vnode)
-
     if (Array.isArray(vnode.children) && !vnode.children.length) return false
 
     return (

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -69,6 +69,8 @@ const isTextType = computed((): boolean => {
             'border-gray-600',
             'rounded-md',
             'w-full',
+            'disabled:opacity-70',
+            'disabled:cursor-not-allowed',
           ]
         : []),
     ]"

--- a/src/lib-components/forms/Checkbox.vue
+++ b/src/lib-components/forms/Checkbox.vue
@@ -40,6 +40,9 @@ const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
     <div class="ml-3">
       <InputLabel
         class="mt-auto"
+        :disabled="
+          $attrs.hasOwnProperty('disabled') && $attrs.disabled !== false
+        "
         :id="`${uuid}-label`"
         :for="uuid"
         :label="label"

--- a/src/lib-components/forms/Checkbox.vue
+++ b/src/lib-components/forms/Checkbox.vue
@@ -26,8 +26,9 @@ const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
         :id="uuid"
         :aria-labelledby="label ? `${uuid}-label` : undefined"
         :aria-describedby="help ? `${uuid}-help` : undefined"
-        type="checkbox"
+        :checked="modelValue"
         class="focus:ring-blue-500 h-4 w-4 text-blue-500 border-gray-600 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+        type="checkbox"
         v-bind="{
           onChange: ($event) => {
             emits('update:modelValue', ($event.target as HTMLInputElement).checked)
@@ -38,18 +39,12 @@ const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
     </div>
     <div class="ml-3">
       <InputLabel
-        v-if="label"
         class="mt-auto"
         :id="`${uuid}-label`"
         :for="uuid"
         :label="label"
       />
-      <InputHelp
-        v-if="help"
-        class="-mt-1"
-        :id="`${uuid}-help`"
-        :text="help"
-      ></InputHelp>
+      <InputHelp class="-mt-1" :id="`${uuid}-help`" :text="help"></InputHelp>
     </div>
   </div>
 </template>

--- a/src/lib-components/forms/Checkbox.vue
+++ b/src/lib-components/forms/Checkbox.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
 import InputLabel from "./InputLabel.vue"
+import InputHelp from "./InputHelp.vue"
 import Uniques from "@/helpers/Uniques"
 import { useAttrs } from "vue"
 
-// TODO: checkbox should support the help text prop - possibly as a tooltip
-// TODO: aria-labelledby may be superfluous here since the input is wrapped in a label
 withDefaults(
   defineProps<{
     label?: string
+    help?: string
     modelValue: boolean
   }>(),
   {
     label: "",
+    help: "",
   }
 )
 const emits = defineEmits(["update:modelValue"])
@@ -19,28 +20,36 @@ const attrs = useAttrs()
 const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
 </script>
 <template>
-  <div>
-    <label class="inline-flex items-center">
+  <div class="relative flex items-start">
+    <div class="flex items-center h-5">
       <input
-        :aria-labelledby="label ? `${uuid}-label` : undefined"
-        :checked="modelValue"
-        class="focus:ring-blue-500 h-4 w-4 text-blue-500 border-gray-600 rounded disabled:opacity-50 disabled:cursor-not-allowed"
         :id="uuid"
+        :aria-labelledby="label ? `${uuid}-label` : undefined"
+        :aria-describedby="help ? `${uuid}-help` : undefined"
         type="checkbox"
+        class="focus:ring-blue-500 h-4 w-4 text-blue-500 border-gray-600 rounded disabled:opacity-50 disabled:cursor-not-allowed"
         v-bind="{
-          ...$attrs,
           onChange: ($event) => {
             emits('update:modelValue', ($event.target as HTMLInputElement).checked)
           },
+          ...$attrs,
         }"
       />
+    </div>
+    <div class="ml-3">
       <InputLabel
-        class="ml-2"
+        v-if="label"
+        class="mt-auto"
         :id="`${uuid}-label`"
         :for="uuid"
         :label="label"
-        tag="span"
-      ></InputLabel>
-    </label>
+      />
+      <InputHelp
+        v-if="help"
+        class="-mt-1"
+        :id="`${uuid}-help`"
+        :text="help"
+      ></InputHelp>
+    </div>
   </div>
 </template>

--- a/src/lib-components/forms/FieldsetLegend.vue
+++ b/src/lib-components/forms/FieldsetLegend.vue
@@ -1,22 +1,14 @@
 <script setup lang="ts">
-withDefaults(
-  defineProps<{
-    text?: string
-  }>(),
-  {
-    text: "",
-  }
-)
+import { hasSlotContent } from "@/helpers/Slots"
 </script>
-
 <template>
   <legend
-    v-if="text"
+    v-if="hasSlotContent($slots.default)"
     v-bind="{
       ...$attrs,
       class: 'text-base font-medium leading-tight text-gray-900',
     }"
   >
-    {{ text }}
+    <slot />
   </legend>
 </template>

--- a/src/lib-components/forms/InputHelp.vue
+++ b/src/lib-components/forms/InputHelp.vue
@@ -16,7 +16,7 @@ withDefaults(
     v-if="text"
     v-bind="{
       ...$attrs,
-      class: 'mt-2 text-sm leading-snug font-semibold text-gray-700',
+      class: 'mt-1 text-sm leading-snug font-normal text-gray-700',
     }"
   >
     {{ text }}

--- a/src/lib-components/forms/InputLabel.vue
+++ b/src/lib-components/forms/InputLabel.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 withDefaults(
   defineProps<{
+    disabled?: boolean
     label?: string
     tag?: string
   }>(),
   {
+    disabled: false,
     label: "",
     tag: "label",
   }
@@ -14,9 +16,12 @@ withDefaults(
   <component
     :is="tag"
     v-if="label"
+    :class="{
+      'block my-1 text-sm font-semibold leading-snug text-gray-900': true,
+      'opacity-75': disabled,
+    }"
     v-bind="{
       ...$attrs,
-      class: 'block my-1 text-sm font-semibold leading-snug text-gray-900',
     }"
     >{{ label }}</component
   >

--- a/src/lib-components/forms/Legend.vue
+++ b/src/lib-components/forms/Legend.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    text?: string
+  }>(),
+  {
+    text: "",
+  }
+)
+</script>
+
+<template>
+  <legend
+    v-if="text"
+    v-bind="{
+      ...$attrs,
+      class: 'text-base font-medium leading-tight text-gray-900',
+    }"
+  >
+    {{ text }}
+  </legend>
+</template>

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import Uniques from "@/helpers/Uniques"
-import { useAttrs } from "vue"
-import Legend from "./Legend.vue"
+import { computed, useAttrs, useSlots } from "vue"
+import FieldsetLegend from "./FieldsetLegend.vue"
 import InputLabel from "./InputLabel.vue"
 import InputHelp from "./InputHelp.vue"
 
@@ -11,17 +11,20 @@ type ModelValue = CheckboxValue[]
 const props = withDefaults(
   defineProps<{
     options: {
+      disabled?: boolean
       help?: string
       label: string
-      value: string | number
+      value: CheckboxValue
     }[]
     help?: string
     legend?: string
     modelValue: ModelValue
+    columns?: 2 | 3 | 4
   }>(),
   {
     help: "",
     legend: "",
+    columns: undefined,
   }
 )
 
@@ -29,7 +32,11 @@ const emit = defineEmits<{
   (e: "update:modelValue", modelValue: ModelValue): void
 }>()
 const attrs = useAttrs()
+const slots = useSlots()
 const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
+const hasLegend = computed(() => {
+  return props.legend !== "" || slots.legend !== undefined
+})
 const onChange = (checked: boolean, val: CheckboxValue) => {
   let updateModelValue = [...props.modelValue]
 
@@ -43,16 +50,31 @@ const onChange = (checked: boolean, val: CheckboxValue) => {
 }
 </script>
 <template>
-  <fieldset class="space-y-5">
+  <fieldset
+    class="space-y-5"
+    :aria-labelledby="hasLegend ? `${uuid}-legend` : undefined"
+    :aria-describedby="help ? `${uuid}-help` : undefined"
+  >
     <div class="space-y-0.5">
-      <Legend :text="legend" />
-      <InputHelp tag="p" :text="help" />
+      <FieldsetLegend :id="`${uuid}-legend`">
+        <div v-if="legend">{{ legend }}</div>
+        <slot v-if="$slots.legend" name="legend"></slot>
+      </FieldsetLegend>
+      <InputHelp tag="p" :text="help" :id="`${uuid}-help`" />
     </div>
-    <div class="space-y-4">
+    <div
+      class="grid gap-4"
+      :class="{
+        'sm:grid sm:gap-y-4 sm:gap-x-5 sm:space-y-0': columns !== undefined,
+        'sm:grid-cols-2': columns === 2,
+        'sm:grid-cols-3': columns === 3,
+        'sm:grid-cols-4': columns === 4,
+      }"
+    >
       <div
         v-for="(option, index) in options"
         :key="option.value"
-        class="relative flex items-start"
+        class="flex items-start"
       >
         <div class="flex items-center h-5">
           <input
@@ -62,17 +84,23 @@ const onChange = (checked: boolean, val: CheckboxValue) => {
               option?.help && option.help ? `${uuid}-${index}-help` : undefined
             "
             :checked="modelValue.includes(option.value)"
+            :disabled="option.disabled === true ? true : undefined"
             class="focus:ring-blue-500 h-4 w-4 text-blue-500 border-gray-600 rounded disabled:opacity-50 disabled:cursor-not-allowed"
             type="checkbox"
             v-bind="{
               onChange: ($event) => { onChange(($event.target as HTMLInputElement).checked, option.value) },
-            ...$attrs,
+              ...$attrs,
             }"
           />
         </div>
         <div class="ml-3">
           <InputLabel
             class="mt-auto"
+            :disabled="
+              ($attrs.hasOwnProperty('disabled') &&
+                $attrs.disabled !== false) ||
+              option.disabled === true
+            "
             :id="`${uuid}-${index}-label`"
             :for="uuid"
             :label="option.label"

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -1,55 +1,89 @@
 <script setup lang="ts">
 import Uniques from "@/helpers/Uniques"
-import { ref, useAttrs } from "vue"
+import { useAttrs } from "vue"
+import Legend from "./Legend.vue"
 import InputLabel from "./InputLabel.vue"
+import InputHelp from "./InputHelp.vue"
 
-// TODO: checkbox should support the help text prop - possibly as a tooltip
-// TODO: aria-labelledby may be superfluous here since the input is wrapped in a label
+type CheckboxValue = string | number
+type ModelValue = CheckboxValue[]
 
 const props = withDefaults(
   defineProps<{
     options: {
+      help?: string
       label: string
-      value: string
+      value: string | number
     }[]
+    help?: string
     legend?: string
-    modelValue: string[]
+    modelValue: ModelValue
   }>(),
   {
+    help: "",
     legend: "",
   }
 )
 
-const emits = defineEmits(["update:modelValue"])
+const emit = defineEmits<{
+  (e: "update:modelValue", modelValue: ModelValue): void
+}>()
 const attrs = useAttrs()
 const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
-const model = ref<string[]>(props.modelValue)
+const onChange = (checked: boolean, val: CheckboxValue) => {
+  let updateModelValue = [...props.modelValue]
+
+  if (checked) {
+    updateModelValue.push(val)
+  } else {
+    updateModelValue.splice(updateModelValue.indexOf(val), 1)
+  }
+
+  emit("update:modelValue", updateModelValue)
+}
 </script>
 <template>
-  <fieldset>
-    <InputLabel class="block mb-0" :label="legend" tag="legend"></InputLabel>
-    <div class="mt-4" v-for="(option, index) in options" :key="option.value">
-      <label class="inline-flex items-center">
-        <input
-          type="checkbox"
-          class="focus:ring-blue-500 h-4 w-4 text-xy-blue border-gray-600 rounded disabled:opacity-50 disabled:cursor-not-allowed"
-          :id="`${uuid}-${index}`"
-          :value="option.value"
-          v-model="model"
-          v-bind="{
+  <fieldset class="space-y-5">
+    <div class="space-y-0.5">
+      <Legend :text="legend" />
+      <InputHelp tag="p" :text="help" />
+    </div>
+    <div class="space-y-4">
+      <div
+        v-for="(option, index) in options"
+        :key="option.value"
+        class="relative flex items-start"
+      >
+        <div class="flex items-center h-5">
+          <input
+            :id="uuid"
+            :aria-labelledby="`${uuid}-${index}-label`"
+            :aria-describedby="
+              option?.help && option.help ? `${uuid}-${index}-help` : undefined
+            "
+            :checked="modelValue.includes(option.value)"
+            class="focus:ring-blue-500 h-4 w-4 text-blue-500 border-gray-600 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+            type="checkbox"
+            v-bind="{
+              onChange: ($event) => { onChange(($event.target as HTMLInputElement).checked, option.value) },
             ...$attrs,
-            onChange: () => {
-              emits('update:modelValue', model)
-            },
-          }"
-        />
-        <InputLabel
-          class="ml-2"
-          :for="`${uuid}-${index}`"
-          :label="option.label"
-          tag="span"
-        ></InputLabel>
-      </label>
+            }"
+          />
+        </div>
+        <div class="ml-3">
+          <InputLabel
+            class="mt-auto"
+            :id="`${uuid}-${index}-label`"
+            :for="uuid"
+            :label="option.label"
+          />
+          <InputHelp
+            class="-mt-1"
+            :id="`${uuid}-${index}-help`"
+            :text="option.help"
+          />
+        </div>
+      </div>
     </div>
   </fieldset>
 </template>

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -1,23 +1,27 @@
 <script setup lang="ts">
 import Uniques from "@/helpers/Uniques"
 import { useAttrs } from "vue"
+import Legend from "./Legend.vue"
+import InputHelp from "./InputHelp.vue"
 import InputLabel from "./InputLabel.vue"
 
-// TODO: add horizontal layout support
-const props = withDefaults(
+withDefaults(
   defineProps<{
     options: {
+      help?: string
       label: string
-      value: string
+      value: string | number
     }[]
+    help?: string
     legend?: string
-    modelValue?: string
-    vertical?: boolean
+    modelValue?: string | number
+    columns?: 2 | 3
   }>(),
   {
+    help: "",
     legend: "",
-    modelValue: "",
-    vertical: true,
+    modelValue: undefined,
+    columns: undefined,
   }
 )
 const emits = defineEmits(["update:modelValue"])
@@ -25,34 +29,54 @@ const attrs = useAttrs()
 const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
 </script>
 <template>
-  <fieldset class="mt-1 space-y-2">
-    <InputLabel class="block" :label="legend" tag="legend"></InputLabel>
-    <component
-      v-for="(option, index) in options"
-      :key="option.value"
-      :is="props.vertical ? 'div' : 'span'"
+  <fieldset class="space-y-5">
+    <div class="space-y-0.5">
+      <Legend :text="legend" />
+      <InputHelp tag="p" :text="help" />
+    </div>
+    <div
+      class="grid gap-4"
+      :class="{
+        'sm:grid sm:gap-y-4 sm:gap-x-5 sm:space-y-0': columns !== undefined,
+        'sm:grid-cols-2': columns === 2,
+        'sm:grid-cols-3': columns === 3,
+      }"
     >
-      <label
-        class="inline-flex items-center"
-        :class="{ 'cursor-not-allowed': $attrs.disabled }"
-        :for="`${uuid}-${index}`"
+      <div
+        v-for="(option, index) in options"
+        :key="option.value"
+        class="flex items-start"
       >
-        <input
-          :checked="modelValue === option.value"
-          class="w-4 h-4 border-gray-600 focus:ring-blue-500 text-xy-blue"
-          :id="`${uuid}-${index}`"
-          :name="uuid"
-          type="radio"
-          :value="option.value"
-          v-bind="{
-            ...$attrs,
-            onChange: ($event) => {
-              emits('update:modelValue', ($event.target as HTMLInputElement).value)
-            },
-          }"
-        />
-        <InputLabel class="ml-2" :label="option.label" tag="span"></InputLabel>
-      </label>
-    </component>
+        <div class="flex items-center h-5">
+          <input
+            :checked="modelValue === option.value"
+            class="w-4 h-4 border-gray-600 focus:ring-blue-500 text-xy-blue disabled:opacity-50 disabled:cursor-not-allowed"
+            :id="`${uuid}-${index}`"
+            :name="uuid"
+            type="radio"
+            :value="option.value"
+            v-bind="{
+              ...$attrs,
+              onChange: () => {
+                emits('update:modelValue', option.value)
+              },
+            }"
+          />
+        </div>
+        <div class="ml-3">
+          <InputLabel
+            class="mt-auto"
+            :id="`${uuid}-${index}-label`"
+            :for="uuid"
+            :label="option.label"
+          />
+          <InputHelp
+            class="-mt-1"
+            :id="`${uuid}-${index}-help`"
+            :text="option.help"
+          />
+        </div>
+      </div>
+    </div>
   </fieldset>
 </template>

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -49,6 +49,10 @@ const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
       >
         <div class="flex items-center h-5">
           <input
+            :aria-describedby="
+              option?.help && option.help ? `${uuid}-${index}-help` : undefined
+            "
+            :aria-labelledby="`${uuid}-${index}-label`"
             :checked="modelValue === option.value"
             class="w-4 h-4 border-gray-600 focus:ring-blue-500 text-xy-blue disabled:opacity-50 disabled:cursor-not-allowed"
             :id="`${uuid}-${index}`"

--- a/src/lib-components/forms/Select.vue
+++ b/src/lib-components/forms/Select.vue
@@ -29,9 +29,9 @@ const classes = computed((): string => {
   return (
     {
       standard:
-        "mt-1 block w-full border border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm",
+        "mt-1 block w-full border border-gray-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm disabled:opacity-70 disabled:cursor-not-allowed",
       compressed:
-        "appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-600 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm",
+        "appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-600 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm  disabled:opacity-70 disabled:cursor-not-allowed",
     } as any
   )[props.design]
 })

--- a/src/lib-components/forms/TextArea.vue
+++ b/src/lib-components/forms/TextArea.vue
@@ -40,6 +40,8 @@ const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
       'border-gray-600',
       'rounded-md',
       'w-full',
+      'disabled:opacity-70',
+      'disabled:cursor-not-allowed',
     ]"
     :id="uuid"
     :value="modelValue"

--- a/src/lib-components/forms/Toggle.vue
+++ b/src/lib-components/forms/Toggle.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { Switch } from "@headlessui/vue"
 
+// TODO: disabled support, possibly label and help support - determine current usage first
+
 withDefaults(defineProps<{ modelValue: boolean }>(), { modelValue: false })
 const emits = defineEmits(["update:modelValue"])
 </script>

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -6,11 +6,13 @@ import InputLabel from "./InputLabel.vue"
 const props = withDefaults(
   defineProps<{
     modelValue?: boolean
+    help?: string
     legend?: string
     name?: string
   }>(),
   {
     modelValue: undefined,
+    help: "",
     legend: "",
     name: "",
   }
@@ -26,45 +28,72 @@ const onChange = (e: Event) => {
 }
 </script>
 <template>
-  <fieldset>
-    <InputLabel class="block" :label="legend" tag="legend"></InputLabel>
-    <label
-      class="inline-flex items-center"
-      :class="{ 'cursor-not-allowed': $attrs.disabled }"
-      :for="`${hasNameAttr ? name : uuid}-true`"
-    >
-      <input
-        type="radio"
-        class="w-4 h-4 border-gray-600 focus:ring-blue-500 text-xy-blue"
-        :id="`${hasNameAttr ? name : uuid}-true`"
-        :name="hasNameAttr ? name : uuid"
-        :value="true"
-        :checked="modelValue === true"
-        v-bind="{
-          ...$attrs,
-          onChange: onChange,
-        }"
-      />
-      <InputLabel class="ml-2" label="Yes" tag="span"></InputLabel>
-    </label>
-    <label
-      class="inline-flex items-center ml-6"
-      :class="{ 'cursor-not-allowed': $attrs.disabled }"
-      :for="`${hasNameAttr ? name : uuid}-false`"
-    >
-      <input
-        type="radio"
-        class="w-4 h-4 border-gray-600 focus:ring-blue-500 text-xy-blue"
-        :id="`${hasNameAttr ? name : uuid}-false`"
-        :name="hasNameAttr ? name : uuid"
-        :value="false"
-        :checked="modelValue === false"
-        v-bind="{
-          ...$attrs,
-          onChange: onChange,
-        }"
-      />
-      <InputLabel class="ml-2" label="No" tag="span"></InputLabel>
-    </label>
+  <fieldset
+    class="space-y-3"
+    :aria-labelledby="legend ? `${uuid}-legend` : undefined"
+    :aria-describedby="help ? `${uuid}-help` : undefined"
+  >
+    <div class="space-y-0.5">
+      <InputLabel
+        class="block my-auto"
+        :label="legend"
+        tag="legend"
+      ></InputLabel>
+      <InputHelp tag="p" :text="help" :id="`${uuid}-help`" />
+    </div>
+    <div>
+      <label
+        class="inline-flex items-center"
+        :class="{ 'cursor-not-allowed': $attrs.disabled }"
+        :for="`${hasNameAttr ? name : uuid}-true`"
+      >
+        <input
+          type="radio"
+          class="w-4 h-4 border-gray-600 focus:ring-blue-500 text-xy-blue disabled:opacity-50 disabled:cursor-not-allowed"
+          :id="`${hasNameAttr ? name : uuid}-true`"
+          :name="hasNameAttr ? name : uuid"
+          :value="true"
+          :checked="modelValue === true"
+          v-bind="{
+            ...$attrs,
+            onChange: onChange,
+          }"
+        />
+        <InputLabel
+          class="ml-2"
+          :disabled="
+            $attrs.hasOwnProperty('disabled') && $attrs.disabled !== false
+          "
+          label="Yes"
+          tag="span"
+        ></InputLabel>
+      </label>
+      <label
+        class="inline-flex items-center ml-6"
+        :class="{ 'cursor-not-allowed': $attrs.disabled }"
+        :for="`${hasNameAttr ? name : uuid}-false`"
+      >
+        <input
+          type="radio"
+          class="w-4 h-4 border-gray-600 focus:ring-blue-500 text-xy-blue disabled:opacity-50 disabled:cursor-not-allowed"
+          :id="`${hasNameAttr ? name : uuid}-false`"
+          :name="hasNameAttr ? name : uuid"
+          :value="false"
+          :checked="modelValue === false"
+          v-bind="{
+            ...$attrs,
+            onChange: onChange,
+          }"
+        />
+        <InputLabel
+          class="ml-2"
+          :disabled="
+            $attrs.hasOwnProperty('disabled') && $attrs.disabled !== false
+          "
+          label="No"
+          tag="span"
+        ></InputLabel>
+      </label>
+    </div>
   </fieldset>
 </template>

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -30,6 +30,7 @@ import { default as Checkbox } from "./forms/Checkbox.vue"
 import { default as DateRangePicker } from "./forms/DateRangePicker.vue"
 import { default as InputHelp } from "./forms/InputHelp.vue"
 import { default as InputLabel } from "./forms/InputLabel.vue"
+import { default as Legend } from "./forms/Legend.vue"
 import { default as MultiCheckboxes } from "./forms/MultiCheckboxes.vue"
 import { default as Radio } from "./forms/Radio.vue"
 import { default as Select } from "./forms/Select.vue"
@@ -64,6 +65,7 @@ export {
   DateRangePicker,
   InputHelp,
   InputLabel,
+  Legend,
   MultiCheckboxes,
   Radio,
   Select,
@@ -101,6 +103,7 @@ export interface TreesComponents {
   DateRangePicker: typeof DateRangePicker
   InputHelp: typeof InputHelp
   InputLabel: typeof InputLabel
+  Legend: typeof Legend
   MultiCheckboxes: typeof MultiCheckboxes
   Radio: typeof Radio
   Select: typeof Select

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -30,7 +30,7 @@ import { default as Checkbox } from "./forms/Checkbox.vue"
 import { default as DateRangePicker } from "./forms/DateRangePicker.vue"
 import { default as InputHelp } from "./forms/InputHelp.vue"
 import { default as InputLabel } from "./forms/InputLabel.vue"
-import { default as Legend } from "./forms/Legend.vue"
+import { default as FieldsetLegend } from "./forms/FieldsetLegend.vue"
 import { default as MultiCheckboxes } from "./forms/MultiCheckboxes.vue"
 import { default as Radio } from "./forms/Radio.vue"
 import { default as Select } from "./forms/Select.vue"
@@ -65,7 +65,7 @@ export {
   DateRangePicker,
   InputHelp,
   InputLabel,
-  Legend,
+  FieldsetLegend,
   MultiCheckboxes,
   Radio,
   Select,
@@ -103,7 +103,7 @@ export interface TreesComponents {
   DateRangePicker: typeof DateRangePicker
   InputHelp: typeof InputHelp
   InputLabel: typeof InputLabel
-  Legend: typeof Legend
+  FieldsetLegend: typeof FieldsetLegend
   MultiCheckboxes: typeof MultiCheckboxes
   Radio: typeof Radio
   Select: typeof Select

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -198,7 +198,7 @@ if (props.position === "auto") {
 </script>
 
 <template>
-  <HeadlessPopover v-slot="{ open, close }" class="relative" :as="as">
+  <HeadlessPopover v-slot="{ open, close }" class="relative flex" :as="as">
     <HeadlessPopoverButton ref="trigger">
       <slot name="button" :open="open" :close="close"></slot>
     </HeadlessPopoverButton>


### PR DESCRIPTION
# What this does 

- refactor: tones down help text display to better differentiate it from labels
- fix: regression where popover wrapper was no longer wrapping trigger and content in a flexbox
- fix: two way binding issues on multicheckbox
- fix: radio, checkbox input and label positioning bug on long labels
- feat: adds help/description text support to yes/no, checkbox, multicheckbox, and radio components
- feat: adds basic legend component for style consistency
- feat: adds number type support to radio, checkbox, and multicheckbox
- feat: adds 2, 3, and 4 column multicheckbox radio button support
- feat: minimal disabled input styles for most inputs
- feat: slot based legend on multicheckbox and radio groups
- feat: disable support for multicheckbox and radio individual options


__Fix long label positioning issue where input was center aligned to content vertically__

<img width="789" alt="Screen Shot 2022-03-11 at 11 17 36 AM" src="https://user-images.githubusercontent.com/3856703/157915754-20ee413e-e34e-46cd-9d72-37fe27519807.png">

__Checkbox help text support__

<img width="790" alt="Screen Shot 2022-03-11 at 11 17 46 AM" src="https://user-images.githubusercontent.com/3856703/157915845-db988184-2c32-4489-9237-95937a2d2e06.png">

__Radio help text and column support__

<img width="794" alt="Screen Shot 2022-03-11 at 11 17 55 AM" src="https://user-images.githubusercontent.com/3856703/157915901-c0107edd-bce4-4b52-80ce-2ea02a82c1b0.png">

# TODO

- [x] bump version to 0.4.3