### PR TITLE
feat: radio cards

### DIFF
--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -417,6 +417,41 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               <template #legend>In A Grid Too</template>
             </Radio>
 
+            <div class="">
+              <RadioCards
+                legend="Cards Any One?"
+                help="Just use the RadioCards component."
+                :options="
+                  options.map((option) => ({
+                    disabled: option.disabled,
+                    label: option.label,
+                    value: option.value,
+                  }))
+                "
+                v-model="radioSelection"
+                :columns="2"
+              />
+            </div>
+
+            <div class="">
+              <RadioCards
+                :disabled="true"
+                legend="Cards Any One?"
+                help="Just use the RadioCards component."
+                :options="
+                  options.map((option) => ({
+                    disabled: option.disabled,
+                    help: option.help,
+                    label: option.label,
+                    value: option.value,
+                    sublabel: '$499/mo',
+                  }))
+                "
+                v-model="radioSelection"
+                :columns="2"
+              />
+            </div>
+
             <div class="mt-4"><b>Value:</b> {{ radioSelection }}</div>
             <PropsTable :props="radioProps" />
           </div>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -445,8 +445,8 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             <div class="">
               <RadioCards
                 :disabled="true"
-                legend="Cards Any One?"
-                help="Just use the RadioCards component."
+                legend="Need a complex sublabel on your cards?"
+                help="The sublabel display is supported by both options.sublabel and a named slot #sublabel."
                 :options="
                   options.map((option) => ({
                     disabled: option.disabled,
@@ -462,6 +462,25 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
                   {{ option.value }}:{{ checked }}
                 </template>
               </RadioCards>
+            </div>
+
+            <div class="prose mt-4">
+              <p>
+                The <code>sublabel</code> slot receives the following scoped
+                slot props:
+              </p>
+              <ul>
+                <li>active: boolean</li>
+                <li>checked: boolean</li>
+                <li>disabled: boolean</li>
+                <li>
+                  option:
+                  <code
+                    >{disabled: boolean, help: string, label: string, sublabel:
+                    string, value: string | number, ... }</code
+                  >
+                </li>
+              </ul>
             </div>
 
             <div class="mt-4"><b>Value:</b> {{ radioSelection }}</div>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -412,7 +412,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               help="Set the columns prop to 2, 3, or 4"
               :options="options"
               v-model="radioSelection"
-              :columns="undefined"
+              :columns="2"
               required
             >
               <template #legend>In A Grid Too</template>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -47,7 +47,7 @@ const radioProps = [
   { name: "help", required: false, type: "string" },
   { name: "legend", required: false, type: "string" },
 ]
-const radioSelection = ref<string | number>()
+const radioSelection = ref<string | number>("val1")
 const selectCopy = `<Select :options="options" placeholder="Select an option that you fancy" />`
 const selectProps = [
   { name: "design", required: false, type: "string" },
@@ -421,20 +421,23 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             <div class="">
               <form>
                 <RadioCards
+                  v-model="radioSelection"
                   legend="Cards Any One?"
                   help="Just use the RadioCards component."
                   :options="
                     options.map((option) => ({
                       disabled: option.disabled,
+                      help: option.help,
                       label: option.label,
                       value: option.value,
+                      sublabel: '$499/mo',
                     }))
                   "
-                  v-model="radioSelection"
                   :columns="2"
                   name="my_input"
                   required
                 />
+                <input type="hidden" name="page" value="Forms" />
                 <input class="xy-btn mt-2" type="submit" value="submit" />
               </form>
             </div>
@@ -450,12 +453,15 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
                     help: option.help,
                     label: option.label,
                     value: option.value,
-                    sublabel: '$499/mo',
                   }))
                 "
                 v-model="radioSelection"
                 :columns="2"
-              />
+              >
+                <template #sublabel="{ option, checked }">
+                  {{ option.value }}:{{ checked }}
+                </template>
+              </RadioCards>
             </div>
 
             <div class="mt-4"><b>Value:</b> {{ radioSelection }}</div>

--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -47,7 +47,7 @@ const radioProps = [
   { name: "help", required: false, type: "string" },
   { name: "legend", required: false, type: "string" },
 ]
