### PR TITLE
revert extending AxiosRequestConfig, allow FormData payloads

### DIFF
--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -27,7 +27,7 @@ const { result, error, isLoading, isFinished, isAborted, hasFetched, execute, ab
   useBaseAPI<Paginated<Conifer>>(
     "https://my-json-server.typicode.com/xy-planning-network/trees/conifers",
     "GET",
-    { dataIntercept: true, withCredentials: false}
+    { dataIntercept: true }
   )
 
 const fetch = (opt: RequestOptions = {}, shouldAbort = false,) => {
@@ -50,8 +50,8 @@ const fetch = (opt: RequestOptions = {}, shouldAbort = false,) => {
 
 const fetchDebounce = debounceLeading(() => {
   abort()
-  fetch({ withDelay: 0, skipLoader: true, url: "https://deelay.me/1000/https://my-json-server.typicode.com/xy-planning-network/trees/conifers" }, false)
-}, 100)
+  fetch({ withDelay: 0 }, false)
+}, 50)
 
 
 const buttonText = computed(() => {

--- a/src/composables/useBaseAPI.ts
+++ b/src/composables/useBaseAPI.ts
@@ -54,7 +54,10 @@ export interface UseBaseAPI<T> {
    * Manually call the axios request
    * can be used multiple times
    */
-  execute: (data?: Record<string, unknown>, opts?: RequestOptions) => Promise<T>
+  execute: (
+    data?: Record<string, unknown> | FormData,
+    opts?: RequestOptions
+  ) => Promise<T>
 }
 
 /**
@@ -86,7 +89,7 @@ export default function useBaseAPI<T = any>(
   }
 
   const execute = (
-    data: Record<string, unknown> = {},
+    data: Record<string, unknown> | FormData = {},
     opts: RequestOptions = {}
   ): Promise<T> => {
     requestCount++
@@ -98,17 +101,15 @@ export default function useBaseAPI<T = any>(
     isFinished.value = false
     isLoading.value = true
 
-    const requestOpts = {
-      ...initOpts,
+    const requestConfig = {
       data: ["POST", "post", "PUT", "put"].includes(method) ? data : {},
       method: method,
       params: ["GET", "get"].includes(method) ? data : {},
       signal: controller.signal,
       url: path,
-      ...opts,
     }
 
-    return BaseAPI.makeRequest<T>(requestOpts)
+    return BaseAPI.makeRequest<T>(requestConfig, { ...initOpts, ...opts })
       .then(
         (success) => {
           result.value = success


### PR DESCRIPTION
# What this does

- reverts extending the AxiosRequestConfig in the BaseAPI RequestConfig.  (This was easy to rationalize, but doesn't offer as much as I'd hoped aside from making the config options confusingly large.)
- allows FormData as a payload type in POST and PUT requests.    

## Why FormData?

- The FetchAPI already allows FormData in its config's body property 
- Axios handles both Objects and FormData gracefully setting the appropriate headers for you stringifying etc.  
- We don't need FormData often, but when we do we lose out on the feature set of BaseAPI and have to recreate it.
- It's technically already feasible to do this under the current BaseAPI if you do some Typescript muddlery a la `BaseAPI.post("/some-endpont", {some: "val"} as unknown as Record<string, unknown>)` - obviously shouldn't do this, but it highlights that Axios was handling it under the hood.

## Example refactor with FormData:

__Uploads Before:__
```ts
import { BaseAPI } from "@xy-planning-network/trees";
import axios, { AxiosError, AxiosPromise, AxiosResponse } from "axios";

const upload = (kind: string, data: FormData): AxiosPromise | null => {
  return new Promise((resolve, reject) => {
    const wait = window.setTimeout(() => {
      window.VueBus.emit("Spinner-show");
    }, 200);

    let hasFiles = false;
    for (const key of data.keys()) {
      if (key.includes("file")) {
        hasFiles = true;
        break;
      }
    }

    if (!hasFiles) {
      window.clearTimeout(wait);
      window.VueBus.emit("Spinner-hide");
      resolve(null);
      return;
    }

    axios
      .post(
        `${
          import.meta.env.VITE_APP_BASE_API_URL || "/api/v1"
        }/raw-data-uploads?kind=${kind}`,
        data
      )
      .then((success: AxiosResponse) => {
        window.clearTimeout(wait);
        window.VueBus.emit("Spinner-hide");
        resolve(success.data);
      })
      .catch((error: AxiosError) => {
        window.clearTimeout(wait);
        window.VueBus.emit("Spinner-hide");
        reject(error.response);
      });
  });
};
```

__Uploads After:__

```ts
import { BaseAPI } from "@xy-planning-network/trees";

export interface FileUpload {
  filename: string;
  url: string;
}

const uploads = (kind: string, formData: FormData) => {
  const hasFiles = [...formData.keys()].join(" ").includes("file");
  if (hasFiles === false) {
    return Promise.resolve([] as FileUpload[]);
  }

  return BaseAPI.post<FileUpload[]>(`raw-data-uploads?kind=${kind}`, formData, {
    dataIntercept: true,
  });
};

```

There are some general refactor choices here that are not related to using FormData.  The notable difference is in the ability to leverage the spinner, but also the dataIntercept option and simplifying type support.