### PR TITLE
refactor/fix: overlay stacking context and z-index values

### DIFF
--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -418,6 +418,92 @@ useAppFlasher.warning("Hooray!")</code></pre>
 
         <PropsTable :props="tooltipProps"></PropsTable>
       </ComponentLayout>
+
+      <ComponentLayout
+        class="mt-8"
+        :show-badge="false"
+        title="Stacking Context"
+      >
+        <template v-slot:description>
+          Overlay components naturally can introduce complications in stacking
+          context and z-index for any application. We've made best attempts to
+          set sane z-index values on each overlay component in an order that
+          makes sense for the component's general usage. These components are all
+          wrapped in the <code>&lt;Portal /&gt;</code> component made available
+          by HeadlessUI/Vue to ensure they share a stacking context. We've
+          additionally, preserved the highest order z-index (z-50) for consumers
+          when necessary.
+        </template>
+
+        <div class="prose prose-sm">
+          <h4>Tailwind CSS z-index Values</h4>
+          <table>
+            <thead>
+              <tr>
+                <th>Component</th>
+                <th>z-index</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Popover/Tooltip</td>
+                <td>z-10</td>
+              </tr>
+              <tr>
+                <td>App Sidebar Mobile Nav</td>
+                <td>z-10</td>
+              </tr>
+              <tr>
+                <td>Slideover</td>
+                <td>z-20</td>
+              </tr>
+              <tr>
+                <td>Modal</td>
+                <td>z-30</td>
+              </tr>
+              <tr>
+                <td>Spinner</td>
+                <td>z-40</td>
+              </tr>
+              <tr>
+                <td>Flash</td>
+                <td>z-45</td>
+              </tr>
+              <tr>
+                <td>Unused (preserved for consumers)</td>
+                <td>z-50</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h4>Climbing Above The Rest</h4>
+          <p>
+            In the event that you need to establish a z-index level above any of
+            the overlay components, you'll need to wrap your component in the
+            HeadlessUI/Vue <code>&lt;Portal /&gt;</code> component. This convenience component is not
+            documented by HeadlessUI, but is effectively a wrapper around the
+            Vue Teleport component. It maintains a single container before the
+            closing body tag and teleports all Portal markup to that location
+            ensuring the same stacking context between those DOM elements.
+          </p>
+
+          <p>
+            <pre class="overflow-scroll bg-gray-50 p-4">
+<code class="language-typescript">{{`<script lang="ts" setup>
+  import { Portal } from "@headlessui/vue"
+</script>
+
+<template>
+  <Portal>
+    <div class="fixed top-0 left-0 right-0 bottom-0 z-50">
+      <h1>Head and shoulders above the rest!</h1>
+    </div>
+  </Portal>
+</template>`}}</code>
+            </pre>
+          </p>
+        </div>
+      </ComponentLayout>
     </div>
   </div>
 </template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/src/lib-components/indicators/XYSpinner.vue
+++ b/src/lib-components/indicators/XYSpinner.vue
@@ -15,7 +15,7 @@ const attrs = useAttrs()
         <p class="sr-only">
           <slot></slot>
         </p>
-        <div class="animate-spin-gear">
+        <div class="animate-spin-gear drop-shadow-md">
           <svg
             width="100%"
             height="100%"