-const radioSelection = ref<string | number>("val2")
+const radioSelection = ref<string | number>()
 const selectCopy = `<Select :options="options" placeholder="Select an option that you fancy" />`
 const selectProps = [
   { name: "design", required: false, type: "string" },
@@ -413,24 +413,30 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               :options="options"
               v-model="radioSelection"
               :columns="undefined"
+              required
             >
               <template #legend>In A Grid Too</template>
             </Radio>
 
             <div class="">
-              <RadioCards
-                legend="Cards Any One?"
-                help="Just use the RadioCards component."
-                :options="
-                  options.map((option) => ({
-                    disabled: option.disabled,
-                    label: option.label,
-                    value: option.value,
-                  }))
-                "
-                v-model="radioSelection"
-                :columns="2"
-              />
+              <form>
+                <RadioCards
+                  legend="Cards Any One?"
+                  help="Just use the RadioCards component."
+                  :options="
+                    options.map((option) => ({
+                      disabled: option.disabled,
+                      label: option.label,
+                      value: option.value,
+                    }))
+                  "
+                  v-model="radioSelection"
+                  :columns="2"
+                  name="my_input"
+                  required
+                />
+                <input class="xy-btn mt-2" type="submit" value="submit" />
+              </form>
             </div>
 
             <div class="">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.4.8",
+  "version": "0.4.9-rc-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.4.8",
+      "version": "0.4.9-rc-2",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.4.8",
+  "version": "0.4.9-rc-2",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/src/lib-components/forms/FieldsetLegend.vue
+++ b/src/lib-components/forms/FieldsetLegend.vue
@@ -1,8 +1,17 @@
 <script setup lang="ts">
 import { hasSlotContent } from "@/helpers/Slots"
+withDefaults(
+  defineProps<{
+    tag?: string
+  }>(),
+  {
+    tag: "legend",
+  }
+)
 </script>
 <template>
-  <legend
+  <component
+    :is="tag"
     v-if="hasSlotContent($slots.default)"
     v-bind="{
       ...$attrs,
@@ -10,5 +19,5 @@ import { hasSlotContent } from "@/helpers/Slots"
     }"
   >
     <slot />
-  </legend>
+  </component>
 </template>

