### PR TITLE
feat: use base api

### DIFF
--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -5,24 +5,27 @@ import { computed } from "vue"
 import useBaseAPI from "../../src/composables/useBaseAPI"
 import { debounceLeading } from "../../src/helpers/Debounce"
 
-interface Thing {
-  id: number 
-  created_at: number
-  type: string
-  title: string
-}
-
-interface ThingResponse {
+interface Paginated<T> {
   page: number
   perPage: number
   totalItems: number
   totalPages: number
-  items: Thing[]
+  items: T[]
+}
+
+interface Conifer {
+  id: number 
+  name: number
+  type: string
+  leaf: {
+    type: string
+    length: string
+  }
 }
 
 const { result, error, isLoading, isFinished, isAborted, hasFetched, execute, abort } =
-  useBaseAPI<ThingResponse>(
-    "https://my-json-server.typicode.com/xy-planning-network/trees/things",
+  useBaseAPI<Paginated<Conifer>>(
+    "https://my-json-server.typicode.com/xy-planning-network/trees/conifers",
     "GET",
     { dataIntercept: true, withCredentials: false}
   )
@@ -47,7 +50,7 @@ const fetch = (opt: RequestOptions = {}, shouldAbort = false,) => {
 
 const fetchDebounce = debounceLeading(() => {
   abort()
-  fetch({ withDelay: 0, skipLoader: true, url: "https://deelay.me/1000/https://my-json-server.typicode.com/xy-planning-network/trees/things" }, false)
+  fetch({ withDelay: 0, skipLoader: true, url: "https://deelay.me/1000/https://my-json-server.typicode.com/xy-planning-network/trees/conifers" }, false)
 }, 100)
 
 
@@ -69,7 +72,7 @@ const buttonTextWithAbort = computed(() => {
   return "Fetch & Abort"
 })
 
-const things = computed(() => { 
+const conifers = computed(() => { 
   return result.value?.items
 })
 </script>
@@ -86,19 +89,22 @@ const things = computed(() => {
         
           <pre class="overflow-scroll bg-gray-50 p-4">
             <code class="language-typescript">{{`
-interface Thing {
-  id: number 
-  created_at: number
-  type: string
-  title: string
-}
-
-interface ThingResponse {
+interface Paginated<T> {
   page: number
   perPage: number
   totalItems: number
   totalPages: number
-  items: Thing[]
+  items: T[]
+}
+
+interface Conifer {
+  id: number 
+  name: number
+  type: string
+  leaf: {
+    type: string
+    length: string
+  }
 }
 
 const {
@@ -110,13 +116,13 @@ const {
   hasFetched,
   execute,
   abort
-} = useBaseAPI<ThingResponse>("https://my-json-server.typicode.com/xy-planning-network/trees/things", "GET", {dataIntercept: true})
+} = useBaseAPI<Paginated<Conifer>>("https://my-json-server.typicode.com/xy-planning-network/trees/things", "GET", {dataIntercept: true})
 
 execute({ query: Date.now() }, { withDelay: 3000 })
   .then(data => {
     // you could do something with this data variable
-    // which has a Type of ThingResponse, but the result
-    // variable will already be a Ref<ThingResponse>
+    // which has a Type of Paginated<Conifer>, but the result
+    // variable will already be a Ref<Paginated<Conifer>>
     console.log(data, result)
   }).catch((err: Error | AxiosError) => {
     // you could do something with this err variable
@@ -175,12 +181,12 @@ const things = computed(() => {
           <li><b>Result:</b><pre class="bg-gray-50 p-2">{{result ? result : 'undefined'}}</pre></li>
         </ul>
 
-        <ul v-if="things" class="mt-6 space-y-2">
-          <li v-for="thing in things" :key="thing.id">
-            <b>{{thing.title}}</b> : <em>{{thing.type}}</em>
+        <ul v-if="conifers" class="mt-6 space-y-2">
+          <li v-for="conifer in conifers" :key="conifer.id">
+            <b>{{conifer.name}}</b>: <em>{{conifer.leaf.type}}</em>
           </li>
         </ul>
-        <p v-else>No(thing)s</p>
+        <p v-else>No trees on these trails.</p>
       </ComponentLayout>
     </div>
   </div>

--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RequestOptions } from "@/api/base"
-import { AxiosError, AxiosRequestConfig } from "axios";
+import { AxiosError } from "axios";
 import { computed } from "vue"
 import useBaseAPI from "../../src/composables/useBaseAPI"
 import { debounceLeading } from "../../src/helpers/Debounce"
@@ -23,11 +23,12 @@ interface ThingResponse {
 const { result, error, isLoading, isFinished, isAborted, hasFetched, execute, abort } =
   useBaseAPI<ThingResponse>(
     "https://my-json-server.typicode.com/xy-planning-network/trees/things",
-    "GET"
+    "GET",
+    { dataIntercept: true, withCredentials: false}
   )
 
-const fetch = (opt: RequestOptions = {}, shouldAbort = false, config: AxiosRequestConfig = {}) => {
-  execute({ query: Date.now() }, {dataIntercept: true, ...opt}, {withCredentials: false, ...config})
+const fetch = (opt: RequestOptions = {}, shouldAbort = false,) => {
+  execute({ query: Date.now() }, opt)
   .then(data => {
     // you could do something with this data variable
     // which has a Type of ThingResponse, but the result
@@ -46,7 +47,7 @@ const fetch = (opt: RequestOptions = {}, shouldAbort = false, config: AxiosReque
 
 const fetchDebounce = debounceLeading(() => {
   abort()
-  fetch({ withDelay: 0, skipLoader: true }, false, {url: "https://deelay.me/1000/https://my-json-server.typicode.com/xy-planning-network/trees/things"})
+  fetch({ withDelay: 0, skipLoader: true, url: "https://deelay.me/1000/https://my-json-server.typicode.com/xy-planning-network/trees/things" }, false)
 }, 100)
 
 
@@ -142,7 +143,7 @@ const things = computed(() => {
 
             <button
               class="xy-btn"
-              @click="fetch({ withDelay: 1250 })"
+              @click="fetch({ withDelay: 1500 })"
               :disabled="isLoading"
             >
               {{ buttonTextWithDelay }}

--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -6,15 +6,19 @@ import useBaseAPI from "../../src/composables/useBaseAPI"
 import { debounceLeading } from "../../src/helpers/Debounce"
 
 interface Thing {
-    id: number 
-    created_at: number
-    type: string
-    title: string
-  }
+  id: number 
+  created_at: number
+  type: string
+  title: string
+}
 
-  interface ThingResponse {
-    data: Thing[]
-  }
+interface ThingResponse {
+  page: number
+  perPage: number
+  totalItems: number
+  totalPages: number
+  items: Thing[]
+}
 
 const { result, error, isLoading, isFinished, isAborted, hasFetched, execute, abort } =
   useBaseAPI<ThingResponse>(
@@ -23,7 +27,7 @@ const { result, error, isLoading, isFinished, isAborted, hasFetched, execute, ab
   )
 
 const fetch = (opt: RequestOptions = {}, shouldAbort = false, config: AxiosRequestConfig = {}) => {
-  execute({ query: Date.now() }, opt, {...{withCredentials: false}, ...config})
+  execute({ query: Date.now() }, {dataIntercept: true, ...opt}, {withCredentials: false, ...config})
   .then(data => {
     // you could do something with this data variable
     // which has a Type of ThingResponse, but the result
@@ -63,6 +67,10 @@ const buttonTextWithAbort = computed(() => {
   if (hasFetched.value) return "Fetch Again & Abort"
   return "Fetch & Abort"
 })
+
+const things = computed(() => { 
+  return result.value?.items
+})
 </script>
 
 <template>
@@ -85,7 +93,11 @@ interface Thing {
 }
 
 interface ThingResponse {
-  data: Thing[]
+  page: number
+  perPage: number
+  totalItems: number
+  totalPages: number
+  items: Thing[]
 }
 
 const {
@@ -97,7 +109,7 @@ const {
   hasFetched,
   execute,
   abort
-} = useBaseAPI<ThingResponse>("https://my-json-server.typicode.com/xy-planning-network/trees/things", "GET")
+} = useBaseAPI<ThingResponse>("https://my-json-server.typicode.com/xy-planning-network/trees/things", "GET", {dataIntercept: true})
 
 execute({ query: Date.now() }, { withDelay: 3000 })
   .then(data => {
@@ -110,6 +122,11 @@ execute({ query: Date.now() }, { withDelay: 3000 })
     // but the error variable will already be a ShallowRef<Error | AxiosError<T>>
     console.log(err, error)
   })
+
+// this computed function is ready with whatever result contains
+const things = computed(() => { 
+  return result.value?.items
+})
   `}}</code>
         </pre>
         
@@ -156,6 +173,13 @@ execute({ query: Date.now() }, { withDelay: 3000 })
           <li><b>Error:</b><pre>{{error ? error : 'undefined'}}</pre></li>
           <li><b>Result:</b><pre class="bg-gray-50 p-2">{{result ? result : 'undefined'}}</pre></li>
         </ul>
+
+        <ul v-if="things" class="mt-6 space-y-2">
+          <li v-for="thing in things" :key="thing.id">
+            <b>{{thing.title}}</b> : <em>{{thing.type}}</em>
+          </li>
+        </ul>
+        <p v-else>No(thing)s</p>
       </ComponentLayout>
     </div>
   </div>

--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -36,7 +36,7 @@ const fetch = (opt: RequestOptions = {}, shouldAbort = false, config: AxiosReque
   })
 
   if (shouldAbort) {
-    setTimeout(abort, 500)
+    setTimeout(abort, 100)
   }
 }
 
@@ -48,19 +48,19 @@ const fetchDebounce = debounceLeading(() => {
 
 const buttonText = computed(() => {
   if (isLoading.value) return "Loading"
-  if (isFinished.value) return "Fetch Again"
+  if (hasFetched.value) return "Fetch Again"
   return "Fetch"
 })
 
 const buttonTextWithDelay = computed(() => {
   if (isLoading.value) return "Loading"
-  if (isFinished.value) return "Fetch Again w/Delay"
+  if (hasFetched.value) return "Fetch Again w/Delay"
   return "Fetch w/Delay"
 })
 
 const buttonTextWithAbort = computed(() => {
   if (isLoading.value) return "Loading"
-  if (isFinished.value) return "Fetch Again & Abort"
+  if (hasFetched.value) return "Fetch Again & Abort"
   return "Fetch & Abort"
 })
 </script>
@@ -125,7 +125,7 @@ execute({ query: Date.now() }, { withDelay: 3000 })
 
             <button
               class="xy-btn"
-              @click="fetch({ withDelay: 1000 })"
+              @click="fetch({ withDelay: 1250 })"
               :disabled="isLoading"
             >
               {{ buttonTextWithDelay }}

--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -16,7 +16,7 @@ interface Thing {
     data: Thing[]
   }
 
-const { result, error, isLoading, isFinished, isAborted, execute, abort } =
+const { result, error, isLoading, isFinished, isAborted, hasFetched, execute, abort } =
   useBaseAPI<ThingResponse>(
     "https://my-json-server.typicode.com/xy-planning-network/trees/things",
     "GET"
@@ -74,44 +74,44 @@ const buttonTextWithAbort = computed(() => {
           helpful reactive variables along with an execute and abort methods.
         </template>
 
-        <code class="">
-          <pre class="overflow-scroll bg-gray-100">{{
-            `
-  interface Thing {
-    id: number 
-    created_at: number
-    type: string
-    title: string
-  }
+        
+          <pre class="overflow-scroll bg-gray-50 p-4">
+            <code class="language-typescript">{{`
+interface Thing {
+  id: number 
+  created_at: number
+  type: string
+  title: string
+}
 
-  interface ThingResponse {
-    data: Thing[]
-  }
+interface ThingResponse {
+  data: Thing[]
+}
 
-  const {
-    result,
-    error,
-    isLoading,
-    isFinished,
-    isAborted,
-    execute,
-    abort
-  } = useBaseAPI<ThingResponse>("https://my-json-server.typicode.com/xy-planning-network/trees/things", "GET")
+const {
+  result,
+  error,
+  isLoading,
+  isFinished,
+  isAborted,
+  hasFetched,
+  execute,
+  abort
+} = useBaseAPI<ThingResponse>("https://my-json-server.typicode.com/xy-planning-network/trees/things", "GET")
 
-  execute({ query: Date.now() }, { withDelay: 3000 })
-    .then(data => {
-      // you could do something with this data variable
-      // which has a Type of ThingResponse, but the result
-      // variable will already be a Ref<ThingResponse>
-      console.log(data, result)
-    }).catch((err: Error | AxiosError) => {
-      // you could do something with this err variable
-      // but the error variable will already be a ShallowRef<Error | AxiosError<T>>
-      console.log(err, error)
-    })
-  `
-          }}</pre>
-        </code>
+execute({ query: Date.now() }, { withDelay: 3000 })
+  .then(data => {
+    // you could do something with this data variable
+    // which has a Type of ThingResponse, but the result
+    // variable will already be a Ref<ThingResponse>
+    console.log(data, result)
+  }).catch((err: Error | AxiosError) => {
+    // you could do something with this err variable
+    // but the error variable will already be a ShallowRef<Error | AxiosError<T>>
+    console.log(err, error)
+  })
+  `}}</code>
+        </pre>
         
         <div class="space-y-4">
           <div class="flex space-x-4">
@@ -149,11 +149,12 @@ const buttonTextWithAbort = computed(() => {
         </div>
 
         <ul class="space-y-2">
+          <li><b>Fetched:</b> {{hasFetched}} (has run once)</li>
           <li><b>Loading:</b> {{isLoading}} (run's always)</li>
-          <li><b>Finished:</b> {{isFinished}} (run's once)</li>
+          <li><b>Finished:</b> {{isFinished}} (run's always)</li>
           <li><b>Aborted:</b> {{isAborted}} (when aborted, reset on new fetch)</li>
           <li><b>Error:</b><pre>{{error ? error : 'undefined'}}</pre></li>
-          <li><b>Result:</b><pre>{{result ? result : 'undefined'}}</pre></li>
+          <li><b>Result:</b><pre class="bg-gray-50 p-2">{{result ? result : 'undefined'}}</pre></li>
         </ul>
       </ComponentLayout>
     </div>

--- a/dev/content/Home.vue
+++ b/dev/content/Home.vue
@@ -4,6 +4,7 @@ import {
   ColorSwatchIcon,
   DocumentTextIcon,
   LocationMarkerIcon,
+  PencilAltIcon,
   TableIcon,
   UserGroupIcon,
 } from "@heroicons/vue/outline"
@@ -50,6 +51,11 @@ const features = [
     icon: UserGroupIcon,
     description:
       "Our team once built something that helped the company, and we've been grateful ever since.",
+  },
+  {
+    name: "Composables",
+    icon: PencilAltIcon,
+    description: "Functions that manage reactivity behind the scenes.",
   },
 ]
 </script>

--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -6,9 +6,11 @@ import {
   DocumentTextIcon,
   HomeIcon,
   LocationMarkerIcon,
+  PencilAltIcon,
   TableIcon,
   UserGroupIcon,
 } from "@heroicons/vue/outline"
+import Composables from "./content/Composables.vue"
 import Elements from "./content/Elements.vue"
 import Forms from "./content/Forms.vue"
 import Home from "./content/Home.vue"
@@ -31,6 +33,7 @@ const navigation = [
   { name: "Overlays", url: "/trees/?page=Overlays", icon: CollectionIcon },
   { name: "Elements", url: "/trees/?page=Elements", icon: ColorSwatchIcon },
   { name: "Team", url: "/trees/?page=Team", icon: UserGroupIcon },
+  { name: "Composables", url: "/trees/?page=Composables", icon: PencilAltIcon },
 ]
 const user = ref({
   accountID: 1,
@@ -81,6 +84,7 @@ onMounted(() => {
       <Overlays v-if="showing('Overlays')" />
       <Elements v-if="showing('Elements')" />
       <Team v-if="showing('Team')" />
+      <Composables v-if="showing('Composables')" />
       <button
         type="button"
         class="xy-btn"

--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
   <meta charset="UTF-8" />
   <link rel="icon" href="/dev/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="https://unpkg.com/prismjs@1.28.0/themes/prism.css" rel="stylesheet" crossorigin="anonymous" />
+
+  <script src="https://unpkg.com/prismjs@1.28.0/components/prism-core.min.js" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/prismjs@1.28.0/plugins/autoloader/prism-autoloader.min.js"
+    crossorigin="anonymous"></script>
   <title>Trees Docs</title>
 </head>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@headlessui/vue": "^1.4.2",
         "@heroicons/vue": "^1.0.5",
-        "axios": "^0.21.4",
+        "axios": "^0.27.2",
         "flatpickr": "^4.6.9"
       },
       "devDependencies": {
@@ -1000,6 +1000,11 @@
       "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.0.tgz",
@@ -1027,11 +1032,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/babel-walk": {
@@ -1247,6 +1253,17 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -1409,6 +1426,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/detect-file": {
       "version": "1.0.0",
@@ -2459,9 +2484,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
       "funding": [
         {
           "type": "individual",
@@ -2475,6 +2500,19 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -3357,6 +3395,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mini-svg-data-uri": {
@@ -5919,6 +5976,11 @@
       "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "autoprefixer": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.0.tgz",
@@ -5933,11 +5995,12 @@
       }
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "babel-walk": {
@@ -6103,6 +6166,14 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -6229,6 +6300,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-file": {
       "version": "1.0.0",
@@ -6999,9 +7075,19 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fraction.js": {
       "version": "4.1.2",
@@ -7659,6 +7745,19 @@
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "mini-svg-data-uri": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@headlessui/vue": "^1.4.2",
     "@heroicons/vue": "^1.0.5",
-    "axios": "^0.21.4",
+    "axios": "^0.27.2",
     "flatpickr": "^4.6.9"
   },
   "peerDependencies": {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -25,34 +25,35 @@ export interface RequestOptions extends AxiosRequestConfig {
   withDelay?: number
 }
 
-interface APIResponse extends AxiosResponse {
+interface APIResponse<T = any> extends AxiosResponse<T> {
   config: RequestOptions
 }
 
 /**
  * apiDelayIntercept delays the request of an api call by the configured withDelay value in RequestOptions
  * @param config RequestOptions
- * @returns Promise
+ * @returns RequestOptions
  */
 const apiDelayReqIntercept = (config: RequestOptions) => {
+  const delay = config.withDelay || 0
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(config)
-    }, config.withDelay || 0)
+    }, Math.max(delay, 0))
   })
 }
 
 /**
- * apiDataIntercept removes any secondary data properties from an Axios response.
- * example: an AxiosResponse has it's own data key and the server response also nests
- * it's primary response data under another data key.
+ * apiDataIntercept promotes any secondary data keys from an Axios response to the first level data key.
+ * example: an AxiosResponse has it's own data key and the server response also nests it's primary response
+ * payload under another data key, that payload data is promoted to being directly under the AxiosResponse data key.
  * This axios intercept should always be last in the chain of intercepts.
- * @param response AxiosResponse
- * @returns any
+ * @param response APIResponse
+ * @returns APIResponse
  */
 const apiDataRespIntercept = (response: APIResponse) => {
   if (response.config.dataIntercept && response.data?.data) {
-    return response.data
+    response.data = response.data.data
   }
 
   return response

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -10,10 +10,6 @@ export type RequestMethod =
   | "DELETE"
   | "delete"
 
-export interface TreesResponse<T> extends AxiosResponse<T> {
-  data: T
-}
-
 export interface RequestOptions {
   dataIntercept?: boolean
   skipLoader?: boolean

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -47,7 +47,6 @@ const apiDelayReqIntercept = (config: RequestOptions) => {
  * apiDataIntercept promotes any secondary data keys from an Axios response to the first level data key.
  * example: an AxiosResponse has it's own data key and the server response also nests it's primary response
  * payload under another data key, that payload data is promoted to being directly under the AxiosResponse data key.
- * This axios intercept should always be last in the chain of intercepts.
  * @param response APIResponse
  * @returns APIResponse
  */
@@ -72,7 +71,6 @@ const apiAxiosInstance = axios.create({
 apiAxiosInstance.interceptors.request.use(apiDelayReqIntercept)
 
 // apply response intercepts
-// the data intercept should be last in the chain as it heavily mutates the APIResponse
 apiAxiosInstance.interceptors.response.use(apiDataRespIntercept)
 
 const BaseAPI = {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,6 +1,14 @@
 import axios, { AxiosResponse, AxiosRequestConfig } from "axios"
 
-export type RequestMethod = "GET" | "PUT" | "POST" | "DELETE"
+export type RequestMethod =
+  | "GET"
+  | "get"
+  | "PUT"
+  | "put"
+  | "POST"
+  | "post"
+  | "DELETE"
+  | "delete"
 
 export interface RequestOptions {
   skipLoader?: boolean

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -10,7 +10,12 @@ export type RequestMethod =
   | "DELETE"
   | "delete"
 
+export interface TreesResponse<T> extends AxiosResponse<T> {
+  data: T
+}
+
 export interface RequestOptions {
+  dataIntercept?: boolean
   skipLoader?: boolean
   withDelay?: number
 }
@@ -21,34 +26,75 @@ const apiAxiosInstance = axios.create({
   withCredentials: true,
 })
 
+/**
+ * apiDataIntercept removes any secondary data properties from an Axios response.
+ * example: an AxiosResponse has it's own data key and the server response also nests
+ * it's primary response data under another data key.
+ * @param response AxiosResponse
+ * @returns any
+ */
+const apiDataIntercept = (response: AxiosResponse) => {
+  if (response.data?.data) {
+    return response.data
+  }
+
+  return response
+}
+
+/**
+ * apiDelay is a thin wrapper for causing some function to run on a delay
+ * @param func (...args: any[]) => void
+ * @param delay number
+ */
+const apiDelay = (func: (...args: any[]) => void, delay = 0) => {
+  setTimeout(func, delay)
+}
+
 const BaseAPI = {
-  makeRequest<T = any>(config: AxiosRequestConfig, opts: RequestOptions) {
+  makeRequest<T = any>(
+    config: AxiosRequestConfig,
+    opts: RequestOptions
+  ): Promise<T> {
     config.data = JSON.stringify(config.data)
     config.headers = { "Content-Type": "application/json" }
 
+    let dataIntercept: number | null
+
+    if (opts.dataIntercept) {
+      dataIntercept =
+        apiAxiosInstance.interceptors.response.use(apiDataIntercept)
+    }
+
     const wait = window.setTimeout(() => {
-      if (!opts.skipLoader) window.VueBus.emit("Spinner-show")
+      if (!opts.skipLoader) {
+        window.VueBus.emit("Spinner-show")
+      }
     }, 200)
 
     return new Promise<T>((resolve, reject) => {
-      setTimeout(
-        () => {
-          apiAxiosInstance(config)
-            .then(
-              (success: AxiosResponse<T>) => {
-                resolve(success.data)
-              },
-              (err) => {
-                reject(err)
-              }
-            )
-            .finally(() => {
-              window.clearTimeout(wait)
-              if (!opts.skipLoader) window.VueBus.emit("Spinner-hide")
-            })
-        },
-        opts?.withDelay ? opts.withDelay : 0
-      )
+      apiAxiosInstance(config)
+        .then(
+          (success) => {
+            apiDelay(() => {
+              resolve(success.data)
+            }, opts.withDelay || 0)
+          },
+          (err) => {
+            apiDelay(() => {
+              reject(err)
+            }, opts.withDelay || 0)
+          }
+        )
+        .finally(() => {
+          if (dataIntercept !== null) {
+            apiAxiosInstance.interceptors.response.eject(dataIntercept)
+          }
+
+          apiDelay(() => {
+            window.clearTimeout(wait)
+            if (!opts.skipLoader) window.VueBus.emit("Spinner-hide")
+          }, opts.withDelay || 0)
+        })
     })
   },
   get<T = any>(

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,0 +1,20 @@
+// Exposed Composables
+import {
+  default as useBaseAPI,
+  useBaseAPIGet,
+  useBaseAPIPut,
+  useBaseAPIPost,
+  useBaseAPIDelete,
+} from "./useBaseAPI"
+
+import type { UseBaseAPIOptions, UseBaseAPI } from "./useBaseAPI"
+
+export type { UseBaseAPIOptions, UseBaseAPI }
+
+export {
+  useBaseAPI,
+  useBaseAPIGet,
+  useBaseAPIPut,
+  useBaseAPIPost,
+  useBaseAPIDelete,
+}

--- a/src/composables/useBaseAPI.ts
+++ b/src/composables/useBaseAPI.ts
@@ -14,8 +14,6 @@ export interface UseBaseAPI<T> {
   error: ShallowRef<Error | AxiosError<T> | undefined>
   /**
    * Indicates if the request has finished
-   * It is marked true after the first request and remains unchanged
-   * In subsequent requests
    */
   isFinished: Ref<boolean>
   /**
@@ -26,6 +24,10 @@ export interface UseBaseAPI<T> {
    * Indicates if the request was canceled
    */
   isAborted: Ref<boolean>
+  /**
+   * Indicates if a first request has completed
+   */
+  hasFetched: Ref<boolean>
   /**
    * Aborts the current request
    */
@@ -46,6 +48,7 @@ export default function useBaseAPI<T = any>(
 ) {
   const result = ref<T | undefined>()
   const error = shallowRef<Error | AxiosError<T> | undefined>()
+  const hasFetched = ref<boolean>(false)
   const isFinished = ref<boolean>(false)
   const isLoading = ref<boolean>(false)
   const isAborted = ref<boolean>(false)
@@ -69,6 +72,7 @@ export default function useBaseAPI<T = any>(
     controller = new AbortController()
 
     isAborted.value = false
+    isFinished.value = false
     isLoading.value = true
 
     const requestConfig: AxiosRequestConfig = {
@@ -105,9 +109,10 @@ export default function useBaseAPI<T = any>(
       )
       .finally(() => {
         if (count == requestCount) {
+          isFinished.value = true
           isLoading.value = false
         }
-        isFinished.value = true
+        hasFetched.value = true
       })
   }
 
@@ -117,6 +122,7 @@ export default function useBaseAPI<T = any>(
     isFinished,
     isLoading,
     isAborted,
+    hasFetched,
     abort,
     execute,
   }

--- a/src/composables/useBaseAPI.ts
+++ b/src/composables/useBaseAPI.ts
@@ -3,6 +3,23 @@ import { ref, Ref, shallowRef, ShallowRef } from "vue"
 import BaseAPI from "../api/base"
 import type { RequestMethod, RequestOptions } from "../api/base"
 
+/**
+ * UseBaseAPIOptions extends Trees/RequestOptions
+ * these options are used only in the instantiation
+ * of a new UseBaseAPI composable
+ */
+export interface UseBaseAPIOptions extends RequestOptions {
+  /**
+   * Whether to immediately fire the execute function during instantiation
+   */
+  immediate?: boolean
+}
+
+/**
+ * UseBaseAPI is a composable the wraps up the
+ * usage of Trees/BaseAPI and returns reactive
+ * state variables along with reusaable execute and abort functions
+ */
 export interface UseBaseAPI<T> {
   /**
    * Axios response data
@@ -30,10 +47,12 @@ export interface UseBaseAPI<T> {
   hasFetched: Ref<boolean>
   /**
    * Aborts the current request
+   * can be used multiple times
    */
   abort: () => void
   /**
    * Manually call the axios request
+   * can be used multiple times
    */
   execute: (
     data?: Record<string, unknown>,
@@ -42,9 +61,19 @@ export interface UseBaseAPI<T> {
   ) => Promise<T>
 }
 
+/**
+ * useBaseAPI is a composable wrapper of BaseAPI
+ * @param path {string} the api path or full url for the
+ * @param method {RequestMethod} the initial request type
+ * @param initOpts {UseBaseAPIOptions}
+ * @param initConfig {AxiosRequestConfig}
+ * @returns {UseBaseAPI<T>}
+ */
 export default function useBaseAPI<T = any>(
   path: string,
-  method: RequestMethod = "GET"
+  method: RequestMethod = "GET",
+  initOpts: UseBaseAPIOptions = {},
+  initConfig: AxiosRequestConfig = {}
 ) {
   const result = ref<T | undefined>()
   const error = shallowRef<Error | AxiosError<T> | undefined>()
@@ -63,8 +92,8 @@ export default function useBaseAPI<T = any>(
 
   const execute = (
     data: Record<string, unknown> = {},
-    opts: RequestOptions = {},
-    config: AxiosRequestConfig = {}
+    execOpts: RequestOptions = {},
+    execConfig: AxiosRequestConfig = {}
   ): Promise<T> => {
     requestCount++
     const count = requestCount
@@ -76,20 +105,16 @@ export default function useBaseAPI<T = any>(
     isLoading.value = true
 
     const requestConfig: AxiosRequestConfig = {
-      url: path,
+      ...initConfig,
+      data: !["GET", "get"].includes(method) ? data : {},
       method: method,
+      params: ["GET", "get"].includes(method) ? data : {},
       signal: controller.signal,
+      url: path,
+      ...execConfig,
     }
 
-    if (method === "GET") {
-      requestConfig.params = data
-    }
-
-    if (["DELETE", "POST", "PUT"].includes(method)) {
-      requestConfig.data = data
-    }
-
-    return BaseAPI.makeRequest<T>({ ...requestConfig, ...config }, opts)
+    return BaseAPI.makeRequest<T>(requestConfig, { ...initOpts, ...execOpts })
       .then(
         (success) => {
           result.value = success
@@ -108,12 +133,20 @@ export default function useBaseAPI<T = any>(
         }
       )
       .finally(() => {
+        // aborted or previous requests may be resolving
+        //during an active request avoid mutating state when
+        //the request count has incremented
         if (count == requestCount) {
           isFinished.value = true
           isLoading.value = false
         }
         hasFetched.value = true
       })
+  }
+
+  // allow immedate execution to set data variable during script setup
+  if (initOpts?.immediate && initOpts.immediate === true) {
+    execute()
   }
 
   return {
@@ -128,19 +161,62 @@ export default function useBaseAPI<T = any>(
   }
 }
 
-// convenience functions
-export function useBaseAPIGet<T = any>(url: string): UseBaseAPI<T> {
-  return useBaseAPI<T>(url, "GET")
+/**
+ * useBaseAPIGet is a convenience function for useBaseAPI
+ * @param path {string} the api path or full url for the
+ * @param initOpts {UseBaseAPIOptions}
+ * @param initConfig {AxiosRequestConfig}
+ * @returns {UseBaseAPI<T>}
+ */
+export function useBaseAPIGet<T = any>(
+  url: string,
+  initOpts: UseBaseAPIOptions = {},
+  initConfig: AxiosRequestConfig = {}
+): UseBaseAPI<T> {
+  return useBaseAPI<T>(url, "GET", initOpts, initConfig)
 }
 
-export function useBaseAPIDelete<T = any>(url: string): UseBaseAPI<T> {
-  return useBaseAPI<T>(url, "DELETE")
+/**
+ * useBaseAPIDelete is a convenience function for useBaseAPI
+ * @param path {string} the api path or full url for the
+ * @param initOpts {UseBaseAPIOptions}
+ * @param initConfig {AxiosRequestConfig}
+ * @returns {UseBaseAPI<T>}
+ */
+export function useBaseAPIDelete<T = any>(
+  url: string,
+  initOpts: UseBaseAPIOptions = {},
+  initConfig: AxiosRequestConfig = {}
+): UseBaseAPI<T> {
+  return useBaseAPI<T>(url, "DELETE", initOpts, initConfig)
 }
 
-export function useBaseAPIPost<T = any>(url: string): UseBaseAPI<T> {
-  return useBaseAPI<T>(url, "POST")
+/**
+ * useBaseAPIPost is a convenience function for useBaseAPI
+ * @param path {string} the api path or full url for the
+ * @param initOpts {UseBaseAPIOptions}
+ * @param initConfig {AxiosRequestConfig}
+ * @returns {UseBaseAPI<T>}
+ */
+export function useBaseAPIPost<T = any>(
+  url: string,
+  initOpts: UseBaseAPIOptions = {},
+  initConfig: AxiosRequestConfig = {}
+): UseBaseAPI<T> {
+  return useBaseAPI<T>(url, "POST", initOpts, initConfig)
 }
 
-export function useBaseAPIPut<T = any>(url: string): UseBaseAPI<T> {
-  return useBaseAPI<T>(url, "PUT")
+/**
+ * useBaseAPIPut is a convenience function for useBaseAPI
+ * @param path {string} the api path or full url for the
+ * @param initOpts {UseBaseAPIOptions}
+ * @param initConfig {AxiosRequestConfig}
+ * @returns {UseBaseAPI<T>}
+ */
+export function useBaseAPIPut<T = any>(
+  url: string,
+  initOpts: UseBaseAPIOptions = {},
+  initConfig: AxiosRequestConfig = {}
+): UseBaseAPI<T> {
+  return useBaseAPI<T>(url, "PUT", initOpts, initConfig)
 }

--- a/src/composables/useBaseAPI.ts
+++ b/src/composables/useBaseAPI.ts
@@ -1,0 +1,124 @@
+import { AxiosError, AxiosRequestConfig } from "axios"
+import { ref, Ref, shallowRef, ShallowRef } from "vue"
+import BaseAPI from "../api/base"
+import type { RequestMethod, RequestOptions } from "../api/base"
+
+export interface UseBaseAPI<T> {
+  /**
+   * Axios response data
+   */
+  result: Ref<T | undefined>
+  /**
+   * Any errors that may have occurred
+   */
+  error: ShallowRef<Error | AxiosError<T> | undefined>
+  /**
+   * Indicates if the request has finished
+   * It is marked true after the first request and remains unchanged
+   * In subsequent requests
+   */
+  isFinished: Ref<boolean>
+  /**
+   * Indicates if the request is currently loading
+   */
+  isLoading: Ref<boolean>
+  /**
+   * Indicates if the request was canceled
+   */
+  isAborted: Ref<boolean>
+  /**
+   * Aborts the current request
+   */
+  abort: () => void
+  /**
+   * Manually call the axios request
+   */
+  execute: (
+    data?: Record<string, unknown>,
+    opts?: RequestOptions,
+    config?: AxiosRequestConfig
+  ) => Promise<T>
+}
+
+export default function useBaseAPI<T = any>(
+  path: string,
+  method: RequestMethod = "GET"
+) {
+  const result = ref<T | undefined>()
+  const error = shallowRef<Error | AxiosError<T> | undefined>()
+  const isFinished = ref<boolean>(false)
+  const isLoading = ref<boolean>(false)
+  const isAborted = ref<boolean>(false)
+
+  const controller = new AbortController()
+  const abort = () => {
+    controller.abort()
+    isAborted.value = true
+  }
+
+  const execute = (
+    data: Record<string, unknown> = {},
+    opts: RequestOptions = {},
+    config: AxiosRequestConfig = {}
+  ): Promise<T> => {
+    isAborted.value = false
+    isLoading.value = true
+
+    const requestConfig: AxiosRequestConfig = {
+      url: path,
+      method: method,
+      signal: controller.signal,
+    }
+
+    if (method === "GET") {
+      requestConfig.params = data
+    }
+
+    if (["DELETE", "POST", "PUT"].includes(method)) {
+      requestConfig.data = data
+    }
+
+    return BaseAPI.makeRequest<T>({ ...requestConfig, ...config }, opts)
+      .then(
+        (success) => {
+          result.value = success
+          return success
+        },
+        (err) => {
+          error.value = err
+          throw err
+        }
+      )
+      .finally(() => {
+        isLoading.value = false
+        isFinished.value = true
+      })
+  }
+
+  return {
+    result,
+    error,
+    isFinished,
+    isLoading,
+    isAborted,
+    abort,
+    execute,
+  }
+}
+
+// convenience functions
+export function useBaseAPIGet<T = any>(url: string): UseBaseAPI<T> {
+  return useBaseAPI<T>(url, "GET")
+}
+
+export function useBaseAPIDelete<T = any>(url: string): UseBaseAPI<T> {
+  return useBaseAPI<T>(url, "DELETE")
+}
+
+export function useBaseAPIPost<T = any>(url: string): UseBaseAPI<T> {
+  return useBaseAPI<T>(url, "POST")
+}
+
+export function useBaseAPIPut<T = any>(url: string): UseBaseAPI<T> {
+  return useBaseAPI<T>(url, "PUT")
+}

--- a/src/composables/useBaseAPI.ts
+++ b/src/composables/useBaseAPI.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosRequestConfig } from "axios"
+import axios, { AxiosError } from "axios"
 import { ref, Ref, shallowRef, ShallowRef } from "vue"
 import BaseAPI from "../api/base"
 import type { RequestMethod, RequestOptions } from "../api/base"
@@ -54,11 +54,7 @@ export interface UseBaseAPI<T> {
    * Manually call the axios request
    * can be used multiple times
    */
-  execute: (
-    data?: Record<string, unknown>,
-    opts?: RequestOptions,
-    config?: AxiosRequestConfig
-  ) => Promise<T>
+  execute: (data?: Record<string, unknown>, opts?: RequestOptions) => Promise<T>
 }
 
 /**
@@ -72,8 +68,7 @@ export interface UseBaseAPI<T> {
 export default function useBaseAPI<T = any>(
   path: string,
   method: RequestMethod = "GET",
-  initOpts: UseBaseAPIOptions = {},
-  initConfig: AxiosRequestConfig = {}
+  initOpts: UseBaseAPIOptions = {}
 ) {
   const result = ref<T | undefined>()
   const error = shallowRef<Error | AxiosError<T> | undefined>()
@@ -92,8 +87,7 @@ export default function useBaseAPI<T = any>(
 
   const execute = (
     data: Record<string, unknown> = {},
-    execOpts: RequestOptions = {},
-    execConfig: AxiosRequestConfig = {}
+    opts: RequestOptions = {}
   ): Promise<T> => {
     requestCount++
     const count = requestCount
@@ -104,17 +98,17 @@ export default function useBaseAPI<T = any>(
     isFinished.value = false
     isLoading.value = true
 
-    const requestConfig: AxiosRequestConfig = {
-      ...initConfig,
-      data: !["GET", "get"].includes(method) ? data : {},
+    const requestOpts = {
+      ...initOpts,
+      data: ["POST", "post", "PUT", "put"].includes(method) ? data : {},
       method: method,
       params: ["GET", "get"].includes(method) ? data : {},
       signal: controller.signal,
       url: path,
-      ...execConfig,
+      ...opts,
     }
 
-    return BaseAPI.makeRequest<T>(requestConfig, { ...initOpts, ...execOpts })
+    return BaseAPI.makeRequest<T>(requestOpts)
       .then(
         (success) => {
           result.value = success
@@ -170,10 +164,9 @@ export default function useBaseAPI<T = any>(
  */
 export function useBaseAPIGet<T = any>(
   url: string,
-  initOpts: UseBaseAPIOptions = {},
-  initConfig: AxiosRequestConfig = {}
+  opts: UseBaseAPIOptions = {}
 ): UseBaseAPI<T> {
-  return useBaseAPI<T>(url, "GET", initOpts, initConfig)
+  return useBaseAPI<T>(url, "GET", opts)
 }
 
 /**
@@ -185,10 +178,9 @@ export function useBaseAPIGet<T = any>(
  */
 export function useBaseAPIDelete<T = any>(
   url: string,
-  initOpts: UseBaseAPIOptions = {},
-  initConfig: AxiosRequestConfig = {}
+  opts: UseBaseAPIOptions = {}
 ): UseBaseAPI<T> {
-  return useBaseAPI<T>(url, "DELETE", initOpts, initConfig)
+  return useBaseAPI<T>(url, "DELETE", opts)
 }
 
 /**
@@ -200,10 +192,9 @@ export function useBaseAPIDelete<T = any>(
  */
 export function useBaseAPIPost<T = any>(
   url: string,
-  initOpts: UseBaseAPIOptions = {},
-  initConfig: AxiosRequestConfig = {}
+  opts: UseBaseAPIOptions = {}
 ): UseBaseAPI<T> {
-  return useBaseAPI<T>(url, "POST", initOpts, initConfig)
+  return useBaseAPI<T>(url, "POST", opts)
 }
 
 /**
@@ -215,8 +206,7 @@ export function useBaseAPIPost<T = any>(
  */
 export function useBaseAPIPut<T = any>(
   url: string,
-  initOpts: UseBaseAPIOptions = {},
-  initConfig: AxiosRequestConfig = {}
+  opts: UseBaseAPIOptions = {}
 ): UseBaseAPI<T> {
-  return useBaseAPI<T>(url, "PUT", initOpts, initConfig)
+  return useBaseAPI<T>(url, "PUT", opts)
 }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,5 +1,6 @@
 import { App, Plugin } from "vue"
 import BaseAPI from "@/api/base"
+import type { RequestOptions } from "@/api/base"
 
 // Import vue components
 import * as components from "@/lib-components/index"
@@ -24,3 +25,4 @@ export * from "@/composables/index"
 export * from "@/lib-components/index"
 
 export { BaseAPI }
+export type { RequestOptions }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -16,6 +16,9 @@ const install: Exclude<Plugin["install"], undefined> = function installTrees(
 // Create module definition for Vue.use()
 export default install
 
+// expose composables
+export * from "@/composables/index"
+
 // To allow individual component use, export components
 // each can be registered via Vue.component()
 export * from "@/lib-components/index"

--- a/src/helpers/Debounce.ts
+++ b/src/helpers/Debounce.ts
@@ -8,3 +8,19 @@ export function debounce(func: () => void, timeout = 500): () => void {
     }, timeout)
   }
 }
+
+export function debounceLeading(func: () => void, timeout = 500) {
+  let timer: NodeJS.Timer | null = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (...args: any[]) => {
+    if (!timer) {
+      func.apply(args)
+    } else {
+      clearTimeout(timer)
+    }
+
+    timer = setTimeout(() => {
+      timer = null
+    }, timeout)
+  }
+}


### PR DESCRIPTION
# What this does

- adds `withDelay` and `dataIntercept` options to the `RequestOptions` interface.  `withDelay` artificially delays the response from the API request for UI purposes.  `dataIntercept` is a convenience option to receive the response result that is nested inside of AxiosResponse data and server data fields
- adds type generics to BaseAPI methods so that the success response can be correctly inferred
- adds composable `useBaseAPI` which returns a handful of reactive variables that are generally useful for managing the state of a component
- adds a `debounceLeading` function for button triggered debouncing where trailing clicks should be debounced but not the initial click
- adds a composables page to the docs

## Note:

- the abort feature in useBaseAPI requires an axios version bump
- https://github.com/xy-planning-network/college-try/pull/342 is currently using useBaseAPI via the dev release on npm