--- a/src/lib-components/layout/SidebarLayout.vue
+++ b/src/lib-components/layout/SidebarLayout.vue
@@ -40,7 +40,7 @@ const isActive = (url: string): boolean => {
       <Dialog
         as="div"
         static
-        class="fixed inset-0 flex z-40 md:hidden"
+        class="fixed inset-0 flex z-10 md:hidden"
         @close="sidebarOpen = false"
         :open="sidebarOpen"
       >

--- a/src/lib-components/overlays/ContentModal.vue
+++ b/src/lib-components/overlays/ContentModal.vue
@@ -30,7 +30,7 @@ const updateModelValue = (value: boolean) => {
     <Dialog
       as="div"
       static
-      class="fixed z-10 inset-0 overflow-y-auto"
+      class="fixed z-30 inset-0 overflow-y-auto"
       @close="updateModelValue(false)"
       :open="modelValue"
     >

--- a/src/lib-components/overlays/Flash.vue
+++ b/src/lib-components/overlays/Flash.vue
@@ -5,6 +5,7 @@ import {
   loadWindowFlashes,
 } from "@/composables/useFlashes"
 import { onMounted } from "vue"
+import { Portal } from "@headlessui/vue"
 
 const { flasher, flashes } = useAppFlashes()
 
@@ -28,56 +29,62 @@ onMounted(() => {
 })
 </script>
 <template>
-  <div
-    class="fixed inset-0 flex flex-col items-end justify-end px-4 py-6 pointer-events-none sm:p-6 z-40"
-  >
-    <transition-group
-      tag="div"
-      class="max-w-sm space-y-2 w-full"
-      enter-active-class="ease-out duration-300"
-      enter-from-class="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
-      enter-to-class="translate-y-0 opacity-100 sm:translate-x-0"
-      leave-active-class="ease-in duration-100"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-0"
+  <Portal>
+    <div
+      class="fixed inset-0 flex flex-col items-end justify-end px-4 py-6 pointer-events-none sm:p-6 z-[45]"
     >
-      <div
-        v-for="[id, flash] in flashes"
-        :key="flash.message"
-        class="bg-white shadow-lg rounded-lg pointer-events-auto border-t-4 transform"
-        :class="[getFlashClass(flash.type)]"
+      <transition-group
+        tag="div"
+        class="max-w-sm space-y-2 w-full"
+        enter-active-class="ease-out duration-300"
+        enter-from-class="translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2"
+        enter-to-class="translate-y-0 opacity-100 sm:translate-x-0"
+        leave-active-class="ease-in duration-100"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
       >
         <div
-          class="rounded-lg ring-1 ring-black ring-opacity-5 overflow-hidden"
+          v-for="[id, flash] in flashes"
+          :key="flash.message"
+          class="bg-white shadow-lg rounded-lg pointer-events-auto border-t-4 transform z-10"
+          :class="[getFlashClass(flash.type)]"
         >
-          <div class="p-4">
-            <div class="flex items-center">
-              <div class="w-0 flex-1 flex justify-between">
-                <p
-                  class="w-0 flex-1 text-sm leading-5 font-medium text-gray-900"
-                  v-html="flash.message"
-                ></p>
-              </div>
-              <div class="ml-4 shrink-0 flex">
-                <button
-                  @click="flasher.remove(id)"
-                  class="inline-flex text-gray-400 focus:outline-none focus:text-gray-500 transition ease-in-out duration-150"
-                >
-                  <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                    <path
-                      fill-rule="evenodd"
-                      d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
-                </button>
+          <div
+            class="rounded-lg ring-1 ring-black ring-opacity-5 overflow-hidden"
+          >
+            <div class="p-4">
+              <div class="flex items-center">
+                <div class="w-0 flex-1 flex justify-between">
+                  <p
+                    class="w-0 flex-1 text-sm leading-5 font-medium text-gray-900"
+                    v-html="flash.message"
+                  ></p>
+                </div>
+                <div class="ml-4 shrink-0 flex">
+                  <button
+                    @click="flasher.remove(id)"
+                    class="inline-flex text-gray-400 focus:outline-none focus:text-gray-500 transition ease-in-out duration-150"
+                  >
+                    <svg
+                      class="h-5 w-5"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                        clip-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </transition-group>
-  </div>
+      </transition-group>
+    </div>
+  </Portal>
 </template>
 
 <style>

--- a/src/lib-components/overlays/Modal.vue
+++ b/src/lib-components/overlays/Modal.vue
@@ -42,7 +42,7 @@ const updateModelValue = (value: boolean) => {
     <Dialog
       as="div"
       static
-      class="fixed z-10 inset-0 overflow-y-auto"
+      class="fixed z-30 inset-0 overflow-y-auto"
       @close="updateModelValue(false)"
       :open="modelValue"
     >

--- a/src/lib-components/overlays/Slideover.vue
+++ b/src/lib-components/overlays/Slideover.vue
@@ -33,7 +33,7 @@ const close = () => {
     <Dialog
       as="div"
       static
-      class="fixed inset-0 z-40 overflow-hidden bg-black bg-opacity-50"
+      class="fixed inset-0 z-20 overflow-hidden bg-black bg-opacity-50"
       @close="close()"
       :open="modelValue"
     >

--- a/src/lib-components/overlays/Spinner.vue
+++ b/src/lib-components/overlays/Spinner.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { Portal } from "@headlessui/vue"
 import XYSpinner from "../indicators/XYSpinner.vue"
 import { useAppSpinnerDisplay } from "@/composables/useSpinner"
 
@@ -22,30 +23,32 @@ const fadeOut = (): void => {
 }
 </script>
 <template>
-  <div
-    class="fixed top-0 left-0 flex flex-col items-center justify-center w-full h-full cursor-not-allowed z-50 bg-gray-50 bg-opacity-50"
-    v-if="loading"
-  >
-    <XYSpinner class="w-32 h-32" />
-    <div class="mt-2" v-show="messages">
-      <transition
-        appear
-        enter-active-class="ease-out duration-1000"
-        enter-from-class="opacity-0"
-        enter-to-class="opacity-100"
-        leave-active-class="ease-in duration-500"
-        leave-from-class="opacity-100"
-        leave-to-class="opacity-0"
-        @after-enter="fadeOut"
-        @after-leave="fadeIn"
-      >
-        <div
-          class="container font-medium text-lg leading-snug text-center transition-opacity"
-          v-show="showMsg"
+  <Portal>
+    <div
+      class="fixed top-0 left-0 flex flex-col items-center justify-center w-full h-full cursor-not-allowed z-40 bg-gray-50 bg-opacity-50"
+      v-if="loading"
+    >
+      <XYSpinner class="w-32 h-32" />
+      <div class="mt-2" v-show="messages">
+        <transition
+          appear
+          enter-active-class="ease-out duration-1000"
+          enter-from-class="opacity-0"
+          enter-to-class="opacity-100"
+          leave-active-class="ease-in duration-500"
+          leave-from-class="opacity-100"
+          leave-to-class="opacity-0"
+          @after-enter="fadeOut"
+          @after-leave="fadeIn"
         >
-          {{ msg }}
-        </div>
-      </transition>
+          <div
+            class="container font-medium text-lg leading-snug text-center transition-opacity"
+            v-show="showMsg"
+          >
+            {{ msg }}
+          </div>
+        </transition>
+      </div>
     </div>
-  </div>
+  </Portal>
 </template>


### PR DESCRIPTION
# What this does

- Resolves the issue where components like flash and spinner are visibly behind other overlay components such as slideover and modal by wrapping the spinner and flash components in the headlessui Portal component so that all overlay full viewport coverage components share the same staking context.
- Updates existing z-index values on overlay components according to each component's perceived display importance and document those new values.
- Adds a minor drop-shadow on the spinner component to increase visibility in the case of multiple full viewport overlays.
- Bump version to 0.6.1

## Additional Notes:

There are situations where many layers of stacked overlay backgrounds may impact the visibility of the site negatively.  These situations should be few and can be revisited from a design language perspective in the future if warranted.

### Docs:

<img width="1091" alt="Screen Shot 2022-12-14 at 3 41 35 PM" src="https://user-images.githubusercontent.com/3856703/207722973-fda0eb69-23b5-4cc9-9011-056ffd0e1e31.png">

### Crude Display Tests:

<img width="1029" alt="Screen Shot 2022-12-13 at 4 27 48 PM" src="https://user-images.githubusercontent.com/3856703/207723044-7466372d-3da3-4009-8803-f95984ea683f.png">

<img width="485" alt="Screen Shot 2022-12-13 at 4 27 31 PM" src="https://user-images.githubusercontent.com/3856703/207723083-0798a78d-9765-4ffe-aabb-9d4d01536729.png">