--- a/src/lib-components/forms/FieldsetLegend.vue
+++ b/src/lib-components/forms/FieldsetLegend.vue
@@ -15,7 +15,7 @@ withDefaults(
     v-if="hasSlotContent($slots.default)"
     v-bind="{
       ...$attrs,
-      class: 'text-base font-medium leading-tight text-gray-900',
+      class: 'text-sm font-semibold leading-snug text-gray-900',
     }"
   >
     <slot />

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -46,7 +46,7 @@ const hasLegend = computed(() => {
       </FieldsetLegend>
       <InputHelp tag="p" :text="help" :id="`${uuid}-help`" />
     </div>
-    <div class="">
+    <div class="flex">
       <div
         class="grid gap-4"
         :class="{

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -131,12 +131,21 @@ const nameAttr = computed(() => {
               <RadioGroupDescription v-if="option.help" as="div">
                 <InputHelp tag="div" class="mt-auto" :text="option.help" />
               </RadioGroupDescription>
-              <div v-if="option.sublabel" class="mt-auto mb-0">
-                <RadioGroupDescription as="div" class="mt-4">
-                  <InputLabel
-                    tag="span"
-                    class="mt-auto mb-auto"
-                    :label="option.sublabel"
+              <div
+                v-if="option.sublabel || $slots.sublabel"
+                class="mt-auto mb-0"
+              >
+                <RadioGroupDescription
+                  as="div"
+                  class="font-semibold leading-snug mt-4 text-gray-900 text-sm"
+                >
+                  {{ option.sublabel }}
+                  <slot
+                    name="sublabel"
+                    :active="active"
+                    :checked="checked"
+                    :disabled="disabled"
+                    :option="option"
                   />
                 </RadioGroupDescription>
               </div>

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import Uniques from "@/helpers/Uniques"
+import {
+  RadioGroup,
+  RadioGroupDescription,
+  RadioGroupLabel,
+  RadioGroupOption,
+} from "@headlessui/vue"
+import { CheckCircleIcon } from "@heroicons/vue/solid"
+import { ref, useAttrs, watch } from "vue"
+import FieldsetLegend from "./FieldsetLegend.vue"
+
+type ModelValue = string | number
+
+// TODO: support required and hidden field with name attribute
+
+type RadioCard = {
+  disabled?: boolean
+  help?: string
+  label: string
+  sublabel?: string
+  value: ModelValue
+}
+
+const props = withDefaults(
+  defineProps<{
+    columns?: 2 | 3
+    help?: string
+    legend?: string
+    modelValue: ModelValue
+    options: RadioCard[]
+  }>(),
+  {
+    columns: undefined,
+    help: "",
+    legend: "",
+  }
+)
+
+function getSelectedOption(val: ModelValue) {
+  const selected = props.options.find((option) => option.value === val)
+  return selected !== undefined ? selected.value : undefined
+}
+
+const selected = ref(getSelectedOption(props.modelValue))
+
+const emit = defineEmits<{
+  (e: "update:modelValue", modelValue: ModelValue): void
+}>()
+
+const attrs = useAttrs()
+const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
+
+// if modelValue and selected are out of sync
+// then modelValue was updated by the parent
+watch(
+  props,
+  () => {
+    if (props.modelValue !== selected.value) {
+      selected.value = props.modelValue
+    }
+  },
+  { deep: true }
+)
+</script>
+
+<template>
+  <RadioGroup
+    v-model="selected"
+    v-on:update:model-value="(val: ModelValue) => emit('update:modelValue', val)"
+    :disabled="typeof attrs.disabled === 'boolean' ? attrs.disabled : false"
+  >
+    <RadioGroupLabel v-if="legend" class="block">
+      <FieldsetLegend tag="div">{{ legend }}</FieldsetLegend>
+    </RadioGroupLabel>
+    <RadioGroupDescription v-if="help">
+      <InputHelp :text="help" />
+    </RadioGroupDescription>
+
+    <div
+      class="mt-4 grid gap-4"
+      :class="{
+        'sm:grid sm:space-y-0': columns !== undefined,
+        'sm:grid-cols-2': columns === 2,
+        'sm:grid-cols-3': columns === 3,
+      }"
+    >
+      <RadioGroupOption
+        as="template"
+        v-for="option in options"
+        :disabled="option?.disabled ? option.disabled : false"
+        :key="option.value"
+        :name="attrs?.name ? attrs.name : uuid"
+        :value="option.value"
+        v-slot="{ active, checked, disabled }"
+      >
+        <div
+          :class="[
+            checked ? 'border-transparent' : 'border-gray-300',
+            active ? 'border-blue-500 ring-2 ring-blue-500' : '',
+            'relative bg-white border rounded-lg shadow-sm p-4 flex cursor-pointer focus:outline-none',
+            disabled ? 'opacity-75' : '',
+          ]"
+        >
+          <div class="flex-1 flex pr-1">
+            <div class="flex flex-col">
+              <RadioGroupLabel as="div">
+                <InputLabel
+                  tag="div"
+                  class="mt-auto mb-auto"
+                  :label="option.label"
+                />
+              </RadioGroupLabel>
+              <RadioGroupDescription v-if="option.help" as="div">
+                <InputHelp tag="div" class="mt-auto" :text="option.help" />
+              </RadioGroupDescription>
+              <div class="mt-auto mb-0">
+                <RadioGroupDescription
+                  v-if="option.sublabel"
+                  as="div"
+                  class="mt-4"
+                >
+                  <InputLabel
+                    tag="span"
+                    class="mt-auto mb-auto"
+                    :label="option.sublabel"
+                  />
+                </RadioGroupDescription>
+              </div>
+            </div>
+          </div>
+          <CheckCircleIcon
+            :class="[!checked ? 'invisible' : '', 'h-5 w-5 text-blue-600']"
+            aria-hidden="true"
+          />
+          <div
+            :class="[
+              active ? 'border' : 'border-2',
+              checked ? 'border-blue-500' : 'border-transparent',
+              'absolute -inset-px rounded-lg pointer-events-none',
+            ]"
+            aria-hidden="true"
+          />
+        </div>
+      </RadioGroupOption>
+    </div>
+  </RadioGroup>
+</template>

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -52,7 +52,7 @@ const emit = defineEmits<{
 }>()
 
 const attrs = useAttrs()
-const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
+const uuid = Uniques.CreateIdAttribute()
 
 // tracking internal state separate from modelValue
 // allows v-model to be undefined by the consumer but still supports
@@ -141,14 +141,14 @@ const nameAttr = computed(() => {
                   as="div"
                   class="font-semibold leading-snug mt-4 text-gray-900 text-sm"
                 >
-                  {{ option.sublabel }}
                   <slot
                     name="sublabel"
                     :active="active"
                     :checked="checked"
                     :disabled="disabled"
                     :option="option"
-                  />
+                    >{{ option.sublabel }}</slot
+                  >
                 </RadioGroupDescription>
               </div>
             </div>

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -10,6 +10,15 @@ import { CheckCircleIcon } from "@heroicons/vue/solid"
 import { computed, ref, useAttrs } from "vue"
 import FieldsetLegend from "./FieldsetLegend.vue"
 
+/*
+ * NOTE (spk) headless UI introduced a "name" prop that includes a hidden field
+ * to use the modelValue inside of forms.  It does not however resolve the issue of
+ * supporting HTML5 form validation, so we'll add our own hidden radio buttons to support both.
+ *
+ * The headless technique does include supporting complex modelValues such as objects, which we may
+ * need in the future.  We can revist required validation at that time using a singular hidden checkbox.
+ */
+
 type ModelValue = string | number
 
 type RadioCard = {

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -7,12 +7,10 @@ import {
   RadioGroupOption,
 } from "@headlessui/vue"
 import { CheckCircleIcon } from "@heroicons/vue/solid"
-import { ref, useAttrs, watch } from "vue"
+import { computed, ref, useAttrs } from "vue"
 import FieldsetLegend from "./FieldsetLegend.vue"
 
 type ModelValue = string | number
-
-// TODO: support required and hidden field with name attribute
 
 type RadioCard = {
   disabled?: boolean
@@ -27,22 +25,16 @@ const props = withDefaults(
     columns?: 2 | 3
     help?: string
     legend?: string
-    modelValue: ModelValue
+    modelValue?: ModelValue
     options: RadioCard[]
   }>(),
   {
     columns: undefined,
     help: "",
     legend: "",
+    modelValue: undefined,
   }
 )
-
-function getSelectedOption(val: ModelValue) {
-  const selected = props.options.find((option) => option.value === val)
-  return selected !== undefined ? selected.value : undefined
-}
-
-const selected = ref(getSelectedOption(props.modelValue))
 
 const emit = defineEmits<{
   (e: "update:modelValue", modelValue: ModelValue): void
@@ -51,24 +43,54 @@ const emit = defineEmits<{
 const attrs = useAttrs()
 const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
 
-// if modelValue and selected are out of sync
-// then modelValue was updated by the parent
-watch(
-  props,
-  () => {
-    if (props.modelValue !== selected.value) {
-      selected.value = props.modelValue
-    }
-  },
-  { deep: true }
-)
+// tracking internal state separate from modelValue
+// allows v-model to be undefined by the consumer but still supports
+// the display requirements of the component.
+// this is usful when the component is used inside a form element and
+// tracking v-model isn't required.
+const internalState = ref()
+const checked = computed(() => {
+  if (props.modelValue === undefined) {
+    return internalState.value
+  }
+
+  return props.modelValue
+})
+
+// manage some custom required validation using an invisible input field
+const validationInputRef = ref<any>()
+const invalid = ref<boolean>()
+const errMsg = "Please select one of these options."
+const onInvalid = () => {
+  if (validationInputRef.value === undefined) {
+    return
+  }
+
+  invalid.value = true
+  validationInputRef.value.setCustomValidity(errMsg)
+}
+
+const onChange = (val: ModelValue) => {
+  internalState.value = val
+  emit("update:modelValue", val)
+
+  if (validationInputRef.value === undefined) {
+    return
+  }
+
+  invalid.value = false
+  validationInputRef.value.setCustomValidity("")
+}
 </script>
 
 <template>
   <RadioGroup
-    v-model="selected"
-    v-on:update:model-value="(val: ModelValue) => emit('update:modelValue', val)"
+    :modelValue="checked"
+    @update:model-value="onChange"
     :disabled="typeof attrs.disabled === 'boolean' ? attrs.disabled : false"
+    :name="attrs.name ? attrs.name : uuid"
+    :aria-invalid="invalid === true ? 'true' : null"
+    :aria-errormessage="invalid === true ? `error-${uuid}` : null"
   >
     <RadioGroupLabel v-if="legend" class="block">
       <FieldsetLegend tag="div">{{ legend }}</FieldsetLegend>
@@ -76,11 +98,13 @@ watch(
     <RadioGroupDescription v-if="help">
       <InputHelp :text="help" />
     </RadioGroupDescription>
+    <div v-if="invalid === true" :id="`error-${uuid}`" class="sr-only">
+      {{ errMsg }}
+    </div>
 
     <div
-      class="mt-4 grid gap-4"
+      class="mt-4 grid grid-cols-1 gap-y-5 gap-x-4 relative"
       :class="{
-        'sm:grid sm:space-y-0': columns !== undefined,
         'sm:grid-cols-2': columns === 2,
         'sm:grid-cols-3': columns === 3,
       }"
@@ -90,7 +114,6 @@ watch(
         v-for="option in options"
         :disabled="option?.disabled ? option.disabled : false"
         :key="option.value"
-        :name="attrs?.name ? attrs.name : uuid"
         :value="option.value"
         v-slot="{ active, checked, disabled }"
       >
@@ -114,12 +137,8 @@ watch(
               <RadioGroupDescription v-if="option.help" as="div">
                 <InputHelp tag="div" class="mt-auto" :text="option.help" />
               </RadioGroupDescription>
-              <div class="mt-auto mb-0">
-                <RadioGroupDescription
-                  v-if="option.sublabel"
-                  as="div"
-                  class="mt-4"
-                >
+              <div v-if="option.sublabel" class="mt-auto mb-0">
+                <RadioGroupDescription as="div" class="mt-4">
                   <InputLabel
                     tag="span"
                     class="mt-auto mb-auto"
@@ -143,6 +162,15 @@ watch(
           />
         </div>
       </RadioGroupOption>
+      <input
+        ref="validationInputRef"
+        class="absolute sr-only top-1 left-4"
+        aria-hidden="true"
+        type="checkbox"
+        :checked="internalState !== undefined"
+        :required="attrs.required !== undefined && attrs.required !== false"
+        @invalid="onInvalid"
+      />
     </div>
   </RadioGroup>
 </template>

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -8,6 +8,8 @@ import {
 } from "@headlessui/vue"
 import { CheckCircleIcon } from "@heroicons/vue/solid"
 import { computed, ref, useAttrs } from "vue"
+import InputLabel from "./InputLabel.vue"
+import InputHelp from "./InputHelp.vue"
 import FieldsetLegend from "./FieldsetLegend.vue"
 
 /*

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -33,6 +33,7 @@ import { default as InputLabel } from "./forms/InputLabel.vue"
 import { default as FieldsetLegend } from "./forms/FieldsetLegend.vue"
 import { default as MultiCheckboxes } from "./forms/MultiCheckboxes.vue"
 import { default as Radio } from "./forms/Radio.vue"
+import { default as RadioCards } from "./forms/RadioCards.vue"
 import { default as Select } from "./forms/Select.vue"
 import { default as TextArea } from "./forms/TextArea.vue"
 import { default as YesOrNoRadio } from "./forms/YesOrNoRadio.vue"
@@ -68,6 +69,7 @@ export {
   FieldsetLegend,
   MultiCheckboxes,
   Radio,
+  RadioCards,
   Select,
   TextArea,
   YesOrNoRadio,
@@ -106,6 +108,7 @@ export interface TreesComponents {
   FieldsetLegend: typeof FieldsetLegend
   MultiCheckboxes: typeof MultiCheckboxes
   Radio: typeof Radio
+  RadioCards: typeof RadioCards
   Select: typeof Select
   TextArea: typeof TextArea
   YesOrNoRadio: typeof YesOrNoRadio


### PR DESCRIPTION
# What this does

- adds a fancy radio button that looks like a card
- support for HTML5 form validation and FormData
- includes the benefits of headless ui features like focus trap and aria tags
- avoids using the headless ui feature of supporting FormData since their solution does not support the required attribute
- fixes layout bug in radio buttons in columns mode
- brings radio/checkbox legend styles inline with field level labels

### Why

- a potential use case in Portal.
- seems generally beneficial to have additional form field display options when the classics aren't enough

https://user-images.githubusercontent.com/3856703/174171772-503bf766-1021-4ae5-b5eb-589c535bdcc5.mov


