### PR TITLE
refactor/base api interface improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ module.exports = {
     sourceType: "module",
   },
   rules: {
-    "@typescript-eslint/no-non-null-assertion": "warn",
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/no-empty-interface": [
       "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,13 @@ module.exports = {
     sourceType: "module",
   },
   rules: {
-    "@typescript-eslint/no-non-null-assertion": 0,
+    "@typescript-eslint/no-non-null-assertion": "warn",
     "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/no-empty-interface": [
+      "error",
+      {
+        allowSingleExtends: true,
+      },
+    ],
   },
 }

--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import http from "@/api/base"
-import { HttpError, RequestOptions, TrailsResponsePaged } from "@/api/client"
+import { RequestOptions, TrailsResponsePaged } from "@/api/client"
 import { computed } from "vue"
 import useBaseAPI from "../../src/composables/useBaseAPI"
 import { debounceLeading } from "../../src/helpers/Debounce"

--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { hasHttpErrStatus, isHttpError } from "@/api/base"
+import { isHttpError } from "@/api/base"
 import { RequestOptions, TrailsResponsePaged } from "@/api/client"
 import { computed } from "vue"
 import useBaseAPI from "../../src/composables/useBaseAPI"
@@ -31,7 +31,7 @@ const fetch = (opt: RequestOptions = {}, shouldAbort = false,) => {
   }).catch((err: unknown) => {
     // you could do something with this err variable
     // but the error variable will already be a ShallowRef<Error | HttpError<T>>
-    console.log(err, error.value, isHttpError(err), hasHttpErrStatus(err, 0))
+    console.log(err, error.value, isHttpError(err))
   })
 
   if (shouldAbort) {
@@ -114,7 +114,7 @@ execute({ query: Date.now() }, { withDelay: 3000 })
   }).catch((err: unknown) => {
     // you could do something with this err variable
     // but the error variable will already be a ShallowRef<Error | HttpError>
-    console.log(err, error.value, isHttpError(err), hasHttpErrStatus(err, 0))
+    console.log(err, error.value, isHttpError(err))
   })
 
 // this computed function is ready with whatever result contains

--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import http from "@/api/base"
+import { hasHttpErrStatus, isHttpError } from "@/api/base"
 import { RequestOptions, TrailsResponsePaged } from "@/api/client"
 import { computed } from "vue"
 import useBaseAPI from "../../src/composables/useBaseAPI"
@@ -31,7 +31,7 @@ const fetch = (opt: RequestOptions = {}, shouldAbort = false,) => {
   }).catch((err: unknown) => {
     // you could do something with this err variable
     // but the error variable will already be a ShallowRef<Error | HttpError<T>>
-    console.log(err, error.value, http.isHttpError(err), http.hasErrStatus(err, 0))
+    console.log(err, error.value, isHttpError(err), hasHttpErrStatus(err, 0))
   })
 
   if (shouldAbort) {
@@ -114,7 +114,7 @@ execute({ query: Date.now() }, { withDelay: 3000 })
   }).catch((err: unknown) => {
     // you could do something with this err variable
     // but the error variable will already be a ShallowRef<Error | HttpError>
-    console.log(err, error.value)
+    console.log(err, error.value, isHttpError(err), hasHttpErrStatus(err, 0))
   })
 
 // this computed function is ready with whatever result contains

--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { onMounted} from "vue"
 import http from "@/api/base"
 import { HttpError, RequestOptions, TrailsResponsePaged } from "@/api/client"
 import { computed } from "vue"
@@ -29,11 +28,10 @@ const fetch = (opt: RequestOptions = {}, shouldAbort = false,) => {
     // which has a Type of TrailsResponsePaged<Conifer>, but the result
     // variable will already be a Ref<TrailsResponsePaged<Conifer>>
     console.log(response, result.value)
-  }).catch((err: Error | HttpError) => {
+  }).catch((err: unknown) => {
     // you could do something with this err variable
     // but the error variable will already be a ShallowRef<Error | HttpError<T>>
-    console.log(err, error, http.isHttpError(err), http.hasErrStatus(err, 0))
-    console.log(err.stack)
+    console.log(err, error.value, http.isHttpError(err), http.hasErrStatus(err, 0))
   })
 
   if (shouldAbort) {
@@ -63,23 +61,6 @@ const buttonTextWithAbort = computed(() => {
   if (isLoading.value) return "Loading"
   if (hasFetched.value) return "Fetch Again & Abort"
   return "Fetch & Abort"
-})
-
-onMounted(async () => {    
-  try {
-    const { data } = await http.get<TrailsResponsePaged<Conifer>>("https://my-json-server.typicode.com/xy-planning-network/trees/conifers")
-     console.log(data.items)
-  } catch (e) {
-    console.log(e)
-  }
-
-  http.get<TrailsResponsePaged<Conifer>>("https://my-json-server.typicode.com/xy-planning-network/trees/conifers")
-    .then(({ data }) => {
-      console.log(data)
-    })
-    .catch(e => {
-      console.log(e)
-    })
 })
 </script>
 
@@ -130,10 +111,10 @@ execute({ query: Date.now() }, { withDelay: 3000 })
     // which has a Type of TrailsResponsePaged<Conifer>, but the result
     // variable will already be a Ref<TrailsResponsePaged<Conifer>>
     console.log(data, result)
-  }).catch((err: Error | HttpError) => {
+  }).catch((err: unknown) => {
     // you could do something with this err variable
     // but the error variable will already be a ShallowRef<Error | HttpError>
-    console.log(err, error)
+    console.log(err, error.value)
   })
 
 // this computed function is ready with whatever result contains

--- a/dev/content/Composables.vue
+++ b/dev/content/Composables.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { isHttpError } from "@/api/base"
-import { RequestOptions, TrailsResponsePaged } from "@/api/client"
+import { ReqOptions, TrailsRespPaged } from "@/api/client"
 import { computed } from "vue"
 import useBaseAPI from "../../src/composables/useBaseAPI"
 import { debounceLeading } from "../../src/helpers/Debounce"
@@ -16,17 +16,17 @@ interface Conifer {
 }
 
 const { result, error, isLoading, isFinished, isAborted, hasFetched, execute, abort } =
-  useBaseAPI<TrailsResponsePaged<Conifer>>(
+  useBaseAPI<TrailsRespPaged<Conifer>>(
     "https://my-json-server.typicode.com/xy-planning-network/trees/conifers",
     "GET"
   )
 
-const fetch = (opt: RequestOptions = {}, shouldAbort = false,) => {
+const fetch = (opt: ReqOptions = {}, shouldAbort = false,) => {
   execute({ query: Date.now() }, opt)
   .then((response) => {
     // you could do something with this data variable
-    // which has a Type of TrailsResponsePaged<Conifer>, but the result
-    // variable will already be a Ref<TrailsResponsePaged<Conifer>>
+    // which has a Type of TrailsRespPaged<Conifer>, but the result
+    // variable will already be a Ref<TrailsRespPaged<Conifer>>
     console.log(response, result.value)
   }).catch((err: unknown) => {
     // you could do something with this err variable
@@ -76,7 +76,7 @@ const buttonTextWithAbort = computed(() => {
         
           <pre class="overflow-scroll bg-gray-50 p-4">
             <code class="language-typescript">{{`
-interface TrailsResponsePaged<T> {
+interface TrailsRespPaged<T> {
   page: number
   perPage: number
   totalItems: number
@@ -103,13 +103,13 @@ const {
   hasFetched,
   execute,
   abort
-} = useBaseAPI<TrailsResponsePaged<Conifer>>("https://my-json-server.typicode.com/xy-planning-network/trees/things", "GET")
+} = useBaseAPI<TrailsRespPaged<Conifer>>("https://my-json-server.typicode.com/xy-planning-network/trees/things", "GET")
 
 execute({ query: Date.now() }, { withDelay: 3000 })
   .then(data => {
     // you could do something with this data variable
-    // which has a Type of TrailsResponsePaged<Conifer>, but the result
-    // variable will already be a Ref<TrailsResponsePaged<Conifer>>
+    // which has a Type of TrailsRespPaged<Conifer>, but the result
+    // variable will already be a Ref<TrailsRespPaged<Conifer>>
     console.log(data, result)
   }).catch((err: unknown) => {
     // you could do something with this err variable

--- a/dev/content/Home.vue
+++ b/dev/content/Home.vue
@@ -47,15 +47,15 @@ const features = [
     description: "Elements are elemental. Check them out. CSS only.",
   },
   {
+    name: "Additional Tools",
+    icon: PencilAltIcon,
+    description: "Sometimes you need more than just UI elements.",
+  },
+  {
     name: "Team",
     icon: UserGroupIcon,
     description:
       "Our team once built something that helped the company, and we've been grateful ever since.",
-  },
-  {
-    name: "Composables",
-    icon: PencilAltIcon,
-    description: "Functions that manage reactivity behind the scenes.",
   },
 ]
 </script>

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -5,6 +5,8 @@ import { ExclamationIcon } from "@heroicons/vue/outline"
 import { PopoverPosition } from "@/lib-components/overlays/Popover/Popover.vue"
 import { useAppFlasher } from "@/composables/useFlashes"
 import { useAppSpinner } from "@/composables"
+import ProseBase from "../helpers/ProseBase.vue"
+import CodeSample from "../helpers/CodeSample.vue"
 
 const contentModalCopy = `<ContentModal v-model="open" :content="content" :title="title"></ContentModal>`
 
@@ -128,19 +130,20 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
           can deploy flashes from anywhere with the useAppFlashes composable.
         </template>
 
-        <div>
-          <ul class="mt-1 space-y-2">
-            <li>
-              <InputLabel
-                label="Flash generic error using configured email address:"
-              />
-              <pre><code class="language-typescript">/* Import and do this anytime, best before createApp() or inside a root app level component */
+        <ProseBase>
+          <div class="mt-1 space-y-2">
+            <div>
+              <h4>Flash generic error using configured email address:</h4>
+              <CodeSample>{{
+                `
+/* Import and do this anytime, best before createApp() or inside a root app level component */
 import {useAppFlashes} from "@xy-planning-network/trees"
 useAppFlashes().configure({email: "support@trees.com"})
 
 /* use as needed.  imports of useAppFlasher throughout the app will produce the same result */
 useAppFlashes().flasher.genericError()
-</code></pre>
+              `
+              }}</CodeSample>
               <button
                 type="button"
                 class="xy-btn"
@@ -148,17 +151,24 @@ useAppFlashes().flasher.genericError()
               >
                 Show Me
               </button>
-            </li>
-            <li>
-              <InputLabel
-                label="useAppFlasher is the default export as is what you need most of the time."
-              />
-              <pre><code class="language-typescript">import useAppFlasher from "@xy-planning-network/trees"</code></pre>
+            </div>
+            <div>
+              <h4>
+                useAppFlasher is the default export as is what you need most of
+                the time.
+              </h4>
+              <CodeSample>{{
+                `
+import useAppFlasher from "@xy-planning-network/trees"
+              `
+              }}</CodeSample>
 
-              <InputLabel
-                label="Flash generic error with custom email address:"
-              />
-              <pre><code class="language-typescript">useAppFlasher.genericError("help@trees.com")</code></pre>
+              <h4>Flash generic error with custom email address:</h4>
+              <CodeSample>{{
+                `
+useAppFlasher.genericError("help@trees.com")
+              `
+              }}</CodeSample>
               <button
                 type="button"
                 class="xy-btn"
@@ -166,13 +176,17 @@ useAppFlashes().flasher.genericError()
               >
                 Show Me
               </button>
-            </li>
-            <li>
-              <InputLabel label="Flash (error, info, success, warning):" />
-              <pre><code class="language-typescript">useAppFlasher.error("Hooray!")
+            </div>
+            <div>
+              <h4>Flash (error, info, success, warning):</h4>
+              <CodeSample>{{
+                `
+useAppFlasher.error("Hooray!")
 useAppFlasher.info("Hooray!")
 useAppFlasher.success("Hooray!")
-useAppFlasher.warning("Hooray!")</code></pre>
+useAppFlasher.warning("Hooray!")
+              `
+              }}</CodeSample>
               <button
                 type="button"
                 class="xy-btn"
@@ -180,10 +194,14 @@ useAppFlasher.warning("Hooray!")</code></pre>
               >
                 Flash Success
               </button>
-            </li>
-            <li>
-              <InputLabel label="Flash persistent info:" />
-              <pre><code class="language-typescript">useAppFlasher.info("Sticky!", true)</code></pre>
+            </div>
+            <div>
+              <h4>Flash persistent info:</h4>
+              <CodeSample>{{
+                `
+useAppFlasher.info("Sticky!", true)
+              `
+              }}</CodeSample>
               <button
                 type="button"
                 class="xy-btn"
@@ -191,9 +209,9 @@ useAppFlasher.warning("Hooray!")</code></pre>
               >
                 Flash Persistent
               </button>
-            </li>
-          </ul>
-        </div>
+            </div>
+          </div>
+        </ProseBase>
       </ComponentLayout>
 
       <ComponentLayout class="mt-8" title="Modal">
@@ -428,14 +446,14 @@ useAppFlasher.warning("Hooray!")</code></pre>
           Overlay components naturally can introduce complications in stacking
           context and z-index for any application. We've made best attempts to
           set sane z-index values on each overlay component in an order that
-          makes sense for the component's general usage. These components are all
-          wrapped in the <code>&lt;Portal /&gt;</code> component made available
-          by HeadlessUI/Vue to ensure they share a stacking context. We've
-          additionally, preserved the highest order z-index (z-50) for consumers
-          when necessary.
+          makes sense for the component's general usage. These components are
+          all wrapped in the <code>&lt;Portal /&gt;</code> component made
+          available by HeadlessUI/Vue to ensure they share a stacking context.
+          We've additionally, preserved the highest order z-index (z-50) for
+          consumers when necessary.
         </template>
 
-        <div class="prose prose-sm">
+        <ProseBase>
           <h4>Tailwind CSS z-index Values</h4>
           <table>
             <thead>
@@ -480,29 +498,29 @@ useAppFlasher.warning("Hooray!")</code></pre>
           <p>
             In the event that you need to establish a z-index level above any of
             the overlay components, you'll need to wrap your component in the
-            HeadlessUI/Vue <code>&lt;Portal /&gt;</code> component. This convenience component is not
-            documented by HeadlessUI, but is effectively a wrapper around the
-            Vue Teleport component. It maintains a single container before the
-            closing body tag and teleports all Portal markup to that location
-            ensuring the same stacking context between those DOM elements.
+            HeadlessUI/Vue <code>&lt;Portal /&gt;</code> component. This
+            convenience component is not documented by HeadlessUI, but is
+            effectively a wrapper around the Vue Teleport component. It
+            maintains a single container before the closing body tag and
+            teleports all Portal markup to that location ensuring the same
+            stacking context between those DOM elements.
           </p>
+          <CodeSample language="html"
+            >{{ `
+            <script lang="ts" setup>
+              import { Portal } from "@headlessui/vue"
+            </script>
 
-          <p>
-            <pre class="overflow-scroll bg-gray-50 p-4">
-<code class="language-typescript">{{`<script lang="ts" setup>
-  import { Portal } from "@headlessui/vue"
-</script>
-
-<template>
-  <Portal>
-    <div class="fixed top-0 left-0 right-0 bottom-0 z-50">
-      <h1>Head and shoulders above the rest!</h1>
-    </div>
-  </Portal>
-</template>`}}</code>
-            </pre>
-          </p>
-        </div>
+            <template>
+              <Portal>
+                <div class="fixed top-0 left-0 right-0 bottom-0 z-50">
+                  <h1>Head and shoulders above the rest!</h1>
+                </div>
+              </Portal>
+            </template>
+            ` }}</CodeSample
+          >
+        </ProseBase>
       </ComponentLayout>
     </div>
   </div>

--- a/dev/content/Tools.vue
+++ b/dev/content/Tools.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import BaseAPI from "./Tools/BaseAPI.vue"
+import UseBaseAPI from "./Tools/UseBaseAPI.vue"
+</script>
+
+<template>
+  <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+    <div class="max-w-3xl mx-auto space-y-8">
+      <BaseAPI />
+      <UseBaseAPI />
+    </div>
+  </div>
+</template>

--- a/dev/content/Tools/BaseAPI.vue
+++ b/dev/content/Tools/BaseAPI.vue
@@ -1,0 +1,218 @@
+<script lang="ts" setup>
+import CodeSample from "../../helpers/CodeSample.vue";
+import ProseBase from "../../helpers/ProseBase.vue"
+</script>
+
+<template>
+  <ComponentLayout :show-badge="false" title="BaseAPI">
+    <template v-slot:description>
+      Need an HTTP client? Don't worry we've got you covered. BaseAPI offers an
+      easy to understand API for making http requests.
+    </template>
+
+    <ProseBase>
+        <h4>The HttpClient Interface</h4>
+        <CodeSample>{{`
+/**
+ * HttpPromise
+ * The successfully resolved interface of an http client request.
+ */
+export interface HttpPromise<T = any> extends Promise<T> {}
+
+/**
+ * QueryParams
+ * Http GET request query params.
+ */
+export type QueryParams = Record<string, any>
+
+/**
+ * ReqPayload
+ * Http POST and PUT payloads.
+ */
+export type ReqPayload = Record<string, any> | FormData
+
+/**
+ * HttpClient
+ * The http client interface the BaseAPI implements.
+ */
+export interface HttpClient {
+  /**
+   * The method to make an http DELETE request.
+   * @param path string
+   * @param opts ReqOptions
+   * @returns HttpPromise<T>
+   */
+  delete<T>(path: string, opts?: ReqOptions): HttpPromise<T>
+  /**
+   * The method to make an http GET request.
+   * @param path string
+   * @param opts ReqOptions
+   * @param params QueryParams
+   * @returns HttpPromise<T>
+   */
+  get<T>(path: string, opts?: ReqOptions, params?: QueryParams): HttpPromise<T>
+  /**
+   * The method to make an http PATCH request.
+   * @param path string
+   * @param data ReqPayload
+   * @param opts ReqOptions
+   */
+  patch<T>(path: string, data?: ReqPayload, opts?: ReqOptions): HttpPromise<T>
+  /**
+   * The method to make an http POST request.
+   * @param path string
+   * @param data ReqPayload
+   * @param opts ReqOptions
+   */
+  post<T>(path: string, data?: ReqPayload, opts?: ReqOptions): HttpPromise<T>
+  /**
+   * The method to make an http PUT request.
+   * @param path string
+   * @param data ReqPayload
+   * @param opts ReqOptions
+   */
+  put<T>(path: string, data?: ReqPayload, opts?: ReqOptions): HttpPromise<T>
+}
+        `}}</CodeSample>
+      
+        <h4>Example Usage</h4>
+        <CodeSample>{{`
+import {
+    BaseAPI,
+    HttpError,
+    isHttpError,
+    TrailsRespPaged
+} from "@xy-planning-network/trees"
+
+interface Conifer {
+  id: number 
+  name: number
+  type: string
+  leaf: {
+    type: string
+    length: string
+  }
+}
+
+// make the api call to your endpoint
+// Note: BaseAPI supports a generic type for the expected response shape
+BaseAPI.get<TrailsRespPaged<Conifer>>("https://my-json-server.typicode.com/xy-planning-network/trees/things", {withDelay: 500}, {query: Date.now()})
+    .then((result) => {
+        // result will be inferred as the shape declared in the generic TrailsRespPaged<Conifer>
+        const {page, totalPages, items} = result
+        console.log(page, totalPages)
+        
+        // tree will be inferred as Confier
+        items.forEach((tree) => {
+            console.log(tree.name)
+        })
+    })
+    .catch((err: HttpError | Error) => {
+        // use the isHttpError type guard to handle http errors
+        if(isHttpError(err)) {
+            // handle http error
+            console.log(err.status)
+        } else {
+          // handle unexpected error  
+        }
+    })
+        `}}</CodeSample>
+
+        <h4>Working with Trails</h4>
+        <p>Trees offers up a number of convenient interfaces for annotating your expected API responses with TypeScript.</p>
+        <CodeSample>{{`
+/**
+ * TrailsPromise
+ * The successfully resolved interface of an http client request returned by @xy-planning-network/Trails.
+ *
+ * Example Usage:
+ * interface User {
+ *     id: number
+ *     email: string
+ * }
+ *
+ * const UsersAPI = {
+ *    update(
+ *      id: number,
+ *      data: ReqPayload,
+ *      opts?: ReqOptions
+ *    ): TrailsPromise<User> {
+ *      return BaseAPI.put<TrailsResp<User>>(\`/users/\${id}\`, data, opts)
+ *    }
+ * }
+ */
+export interface TrailsPromise<T = any> extends Promise<TrailsResp<T>> {}
+
+/**
+ * TrailsPromisePaged
+ * The successfully resolved interface of a paged http client request returned by @xy-planning-network/Trails.
+ *
+ * Example Usage:
+ * interface User {
+ *     id: number
+ *     email: string
+ * }
+ *
+ * const UsersAPI = {
+ *    index(opts?: ReqOptions, params?: QueryParams): TrailsPromisePaged<User> {
+ *    return BaseAPI.get<TrailsRespPaged<User>>("/users", opts, params)
+ *    }
+ * }
+ */
+export interface TrailsPromisePaged<T = any>
+  extends Promise<TrailsRespPaged<T>> {}
+
+/**
+ * TrailsResp
+ * A convenience interface to represent the shape of a Trails delivered API response.
+ *
+ * Example Usage:
+ * interface User {
+ *     id: number
+ *     email: string
+ * }
+ *
+ * BaseAPI.get<TrailsResp<User>>(\`/user/\${id}\`)
+ *     .then((result) => {
+ *         const id = result.data.id
+ *         const email = result.data.email
+ *         const user = result.data
+ *     })
+ */
+export interface TrailsResp<T = any> {
+  data: T
+}
+
+/**
+ * TrailsRespPaged
+ * A convenience interface to represent the shape of a paginated Trails delivered API response.
+ *
+ * Example Usage:
+ * interface User {
+ *     id: number
+ *     email: string
+ * }
+ *
+ * BaseAPI.get<TrailsRespPaged<User>>(\`/users\`)
+ *     .then((result) => {
+ *         const currentPage = result.data.page
+ *         const users = result.data.items
+ *
+ *         users.forEach((u) => {
+ *             console.log(u.id)
+ *         })
+ *     })
+ */
+export interface TrailsRespPaged<T = any> {
+  data: {
+    items: T[]
+    page: number
+    perPage: number
+    totalItems: number
+    totalPages: number
+  }
+}
+        `}}</CodeSample>
+    </ProseBase>
+  </ComponentLayout>
+</template>

--- a/dev/content/Tools/UseBaseAPI.vue
+++ b/dev/content/Tools/UseBaseAPI.vue
@@ -2,8 +2,10 @@
 import { isHttpError } from "@/api/base"
 import { ReqOptions, TrailsRespPaged } from "@/api/client"
 import { computed } from "vue"
-import useBaseAPI from "../../src/composables/useBaseAPI"
-import { debounceLeading } from "../../src/helpers/Debounce"
+import useBaseAPI from "../../../src/composables/useBaseAPI"
+import { debounceLeading } from "../../../src/helpers/Debounce"
+import CodeSample from "../../helpers/CodeSample.vue"
+import ProseBase from "../../helpers/ProseBase.vue"
 
 interface Conifer {
   id: number 
@@ -65,24 +67,79 @@ const buttonTextWithAbort = computed(() => {
 </script>
 
 <template>
-  <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-    <div class="max-w-3xl mx-auto">
+  
       <ComponentLayout :show-badge="false" title="useBaseAPI">
         <template v-slot:description>
-          useBaseAPI wraps up the BaseAPI functionality and returns a bunch of
+          useBaseAPI is a set of composable methods that wrap up the BaseAPI functionality and returns a bunch of
           helpful reactive variables along with an execute and abort methods.
         </template>
 
-        
-          <pre class="overflow-scroll bg-gray-50 p-4">
-            <code class="language-typescript">{{`
-interface TrailsRespPaged<T> {
-  page: number
-  perPage: number
-  totalItems: number
-  totalPages: number
-  items: T[]
+        <ProseBase>
+            <h4>The useBaseAPI Interface</h4>
+            <CodeSample>{{`  
+/**
+ * UseBaseAPIOptions extends Trees/ReqOptions
+ * these options are used only in the instantiation
+ * of a new UseBaseAPI composable
+ */
+export interface UseBaseAPIOptions extends ReqOptions {
+  /**
+   * Whether to immediately fire the execute function during instantiation
+   */
+  immediate?: boolean
 }
+
+/**
+ * UseBaseAPI is a composable the wraps up the
+ * usage of Trees/BaseAPI and returns reactive
+ * state variables along with reusaable execute and abort functions
+ */
+export interface UseBaseAPI<T> {
+  /**
+   * Axios response data
+   */
+  result: Ref<T | undefined>
+  /**
+   * Any errors that may have occurred
+   */
+  error: ShallowRef<Error | HttpError<T> | undefined>
+  /**
+   * Indicates if the request has finished
+   */
+  isFinished: Ref<boolean>
+  /**
+   * Indicates if the request is currently loading
+   */
+  isLoading: Ref<boolean>
+  /**
+   * Indicates if the request was canceled
+   */
+  isAborted: Ref<boolean>
+  /**
+   * Indicates if a first request has completed
+   */
+  hasFetched: Ref<boolean>
+  /**
+   * Aborts the current request
+   * can be used multiple times
+   */
+  abort: () => void
+  /**
+   * Manually call the axios request
+   * can be used multiple times
+   */
+  execute: (payload?: ReqPayload, opts?: ReqOptions) => HttpPromise<T>
+} 
+            `}}</CodeSample>
+
+          <h4>Example Usage</h4>
+            <CodeSample>{{`
+import {
+    useBaseAPI,
+    HttpError,
+    isHttpError,
+    TrailsRespPaged
+} from "@xy-planning-network/trees"
 
 interface Conifer {
   id: number 
@@ -121,8 +178,7 @@ execute({ query: Date.now() }, { withDelay: 3000 })
 const things = computed(() => { 
   return result.value?.items
 })
-  `}}</code>
-        </pre>
+  `}}</CodeSample></ProseBase>
         
         <div class="space-y-4">
           <div class="flex space-x-4">
@@ -175,6 +231,4 @@ const things = computed(() => {
         </ul>
         <p v-else>No trees on these trails.</p>
       </ComponentLayout>
-    </div>
-  </div>
 </template>

--- a/dev/helpers/CodeSample.vue
+++ b/dev/helpers/CodeSample.vue
@@ -1,0 +1,26 @@
+<script lang="ts" setup>
+import { useSlots, computed } from "vue"
+
+withDefaults(defineProps<{ language?: "typescript" | "html" }>(), {
+  language: "typescript",
+})
+
+const slots = useSlots()
+
+const slotText = computed(() => {
+  if (slots.default === undefined) {
+    return ""
+  }
+
+  const raw = slots.default()[0].children
+  if (raw === null || typeof raw !== "string") {
+    return ""
+  }
+
+  return raw
+})
+</script>
+
+<template>
+  <pre><code v-highlight :class="language"><slot v-if="false" />{{slotText}}</code></pre>
+</template>

--- a/dev/helpers/ProseBase.vue
+++ b/dev/helpers/ProseBase.vue
@@ -1,0 +1,3 @@
+<template>
+  <div class="prose prose-base max-w-full"><slot /></div>
+</template>

--- a/dev/libs.d.ts
+++ b/dev/libs.d.ts
@@ -1,0 +1,3 @@
+declare module "@point-hub/vue-highlight"
+declare module "highlight.js/lib/languages/xml"
+declare module "highlight.js/lib/languages/typescript"

--- a/dev/serve.ts
+++ b/dev/serve.ts
@@ -13,12 +13,21 @@ import PropsTable from "./helpers/PropsTable.vue"
 import "./main.css"
 import mitt from "mitt"
 import { useAppFlashes } from "@/composables/useFlashes"
+import Highlight from "@point-hub/vue-highlight"
+import "highlight.js/styles/atom-one-dark.css"
+import html from "highlight.js/lib/languages/xml"
+import typescript from "highlight.js/lib/languages/typescript"
+
+// Register Language
+Highlight.registerLanguage("html", html)
+Highlight.registerLanguage("typescript", typescript)
 
 window.VueBus = mitt()
 useAppFlashes().configure({ email: "support@trees.com" })
 
 const app = createApp(Serve)
 app.use(Trees)
+app.use(Highlight.plugin)
 app.component("ClickToCopy", ClickToCopy)
 app.component("ComponentLayout", ComponentLayout)
 app.component("PropsTable", PropsTable)

--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -20,7 +20,6 @@ import {
   TableIcon,
   UserGroupIcon,
 } from "@heroicons/vue/outline"
-import Composables from "./content/Composables.vue"
 import Elements from "./content/Elements.vue"
 import Forms from "./content/Forms.vue"
 import Home from "./content/Home.vue"
@@ -28,6 +27,7 @@ import Lists from "./content/Lists.vue"
 import Navigation from "./content/Navigation.vue"
 import Overlays from "./content/Overlays.vue"
 import Team from "./content/Team.vue"
+import Tools from "./content/Tools.vue"
 
 const currentPage = ref("Home")
 const currentNav = ref("StackedLayout")
@@ -42,8 +42,8 @@ const navigation = [
   { name: "Lists", url: "/trees/?page=Lists", icon: TableIcon },
   { name: "Overlays", url: "/trees/?page=Overlays", icon: CollectionIcon },
   { name: "Elements", url: "/trees/?page=Elements", icon: ColorSwatchIcon },
+  { name: "Tools", url: "/trees/?page=Additional Tools", icon: PencilAltIcon },
   { name: "Team", url: "/trees/?page=Team", icon: UserGroupIcon },
-  { name: "Composables", url: "/trees/?page=Composables", icon: PencilAltIcon },
 ]
 const user = ref({
   accountID: 1,
@@ -99,8 +99,8 @@ watch(currentPage, () => {
       <Lists v-if="showing('Lists')" :user="user" />
       <Overlays v-if="showing('Overlays')" />
       <Elements v-if="showing('Elements')" />
+      <Tools v-if="showing('Additional Tools')" />
       <Team v-if="showing('Team')" />
-      <Composables v-if="showing('Composables')" />
       <button
         type="button"
         class="xy-btn"

--- a/index.html
+++ b/index.html
@@ -5,11 +5,6 @@
   <meta charset="UTF-8" />
   <link rel="icon" href="/dev/assets/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link href="https://unpkg.com/prismjs@1.28.0/themes/prism.css" rel="stylesheet" crossorigin="anonymous" />
-  <script src="https://unpkg.com/prismjs@1.28.0/components/prism-core.min.js" crossorigin="anonymous"
-    data-manual></script>
-  <script src="https://unpkg.com/prismjs@1.28.0/plugins/autoloader/prism-autoloader.min.js"
-    crossorigin="anonymous"></script>
   <title>Trees Docs</title>
 </head>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.1",
+  "version": "0.6.2-rc-4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.6.1",
+      "version": "0.6.2-rc-4",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.2-rc-7",
+  "version": "0.6.2-rc-8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.6.2-rc-7",
+      "version": "0.6.2-rc-8",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.4.2",
@@ -15,6 +15,7 @@
         "flatpickr": "^4.6.9"
       },
       "devDependencies": {
+        "@point-hub/vue-highlight": "^0.1.4",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/line-clamp": "^0.4.2",
         "@tailwindcss/typography": "^0.5.7",
@@ -229,6 +230,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@point-hub/vue-highlight": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@point-hub/vue-highlight/-/vue-highlight-0.1.4.tgz",
+      "integrity": "sha512-bLk3KwEXDQdBcmgr6aoOzJtCP2DV0gQR9EklbXw48NpZqN8ee2qelOQhjimh6re1Wi7VLm4qpzG+RianWzZ14A==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.6.5",
+        "highlight.js": "^10.2.1",
+        "vue": "^3.0.0-0"
       }
     },
     "node_modules/@tailwindcss/forms": {
@@ -566,7 +578,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.26.tgz",
       "integrity": "sha512-ePpnfktV90UcLdsDQUh2JdiTuhV0Skv2iYXxfNMOK/F3Q+2BO0AulcVcfoksOpTJGmhhfosWfMyEaEf0UaWpIw==",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.26",
@@ -584,7 +595,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.26.tgz",
       "integrity": "sha512-2mywLX0ODc4Zn8qBoA2PDCsLEZfpUGZcyoFRLSOjyGGK6wDy2/5kyDOWtf0S0UvtoyVq95OTSGIALjZ4k2q/ag==",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.2.26",
         "@vue/shared": "3.2.26"
@@ -649,7 +659,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.26.tgz",
       "integrity": "sha512-XKMyuCmzNA7nvFlYhdKwD78rcnmPb7q46uoR00zkX6yZrUmcCQ5OikiwUEVbvNhL5hBJuvbSO95jB5zkUon+eQ==",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.26",
@@ -662,7 +671,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.26.tgz",
       "integrity": "sha512-BcYi7qZ9Nn+CJDJrHQ6Zsmxei2hDW0L6AB4vPvUQGBm2fZyC0GXd/4nVbyA2ubmuhctD5RbYY8L+5GUJszv9mQ==",
-      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.2.26",
         "@vue/shared": "3.2.26"
@@ -672,7 +680,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.26.tgz",
       "integrity": "sha512-dY56UIiZI+gjc4e8JQBwAifljyexfVCkIAu/WX8snh8vSOt/gMSEGwPRcl2UpYpBYeyExV8WCbgvwWRNt9cHhQ==",
-      "peer": true,
       "dependencies": {
         "@vue/runtime-core": "3.2.26",
         "@vue/shared": "3.2.26",
@@ -683,7 +690,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.26.tgz",
       "integrity": "sha512-Jp5SggDUvvUYSBIvYEhy76t4nr1vapY/FIFloWmQzn7UxqaHrrBpbxrqPcTrSgGrcaglj0VBp22BKJNre4aA1w==",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.2.26",
         "@vue/shared": "3.2.26"
@@ -1200,6 +1206,17 @@
         "copyup": "copyfiles"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+      "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -1235,8 +1252,7 @@
     "node_modules/csstype": {
       "version": "2.6.19",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
-      "peer": true
+      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ=="
     },
     "node_modules/debug": {
       "version": "4.3.3",
@@ -2732,6 +2748,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -3227,7 +3252,6 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "peer": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -4191,8 +4215,7 @@
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "peer": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -4825,7 +4848,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.26.tgz",
       "integrity": "sha512-KD4lULmskL5cCsEkfhERVRIOEDrfEL9CwAsLYpzptOGjaGFNWo3BQ9g8MAb7RaIO71rmVOziZ/uEN/rHwcUIhg==",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.2.26",
         "@vue/compiler-sfc": "3.2.26",
@@ -5168,6 +5190,17 @@
         "fastq": "^1.6.0"
       }
     },
+    "@point-hub/vue-highlight": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@point-hub/vue-highlight/-/vue-highlight-0.1.4.tgz",
+      "integrity": "sha512-bLk3KwEXDQdBcmgr6aoOzJtCP2DV0gQR9EklbXw48NpZqN8ee2qelOQhjimh6re1Wi7VLm4qpzG+RianWzZ14A==",
+      "dev": true,
+      "requires": {
+        "core-js": "^3.6.5",
+        "highlight.js": "^10.2.1",
+        "vue": "^3.0.0-0"
+      }
+    },
     "@tailwindcss/forms": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.3.tgz",
@@ -5417,7 +5450,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.26.tgz",
       "integrity": "sha512-ePpnfktV90UcLdsDQUh2JdiTuhV0Skv2iYXxfNMOK/F3Q+2BO0AulcVcfoksOpTJGmhhfosWfMyEaEf0UaWpIw==",
-      "peer": true,
       "requires": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.26",
@@ -5435,7 +5467,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.26.tgz",
       "integrity": "sha512-2mywLX0ODc4Zn8qBoA2PDCsLEZfpUGZcyoFRLSOjyGGK6wDy2/5kyDOWtf0S0UvtoyVq95OTSGIALjZ4k2q/ag==",
-      "peer": true,
       "requires": {
         "@vue/compiler-dom": "3.2.26",
         "@vue/shared": "3.2.26"
@@ -5482,7 +5513,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.26.tgz",
       "integrity": "sha512-XKMyuCmzNA7nvFlYhdKwD78rcnmPb7q46uoR00zkX6yZrUmcCQ5OikiwUEVbvNhL5hBJuvbSO95jB5zkUon+eQ==",
-      "peer": true,
       "requires": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.26",
@@ -5495,7 +5525,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.26.tgz",
       "integrity": "sha512-BcYi7qZ9Nn+CJDJrHQ6Zsmxei2hDW0L6AB4vPvUQGBm2fZyC0GXd/4nVbyA2ubmuhctD5RbYY8L+5GUJszv9mQ==",
-      "peer": true,
       "requires": {
         "@vue/reactivity": "3.2.26",
         "@vue/shared": "3.2.26"
@@ -5505,7 +5534,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.26.tgz",
       "integrity": "sha512-dY56UIiZI+gjc4e8JQBwAifljyexfVCkIAu/WX8snh8vSOt/gMSEGwPRcl2UpYpBYeyExV8WCbgvwWRNt9cHhQ==",
-      "peer": true,
       "requires": {
         "@vue/runtime-core": "3.2.26",
         "@vue/shared": "3.2.26",
@@ -5516,7 +5544,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.26.tgz",
       "integrity": "sha512-Jp5SggDUvvUYSBIvYEhy76t4nr1vapY/FIFloWmQzn7UxqaHrrBpbxrqPcTrSgGrcaglj0VBp22BKJNre4aA1w==",
-      "peer": true,
       "requires": {
         "@vue/compiler-ssr": "3.2.26",
         "@vue/shared": "3.2.26"
@@ -5887,6 +5914,12 @@
         "yargs": "^16.1.0"
       }
     },
+    "core-js": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+      "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -5913,8 +5946,7 @@
     "csstype": {
       "version": "2.6.19",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==",
-      "peer": true
+      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ=="
     },
     "debug": {
       "version": "4.3.3",
@@ -6940,6 +6972,12 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -7310,7 +7348,6 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "peer": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -8007,8 +8044,7 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "peer": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -8498,7 +8534,6 @@
       "version": "3.2.26",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.26.tgz",
       "integrity": "sha512-KD4lULmskL5cCsEkfhERVRIOEDrfEL9CwAsLYpzptOGjaGFNWo3BQ9g8MAb7RaIO71rmVOziZ/uEN/rHwcUIhg==",
-      "peer": true,
       "requires": {
         "@vue/compiler-dom": "3.2.26",
         "@vue/compiler-sfc": "3.2.26",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.2-rc-4",
+  "version": "0.6.2-rc-7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.6.2-rc-4",
+      "version": "0.6.2-rc-7",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.1",
+  "version": "0.6.2-rc-4",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.2-rc-4",
+  "version": "0.6.2-rc-7",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.2-rc-7",
+  "version": "0.6.2-rc-8",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",
@@ -33,6 +33,7 @@
     "typecheck:docs": "vue-tsc -p dev --noEmit"
   },
   "devDependencies": {
+    "@point-hub/vue-highlight": "^0.1.4",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
     "@tailwindcss/typography": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "lint": "eslint --ext .js,.ts,.vue src",
     "lint:fix": "eslint --fix --ext .js,.ts,.vue src dev && prettier -w -u src dev",
     "preview": "vite preview --config vite.docs.config.ts",
-    "typecheck": "vue-tsc -p src --noEmit"
+    "typecheck": "npm run typecheck:src && npm run typecheck:docs",
+    "typecheck:src": "vue-tsc -p src --noEmit",
+    "typecheck:docs": "vue-tsc -p dev --noEmit"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -121,25 +121,6 @@ const BaseAPI: HttpClient = {
 export default BaseAPI
 
 /**
- * A convenience method for checking if a variable in a failed request has an http status code.
- * This is most useful for checking for specific http status codes in error callbacks.
- * @param err unknown
- * @param codes number | number[]
- * @returns boolean
- */
-export const hasHttpErrStatus = (err: unknown, codes: number | number[]) => {
-  if (typeof codes === "number") {
-    codes = [codes]
-  }
-
-  if (isHttpError(err)) {
-    return codes.includes(err.status)
-  }
-
-  return false
-}
-
-/**
  * A type guard for checking if a variable is in the shape of a HttpError
  * @param err unknown
  * @returns err is HttpError

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -104,6 +104,13 @@ const BaseAPI: HttpClient = {
   isHttpError(err: unknown): err is HttpError {
     return err instanceof HttpError
   },
+  patch<T = any>(
+    path: string,
+    data: Record<string, unknown> | FormData,
+    opts?: RequestOptions
+  ) {
+    return httpRequest<T>({ url: path, data, method: "PATCH" }, opts || {})
+  },
   post<T = any>(
     path: string,
     data: Record<string, unknown> | FormData,

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -78,15 +78,15 @@ export const httpRequest = <T = any>(
 }
 
 const BaseAPI: HttpClient = {
+  delete<T = any>(path: string, opts?: RequestOptions) {
+    return httpRequest<T>({ url: path, method: "DELETE" }, opts || {})
+  },
   get<T = any>(
     path: string,
     opts?: RequestOptions,
     params?: Record<string, unknown>
   ) {
     return httpRequest<T>({ url: path, method: "GET", params }, opts || {})
-  },
-  delete<T = any>(path: string, opts?: RequestOptions) {
-    return httpRequest<T>({ url: path, method: "DELETE" }, opts || {})
   },
   patch<T = any>(
     path: string,

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,20 +1,20 @@
 import axios, { AxiosResponse, AxiosRequestConfig } from "axios"
 import {
-  HTTP_CANCELLED_ERROR,
-  HTTP_ERROR,
+  HTTP_ERR_CANCEL,
+  HTTP_ERR,
   HttpClient,
   HttpError,
   HttpPromise,
-  RequestOptions,
+  ReqOptions,
 } from "./client"
 import { useAppSpinner } from "@/composables/useSpinner"
 
 /**
- * apiDelayIntercept delays the request of an api call by the configured withDelay value in RequestOptions
- * @param config RequestOptions
- * @returns RequestOptions
+ * apiDelayIntercept delays the request of an api call by the configured withDelay value in ReqOptions
+ * @param config ReqOptions
+ * @returns ReqOptions
  */
-const apiDelayReqIntercept = (config: RequestOptions & AxiosRequestConfig) => {
+const apiDelayReqIntercept = (config: ReqOptions & AxiosRequestConfig) => {
   const delay = config.withDelay || 0
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -34,9 +34,9 @@ apiAxiosInstance.interceptors.request.use(apiDelayReqIntercept)
 
 export const httpRequest = <T = any>(
   config: AxiosRequestConfig,
-  opts: RequestOptions
+  opts: ReqOptions
 ): HttpPromise<T> => {
-  const options: RequestOptions = {
+  const options: ReqOptions = {
     skipLoader: false,
     withDelay: 0,
     ...opts,
@@ -58,7 +58,7 @@ export const httpRequest = <T = any>(
           err.message,
           err.response?.status,
           err.response?.data,
-          axios.isCancel(err) ? HTTP_CANCELLED_ERROR : HTTP_ERROR
+          axios.isCancel(err) ? HTTP_ERR_CANCEL : HTTP_ERR
         )
       }
 
@@ -78,12 +78,12 @@ export const httpRequest = <T = any>(
 }
 
 const BaseAPI: HttpClient = {
-  delete<T = any>(path: string, opts?: RequestOptions) {
+  delete<T = any>(path: string, opts?: ReqOptions) {
     return httpRequest<T>({ url: path, method: "DELETE" }, opts || {})
   },
   get<T = any>(
     path: string,
-    opts?: RequestOptions,
+    opts?: ReqOptions,
     params?: Record<string, unknown>
   ) {
     return httpRequest<T>({ url: path, method: "GET", params }, opts || {})
@@ -91,21 +91,21 @@ const BaseAPI: HttpClient = {
   patch<T = any>(
     path: string,
     data: Record<string, unknown> | FormData,
-    opts?: RequestOptions
+    opts?: ReqOptions
   ) {
     return httpRequest<T>({ url: path, data, method: "PATCH" }, opts || {})
   },
   post<T = any>(
     path: string,
     data: Record<string, unknown> | FormData,
-    opts?: RequestOptions
+    opts?: ReqOptions
   ) {
     return httpRequest<T>({ url: path, data, method: "POST" }, opts || {})
   },
   put<T = any>(
     path: string,
     data: Record<string, unknown> | FormData,
-    opts?: RequestOptions
+    opts?: ReqOptions
   ) {
     return httpRequest<T>(
       {
@@ -135,5 +135,5 @@ export const isHttpError = <T>(err: unknown): err is HttpError<T> => {
  * @returns boolean
  */
 export const isHttpCancel = (err: unknown): boolean => {
-  return isHttpError(err) && err.name === HTTP_CANCELLED_ERROR
+  return isHttpError(err) && err.name === HTTP_ERR_CANCEL
 }

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -101,7 +101,7 @@ const BaseAPI: HttpClient = {
   isHttpCancel(err: unknown): boolean {
     return this.isHttpError(err) && err.name === HTTP_CANCELLED_ERROR
   },
-  isHttpError(err: unknown): err is HttpError {
+  isHttpError<T>(err: unknown): err is HttpError<T> {
     return err instanceof HttpError
   },
   patch<T = any>(

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -64,12 +64,40 @@ export interface HttpPromise<T = any> extends Promise<T> {}
 /**
  * TrailsPromise
  * The successfully resolved interface of an http client request returned by @xy-planning-network/Trails.
+ *
+ * Example Usage:
+ * interface User {
+ *     id: number
+ *     email: string
+ * }
+ *
+ * const UsersAPI = {
+ *    update(
+ *      id: number,
+ *      data: ReqPayload,
+ *      opts?: ReqOptions
+ *    ): TrailsPromise<User> {
+ *      return BaseAPI.put<TrailsResp<User>>(`/users/${id}`, data, opts)
+ *    }
+ * }
  */
 export interface TrailsPromise<T = any> extends Promise<TrailsResp<T>> {}
 
 /**
  * TrailsPromisePaged
  * The successfully resolved interface of a paged http client request returned by @xy-planning-network/Trails.
+ *
+ * Example Usage:
+ * interface User {
+ *     id: number
+ *     email: string
+ * }
+ *
+ * const UsersAPI = {
+ *    index(opts?: ReqOptions, params?: QueryParams): TrailsPromisePaged<User> {
+ *    return BaseAPI.get<TrailsRespPaged<User>>("/users", opts, params)
+ *    }
+ * }
  */
 export interface TrailsPromisePaged<T = any>
   extends Promise<TrailsRespPaged<T>> {}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -161,7 +161,7 @@ export interface HttpClient {
    * @param err unknown
    * @returns payload is HttpError
    */
-  isHttpError(err: unknown): err is HttpError
+  isHttpError<T>(err: unknown): err is HttpError<T>
   /**
    * A convenience method for checking if a variable is a cancelled http request error.
    * @param err unknown

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -62,6 +62,19 @@ export class HttpError<T = unknown> extends Error {
 export interface HttpPromise<T = any> extends Promise<T> {}
 
 /**
+ * TrailsPromise
+ * The successfully resolved interface of an http client request returned by @xy-planning-network/Trails.
+ */
+export interface TrailsPromise<T = any> extends Promise<TrailsResponse<T>> {}
+
+/**
+ * TrailsPromisePaged
+ * The successfully resolved interface of a paged http client request returned by @xy-planning-network/Trails.
+ */
+export interface TrailsPromisePaged<T = any>
+  extends Promise<TrailsResponsePaged<T>> {}
+
+/**
  * TrailsResponse
  * A convenience interface to represent the shape of a Trails delivered API response.
  *

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -85,10 +85,10 @@ export interface TrailsPromisePaged<T = any>
  * }
  *
  * BaseAPI.get<TrailsResponse<User>>(`/user/${id}`)
- *     .then(result => {
+ *     .then((result) => {
  *         const id = result.data.id
  *         const email = result.data.email
- *         const user = { ...result.data }
+ *         const user = result.data
  *     })
  */
 export interface TrailsResponse<T = any> {
@@ -106,11 +106,11 @@ export interface TrailsResponse<T = any> {
  * }
  *
  * BaseAPI.get<TrailsResponsePaged<User>>(`/users`)
- *     .then(result => {
+ *     .then((result) => {
  *         const currentPage = result.data.page
- *         const users = { ...result.data.items }
+ *         const users = result.data.items
  *
- *         result.data.items.forEach(u => {
+ *         users.forEach((u) => {
  *             console.log(u.id)
  *         })
  *     })

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -5,6 +5,8 @@
 export type RequestMethod =
   | "GET"
   | "get"
+  | "PATCH"
+  | "patch"
   | "PUT"
   | "put"
   | "POST"
@@ -166,6 +168,17 @@ export interface HttpClient {
    * @returns boolean
    */
   isHttpCancel(err: unknown): boolean
+  /**
+   * The method to make an http PATCH request.
+   * @param path string
+   * @param data RequestPayload
+   * @param opts RequestOptions
+   */
+  patch<T>(
+    path: string,
+    data?: RequestPayload,
+    opts?: RequestOptions
+  ): HttpPromise<T>
   /**
    * The method to make an http POST request.
    * @param path string

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,191 @@
+/**
+ * RequestMethod
+ * The HTTP request methods that our http client supports.
+ */
+export type RequestMethod =
+  | "GET"
+  | "get"
+  | "PUT"
+  | "put"
+  | "POST"
+  | "post"
+  | "DELETE"
+  | "delete"
+
+/**
+ * RequestOptions
+ * The set of options available for any http client request.
+ */
+export interface RequestOptions {
+  /**
+   * Disable the full screen loading interface during the request when true.
+   */
+  skipLoader?: boolean
+  /**
+   * Artificially delay a request by the time specified when set.
+   */
+  withDelay?: number
+}
+
+export const HTTP_ERROR = "HttpError"
+export const HTTP_CANCELLED_ERROR = "HttpCanceledError"
+
+/**
+ * HttpError
+ * An http client error when the request is rejected.
+ */
+export class HttpError<T = unknown> extends Error {
+  /**
+   * The http response status code.
+   */
+  status: number
+
+  /**
+   * The http response body.
+   */
+  response?: T
+
+  constructor(message?: string, status?: number, response?: T, name?: string) {
+    super(message || "")
+    this.name = name || HTTP_ERROR
+    this.status = status || 0
+    this.response = response
+  }
+}
+
+/**
+ * HttpPromise
+ * The successfully resolved interface of an http client request.
+ */
+export interface HttpPromise<T = any> extends Promise<T> {}
+
+/**
+ * TrailsResponse
+ * A convenience interface to represent the shape of a Trails delivered API response.
+ *
+ * Example Usage:
+ * interface User {
+ *     id: number
+ *     email: string
+ * }
+ *
+ * BaseAPI.get<TrailsResponse<User>>(`/user/${id}`)
+ *     .then(result => {
+ *         const id = result.data.id
+ *         const email = result.data.email
+ *         const user = { ...result.data }
+ *     })
+ */
+export interface TrailsResponse<T = any> {
+  data: T
+}
+
+/**
+ * TrailsResponsePaged
+ * A convenience interface to represent the shape of a paginated Trails delivered API response.
+ *
+ * Example Usage:
+ * interface User {
+ *     id: number
+ *     email: string
+ * }
+ *
+ * BaseAPI.get<TrailsResponsePaged<User>>(`/users`)
+ *     .then(result => {
+ *         const currentPage = result.data.page
+ *         const users = { ...result.data.items }
+ *
+ *         result.data.items.forEach(u => {
+ *             console.log(u.id)
+ *         })
+ *     })
+ */
+export interface TrailsResponsePaged<T = any> {
+  data: {
+    items: T[]
+    page: number
+    perPage: number
+    totalItems: number
+    totalPages: number
+  }
+}
+
+/**
+ * QueryParams
+ * Http GET request query params.
+ */
+export type QueryParams = Record<string, any>
+
+/**
+ * RequestPayload
+ * Http POST and PUT payloads.
+ */
+export type RequestPayload = Record<string, any> | FormData
+
+/**
+ * HttpClient
+ * The http client interface the BaseAPI implements.
+ */
+export interface HttpClient {
+  /**
+   * The method to make an http GET request.
+   * @param path string
+   * @param opts RequestOptions
+   * @param params QueryParams
+   * @returns HttpPromise<T>
+   */
+  get<T>(
+    path: string,
+    opts?: RequestOptions,
+    params?: QueryParams
+  ): HttpPromise<T>
+  /**
+   * The method to make an http DELETE request.
+   * @param path string
+   * @param opts RequestOptions
+   * @returns HttpPromise<T>
+   */
+  delete<T>(path: string, opts?: RequestOptions): HttpPromise<T>
+  /**
+   * A convenience method for checking if a variable in a failed request has an http status code.
+   * This is most useful for checking for specific http status codes in error callbacks.
+   * @param err unknown
+   * @param codes number | number[]
+   * @returns boolean
+   */
+  hasErrStatus(err: unknown, codes: number | number[]): boolean
+  /**
+   * A type guard for checking if a variable is in the shape of a HttpError
+   * @param err unknown
+   * @returns payload is HttpError
+   */
+  isHttpError(err: unknown): err is HttpError
+  /**
+   * A convenience method for checking if a variable is a cancelled http request error.
+   * @param err unknown
+   * @returns boolean
+   */
+  isHttpCancel(err: unknown): boolean
+  /**
+   * The method to make an http POST request.
+   * @param path string
+   * @param data RequestPayload
+   * @param opts RequestOptions
+   */
+  post<T>(
+    path: string,
+    data?: RequestPayload,
+    opts?: RequestOptions
+  ): HttpPromise<T>
+  /**
+   * The method to make an http PUT request.
+   * @param path string
+   * @param data RequestPayload
+   * @param opts RequestOptions
+   */
+  put<T>(
+    path: string,
+    data?: RequestPayload,
+    opts?: RequestOptions
+  ): HttpPromise<T>
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -162,26 +162,6 @@ export interface HttpClient {
    */
   delete<T>(path: string, opts?: RequestOptions): HttpPromise<T>
   /**
-   * A convenience method for checking if a variable in a failed request has an http status code.
-   * This is most useful for checking for specific http status codes in error callbacks.
-   * @param err unknown
-   * @param codes number | number[]
-   * @returns boolean
-   */
-  hasErrStatus(err: unknown, codes: number | number[]): boolean
-  /**
-   * A type guard for checking if a variable is in the shape of a HttpError
-   * @param err unknown
-   * @returns payload is HttpError
-   */
-  isHttpError<T>(err: unknown): err is HttpError<T>
-  /**
-   * A convenience method for checking if a variable is a cancelled http request error.
-   * @param err unknown
-   * @returns boolean
-   */
-  isHttpCancel(err: unknown): boolean
-  /**
    * The method to make an http PATCH request.
    * @param path string
    * @param data RequestPayload

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,8 +1,8 @@
 /**
- * RequestMethod
+ * ReqMethod
  * The HTTP request methods that our http client supports.
  */
-export type RequestMethod =
+export type ReqMethod =
   | "DELETE"
   | "delete"
   | "GET"
@@ -15,10 +15,10 @@ export type RequestMethod =
   | "put"
 
 /**
- * RequestOptions
+ * ReqOptions
  * The set of options available for any http client request.
  */
-export interface RequestOptions {
+export interface ReqOptions {
   /**
    * Disable the full screen loading interface during the request when true.
    */
@@ -29,8 +29,8 @@ export interface RequestOptions {
   withDelay?: number
 }
 
-export const HTTP_ERROR = "HttpError"
-export const HTTP_CANCELLED_ERROR = "HttpCanceledError"
+export const HTTP_ERR = "HttpError"
+export const HTTP_ERR_CANCEL = "HttpErrorCanceled"
 
 /**
  * HttpError
@@ -49,7 +49,7 @@ export class HttpError<T = unknown> extends Error {
 
   constructor(message?: string, status?: number, response?: T, name?: string) {
     super(message || "")
-    this.name = name || HTTP_ERROR
+    this.name = name || HTTP_ERR
     this.status = status || 0
     this.response = response
   }
@@ -65,17 +65,17 @@ export interface HttpPromise<T = any> extends Promise<T> {}
  * TrailsPromise
  * The successfully resolved interface of an http client request returned by @xy-planning-network/Trails.
  */
-export interface TrailsPromise<T = any> extends Promise<TrailsResponse<T>> {}
+export interface TrailsPromise<T = any> extends Promise<TrailsResp<T>> {}
 
 /**
  * TrailsPromisePaged
  * The successfully resolved interface of a paged http client request returned by @xy-planning-network/Trails.
  */
 export interface TrailsPromisePaged<T = any>
-  extends Promise<TrailsResponsePaged<T>> {}
+  extends Promise<TrailsRespPaged<T>> {}
 
 /**
- * TrailsResponse
+ * TrailsResp
  * A convenience interface to represent the shape of a Trails delivered API response.
  *
  * Example Usage:
@@ -84,19 +84,19 @@ export interface TrailsPromisePaged<T = any>
  *     email: string
  * }
  *
- * BaseAPI.get<TrailsResponse<User>>(`/user/${id}`)
+ * BaseAPI.get<TrailsResp<User>>(`/user/${id}`)
  *     .then((result) => {
  *         const id = result.data.id
  *         const email = result.data.email
  *         const user = result.data
  *     })
  */
-export interface TrailsResponse<T = any> {
+export interface TrailsResp<T = any> {
   data: T
 }
 
 /**
- * TrailsResponsePaged
+ * TrailsRespPaged
  * A convenience interface to represent the shape of a paginated Trails delivered API response.
  *
  * Example Usage:
@@ -105,7 +105,7 @@ export interface TrailsResponse<T = any> {
  *     email: string
  * }
  *
- * BaseAPI.get<TrailsResponsePaged<User>>(`/users`)
+ * BaseAPI.get<TrailsRespPaged<User>>(`/users`)
  *     .then((result) => {
  *         const currentPage = result.data.page
  *         const users = result.data.items
@@ -115,7 +115,7 @@ export interface TrailsResponse<T = any> {
  *         })
  *     })
  */
-export interface TrailsResponsePaged<T = any> {
+export interface TrailsRespPaged<T = any> {
   data: {
     items: T[]
     page: number
@@ -132,10 +132,10 @@ export interface TrailsResponsePaged<T = any> {
 export type QueryParams = Record<string, any>
 
 /**
- * RequestPayload
+ * ReqPayload
  * Http POST and PUT payloads.
  */
-export type RequestPayload = Record<string, any> | FormData
+export type ReqPayload = Record<string, any> | FormData
 
 /**
  * HttpClient
@@ -145,53 +145,37 @@ export interface HttpClient {
   /**
    * The method to make an http DELETE request.
    * @param path string
-   * @param opts RequestOptions
+   * @param opts ReqOptions
    * @returns HttpPromise<T>
    */
-  delete<T>(path: string, opts?: RequestOptions): HttpPromise<T>
+  delete<T>(path: string, opts?: ReqOptions): HttpPromise<T>
   /**
    * The method to make an http GET request.
    * @param path string
-   * @param opts RequestOptions
+   * @param opts ReqOptions
    * @param params QueryParams
    * @returns HttpPromise<T>
    */
-  get<T>(
-    path: string,
-    opts?: RequestOptions,
-    params?: QueryParams
-  ): HttpPromise<T>
+  get<T>(path: string, opts?: ReqOptions, params?: QueryParams): HttpPromise<T>
   /**
    * The method to make an http PATCH request.
    * @param path string
-   * @param data RequestPayload
-   * @param opts RequestOptions
+   * @param data ReqPayload
+   * @param opts ReqOptions
    */
-  patch<T>(
-    path: string,
-    data?: RequestPayload,
-    opts?: RequestOptions
-  ): HttpPromise<T>
+  patch<T>(path: string, data?: ReqPayload, opts?: ReqOptions): HttpPromise<T>
   /**
    * The method to make an http POST request.
    * @param path string
-   * @param data RequestPayload
-   * @param opts RequestOptions
+   * @param data ReqPayload
+   * @param opts ReqOptions
    */
-  post<T>(
-    path: string,
-    data?: RequestPayload,
-    opts?: RequestOptions
-  ): HttpPromise<T>
+  post<T>(path: string, data?: ReqPayload, opts?: ReqOptions): HttpPromise<T>
   /**
    * The method to make an http PUT request.
    * @param path string
-   * @param data RequestPayload
-   * @param opts RequestOptions
+   * @param data ReqPayload
+   * @param opts ReqOptions
    */
-  put<T>(
-    path: string,
-    data?: RequestPayload,
-    opts?: RequestOptions
-  ): HttpPromise<T>
+  put<T>(path: string, data?: ReqPayload, opts?: ReqOptions): HttpPromise<T>
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,16 +3,16 @@
  * The HTTP request methods that our http client supports.
  */
 export type RequestMethod =
+  | "DELETE"
+  | "delete"
   | "GET"
   | "get"
   | "PATCH"
   | "patch"
-  | "PUT"
-  | "put"
   | "POST"
   | "post"
-  | "DELETE"
-  | "delete"
+  | "PUT"
+  | "put"
 
 /**
  * RequestOptions
@@ -38,14 +38,14 @@ export const HTTP_CANCELLED_ERROR = "HttpCanceledError"
  */
 export class HttpError<T = unknown> extends Error {
   /**
-   * The http response status code.
-   */
-  status: number
-
-  /**
    * The http response body.
    */
   response?: T
+
+  /**
+   * The http response status code.
+   */
+  status: number
 
   constructor(message?: string, status?: number, response?: T, name?: string) {
     super(message || "")
@@ -143,6 +143,13 @@ export type RequestPayload = Record<string, any> | FormData
  */
 export interface HttpClient {
   /**
+   * The method to make an http DELETE request.
+   * @param path string
+   * @param opts RequestOptions
+   * @returns HttpPromise<T>
+   */
+  delete<T>(path: string, opts?: RequestOptions): HttpPromise<T>
+  /**
    * The method to make an http GET request.
    * @param path string
    * @param opts RequestOptions
@@ -154,13 +161,6 @@ export interface HttpClient {
     opts?: RequestOptions,
     params?: QueryParams
   ): HttpPromise<T>
-  /**
-   * The method to make an http DELETE request.
-   * @param path string
-   * @param opts RequestOptions
-   * @returns HttpPromise<T>
-   */
-  delete<T>(path: string, opts?: RequestOptions): HttpPromise<T>
   /**
    * The method to make an http PATCH request.
    * @param path string

--- a/src/composables/useBaseAPI.ts
+++ b/src/composables/useBaseAPI.ts
@@ -104,7 +104,9 @@ export default function useBaseAPI<T = any>(
     isLoading.value = true
 
     const requestConfig = {
-      data: ["POST", "post", "PUT", "put"].includes(method) ? data : {},
+      data: ["PATCH", "patch", "POST", "post", "PUT", "put"].includes(method)
+        ? data
+        : {},
       method: method,
       params: ["GET", "get"].includes(method) ? data : {},
       signal: controller.signal,
@@ -184,6 +186,20 @@ export function useBaseAPIDelete<T = any>(
   opts: UseBaseAPIOptions = {}
 ): UseBaseAPI<T> {
   return useBaseAPI<T>(url, "DELETE", opts)
+}
+
+/**
+ * useBaseAPIPatch is a convenience function for useBaseAPI
+ * @param path {string} the api path or full url for the
+ * @param initOpts {UseBaseAPIOptions}
+ * @param initConfig {AxiosRequestConfig}
+ * @returns {UseBaseAPI<T>}
+ */
+export function useBaseAPIPatch<T = any>(
+  url: string,
+  opts: UseBaseAPIOptions = {}
+): UseBaseAPI<T> {
+  return useBaseAPI<T>(url, "PATCH", opts)
 }
 
 /**

--- a/src/composables/useBaseAPI.ts
+++ b/src/composables/useBaseAPI.ts
@@ -1,5 +1,5 @@
 import { ref, Ref, shallowRef, ShallowRef } from "vue"
-import BaseAPI, { httpRequest } from "../api/base"
+import { httpRequest, isHttpCancel } from "../api/base"
 import type {
   HttpPromise,
   HttpError,
@@ -124,7 +124,7 @@ export default function useBaseAPI<T = any>(
         (err) => {
           error.value = err
 
-          if (BaseAPI.isHttpCancel(err)) {
+          if (isHttpCancel(err)) {
             isAborted.value = true
           }
 

--- a/src/composables/useBaseAPI.ts
+++ b/src/composables/useBaseAPI.ts
@@ -59,7 +59,7 @@ export interface UseBaseAPI<T> {
    * Manually call the axios request
    * can be used multiple times
    */
-  execute: (data?: ReqPayload, opts?: ReqOptions) => HttpPromise<T>
+  execute: (payload?: ReqPayload, opts?: ReqOptions) => HttpPromise<T>
 }
 
 /**

--- a/src/composables/useBaseAPI.ts
+++ b/src/composables/useBaseAPI.ts
@@ -3,17 +3,17 @@ import { httpRequest, isHttpCancel } from "../api/base"
 import type {
   HttpPromise,
   HttpError,
-  RequestMethod,
-  RequestOptions,
-  RequestPayload,
+  ReqMethod,
+  ReqOptions,
+  ReqPayload,
 } from "../api/client"
 
 /**
- * UseBaseAPIOptions extends Trees/RequestOptions
+ * UseBaseAPIOptions extends Trees/ReqOptions
  * these options are used only in the instantiation
  * of a new UseBaseAPI composable
  */
-export interface UseBaseAPIOptions extends RequestOptions {
+export interface UseBaseAPIOptions extends ReqOptions {
   /**
    * Whether to immediately fire the execute function during instantiation
    */
@@ -59,20 +59,20 @@ export interface UseBaseAPI<T> {
    * Manually call the axios request
    * can be used multiple times
    */
-  execute: (data?: RequestPayload, opts?: RequestOptions) => HttpPromise<T>
+  execute: (data?: ReqPayload, opts?: ReqOptions) => HttpPromise<T>
 }
 
 /**
  * useBaseAPI is a composable wrapper of BaseAPI
  * @param path {string} the api path or full url for the
- * @param method {RequestMethod} the initial request type
+ * @param method {ReqMethod} the initial request type
  * @param initOpts {UseBaseAPIOptions}
  * @param initConfig {AxiosRequestConfig}
  * @returns {UseBaseAPI<T>}
  */
 export default function useBaseAPI<T = any>(
   path: string,
-  method: RequestMethod = "GET",
+  method: ReqMethod = "GET",
   initOpts: UseBaseAPIOptions = {}
 ): UseBaseAPI<T> {
   const result = ref<T | undefined>()
@@ -92,7 +92,7 @@ export default function useBaseAPI<T = any>(
 
   const execute = (
     data: Record<string, unknown> | FormData = {},
-    opts: RequestOptions = {}
+    opts: ReqOptions = {}
   ): Promise<T> => {
     requestCount++
     const count = requestCount

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -3,7 +3,9 @@ import BaseAPI from "@/api/base"
 import type {
   HttpPromise,
   HttpError,
+  QueryParams,
   RequestOptions,
+  RequestPayload,
   TrailsResponse,
   TrailsResponsePaged,
 } from "@/api/client"
@@ -34,7 +36,9 @@ export { BaseAPI }
 export type {
   HttpPromise,
   HttpError,
+  QueryParams,
   RequestOptions,
+  RequestPayload,
   TrailsResponse,
   TrailsResponsePaged,
 }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,9 +1,5 @@
 import { App, Plugin } from "vue"
-import BaseAPI, {
-  hasHttpErrStatus,
-  isHttpCancel,
-  isHttpError,
-} from "@/api/base"
+import BaseAPI, { isHttpCancel, isHttpError } from "@/api/base"
 import type {
   HttpPromise,
   HttpError,
@@ -39,7 +35,7 @@ export * from "@/composables/index"
 export * from "@/lib-components/index"
 
 // Http Client exports
-export { BaseAPI, hasHttpErrStatus, isHttpCancel, isHttpError }
+export { BaseAPI, isHttpCancel, isHttpError }
 export type {
   HttpPromise,
   HttpError,

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,6 +1,12 @@
 import { App, Plugin } from "vue"
 import BaseAPI from "@/api/base"
-import type { RequestOptions } from "@/api/base"
+import type {
+  HttpPromise,
+  HttpError,
+  RequestOptions,
+  TrailsResponse,
+  TrailsResponsePaged,
+} from "@/api/client"
 
 // Import vue components
 import * as components from "@/lib-components/index"
@@ -25,4 +31,10 @@ export * from "@/composables/index"
 export * from "@/lib-components/index"
 
 export { BaseAPI }
-export type { RequestOptions }
+export type {
+  HttpPromise,
+  HttpError,
+  RequestOptions,
+  TrailsResponse,
+  TrailsResponsePaged,
+}

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,5 +1,9 @@
 import { App, Plugin } from "vue"
-import BaseAPI from "@/api/base"
+import BaseAPI, {
+  hasHttpErrStatus,
+  isHttpCancel,
+  isHttpError,
+} from "@/api/base"
 import type {
   HttpPromise,
   HttpError,
@@ -34,7 +38,8 @@ export * from "@/composables/index"
 // each can be registered via Vue.component()
 export * from "@/lib-components/index"
 
-export { BaseAPI }
+// Http Client exports
+export { BaseAPI, hasHttpErrStatus, isHttpCancel, isHttpError }
 export type {
   HttpPromise,
   HttpError,

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -6,6 +6,8 @@ import type {
   QueryParams,
   RequestOptions,
   RequestPayload,
+  TrailsPromise,
+  TrailsPromisePaged,
   TrailsResponse,
   TrailsResponsePaged,
 } from "@/api/client"
@@ -39,6 +41,8 @@ export type {
   QueryParams,
   RequestOptions,
   RequestPayload,
+  TrailsPromise,
+  TrailsPromisePaged,
   TrailsResponse,
   TrailsResponsePaged,
 }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -4,12 +4,12 @@ import type {
   HttpPromise,
   HttpError,
   QueryParams,
-  RequestOptions,
-  RequestPayload,
+  ReqOptions,
+  ReqPayload,
   TrailsPromise,
   TrailsPromisePaged,
-  TrailsResponse,
-  TrailsResponsePaged,
+  TrailsResp,
+  TrailsRespPaged,
 } from "@/api/client"
 
 // Import vue components
@@ -40,10 +40,10 @@ export type {
   HttpPromise,
   HttpError,
   QueryParams,
-  RequestOptions,
-  RequestPayload,
+  ReqOptions,
+  ReqPayload,
   TrailsPromise,
   TrailsPromisePaged,
-  TrailsResponse,
-  TrailsResponsePaged,
+  TrailsResp,
+  TrailsRespPaged,
 }

--- a/src/lib-components/lists/Table.vue
+++ b/src/lib-components/lists/Table.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { AxiosResponse } from "axios"
 import {
   ComponentPublicInstance,
   computed,
@@ -12,6 +11,7 @@ import Paginator from "../navigation/Paginator.vue"
 import BaseAPI from "../../api/base"
 import * as TableTypes from "@/composables/table"
 import { useAppFlasher } from "@/composables/useFlashes"
+import { TrailsResponsePaged } from "@/api/client"
 
 const props = withDefaults(
   defineProps<{
@@ -96,8 +96,12 @@ const loadAndRender = (): void => {
     q: query.value,
   }
 
-  BaseAPI.get(props.tableData.url, { skipLoader: !props.loader }, params).then(
-    (success: AxiosResponse) => {
+  BaseAPI.get<TrailsResponsePaged<unknown>>(
+    props.tableData.url,
+    { skipLoader: !props.loader },
+    params
+  ).then(
+    (success) => {
       pagination.value = {
         page: success.data.page,
         perPage: success.data.perPage,

--- a/src/lib-components/lists/Table.vue
+++ b/src/lib-components/lists/Table.vue
@@ -11,7 +11,7 @@ import Paginator from "../navigation/Paginator.vue"
 import BaseAPI from "../../api/base"
 import * as TableTypes from "@/composables/table"
 import { useAppFlasher } from "@/composables/useFlashes"
-import { TrailsResponsePaged } from "@/api/client"
+import { TrailsRespPaged } from "@/api/client"
 
 const props = withDefaults(
   defineProps<{
@@ -96,7 +96,7 @@ const loadAndRender = (): void => {
     q: query.value,
   }
 
-  BaseAPI.get<TrailsResponsePaged<unknown>>(
+  BaseAPI.get<TrailsRespPaged<unknown>>(
     props.tableData.url,
     { skipLoader: !props.loader },
     params

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig",
   "compilerOptions": {
     "declaration": true,
-    "outDir": "../types"
+    "outDir": "../types",
   },
   "include": [
     "./**/*.ts",


### PR DESCRIPTION
# What this does

- Establishes an interface for an `HttpClient` along with convenience interfaces for common Trails response bodies.
- Refactors `BaseAPI` to fulfill the `HttpClient` interface and avoids exposing the library backing the implementation.
- Refactors `useBaseAPI` to mirror `BaseAPI` methods and implementation.
- Provides helper functions and type guards to aid in error checking Promise rejections.
- Removes the `dataIntercept` option from `RequestOptions` interface.
- Adds an `HttpError` class to replace the `AxiosError` interface that was previously received in promise rejections.
- Adds a `patch` request method to the `HttpClient` interface.
- Loosens the type alias for `QueryParams` and `RequestPayload`.
- Sets the `RequestOptions` argument to optional in all `HttpClient` methods.

# What this does not do

I did not choose to create an HttpClient response interface that includes the response status code.  There did not appear to be enough interest in the group to support this, and its use cases were limited.  The side effect would have been a complex response interface that has properties that are rarely if ever accessed after the promise is resolved.  Making the majority of cases more cumbersome than necesary.

# Why

In short, we've been annotating return values and promise results incorrectly when we used BaseAPI.  Let's see how.

__api/users.ts__  

This is a fairly common pattern where we've wrapped up the `BaseAPI.get` method in `UsersAPI.get` and we've annotated that the return value is an `AxiosPromise`.  This is our most common mistake.

```ts
import { AxiosPromise } from "axios"
import { BaseAPI } from "@xy-planning-network/trees"
import { RequestOptions } from "@xy-planning-network/trees/types/api/base"

const UsersAPI = {
  get(opts?: RequestOptions): AxiosPromise {
    return BaseAPI.get("/users", opts || {})
  },
}
```

If we remove `AxiosPromise` and let inference do the work for us, we can see that we're actually getting `Promise<any>`.

<img width="742" alt="Screenshot 2023-01-05 at 5 22 11 PM" src="https://user-images.githubusercontent.com/3856703/210898860-ccf1bf8e-bbd8-4a00-ba33-e0fcbf61a33a.png">

So why doesn't Typescript flag this?  The `AxiosPromise` type definition simply extends `Promise`, so they overlap!  But there is one important distinction.  `AxiosPromise` wraps the `Promise<T>` generic in an `AxiosResponse<T>`.  Where `<T>` is the expected shape of the response body.

```ts
export interface AxiosPromise<T = any> extends Promise<AxiosResponse<T>> {}

// notice that T is mapped to the data property of the AxiosResponse interface
export interface AxiosResponse<T = any, D = any>  {
  data: T;
  status: number;
  statusText: string;
  headers: AxiosResponseHeaders;
  config: AxiosRequestConfig<D>;
  request?: any;
}
```

This exposes two problems.  The first is that without declaring the shape of T the result variable of our resolved promise becomes `AxiosResponse<any, any>`.  This means we've effectively disabled type checking on the data property, so typescript will let us attempt to access anything we want on `result.data`.  

The second issue is that, `BaseAPI` doesn't actually return the full `AxiosResponse`.  It returns only the value of the data property and throws the rest away.

```ts
UsersAPI.get()
  .then((result) => {
    // Typescript is happy to let you do this even though headers and status are undefined properties
    const { data, headers, status } = result

    // Typescript will also let you do this because data: any
    // I'm not saying we shouldn't have an interface with a fuManchu property, but definitely don't yet.
    const { id, fuManchu } = data
  })
  .catch((e) => console.log(e))
```

### Why has this been working?

Because all of our responses from Trails are in a shape that includes a top level data property.  Which is a property available on `AxiosResponse`, and luckily we've not been caught out attempting to access a property on data that doesn't exist on the expected result.  I chalk this up to how client side dev work is done, with real time feedback and adjusting according to those runtime errors vs. depending on Typescript to point out issues for us.

```ts
// This is how our responses come in.
interface TrailsResponse<T> {
    data: T
}
```

### What should we be doing

We should do two things.  The first is to stop using `AxiosPromise` to annotate return values and instead allow inference to do the work for us, which is a good practice in general.  Let inference work, it keeps the code cleaner and easier to read and ensures you have the actual return value, provided that value can be inferred.

The second is that we should leverage type generics to define the expected shape of our response payload and avoid results that are typed as `any`.  This will save us grief down the road.  It's much easier to update an interface, run the type check to find the failed property access and update them accordingly, than it is to try and search and replace or update.  It should also speed up dev workflows, inside your `then` block your result variable will be ready to auto complete any properties declared on your interface and ensure that when you are assigning it to an existing variable outside the scope of that block, that it is a valid assignment.  Think `const user = ref<User>()` and `user.value = result.data`.

### How do we update for this change?

It's actually pretty straightforward.  Every `BaseAPI` accepts a generic type definition, you just need to use it.  The hardest part is just ensuring you declare the correct response interface there.  Most commonly, you'll need to wrap it in a `TrailsResponse<T>` interface when your request is hitting our own API endpoints.

```ts
import {
  BaseAPI,
  RequestOptions,
  TrailsResponse,
} from "@xy-planning-network/trees"
import User from "@/types/user"

const UsersAPI = {
  get(opts?: RequestOptions) {
    return BaseAPI.get<TrailsResponse<User>>("/users", opts)
  },
}
```

Typescript is now ready to be helpful.  Sorry, no fuManchu for you.

<img width="978" alt="Screenshot 2023-01-05 at 6 07 08 PM" src="https://user-images.githubusercontent.com/3856703/210903390-c6645869-a847-4354-b7a2-ca957795134e.png">

### Okay, what about error handling

As discussed, we'll take the pragmatic approach to annotating promise rejections as `HttpError | Error` - this process would be known as "type narrowing" which is still much better than accepting `any`.  If you are interested enough, you can deep dive into Typescripts decision to mark `try/catch` error variables as `unknown` but leave promise rejections as `any`.

Provided the response code is 2xx and the response payload matches the definition we provided, this shouldn't error.

```ts
import { ref } from "vue"
import {
  BaseAPI,
  HttpError,
  RequestOptions,
  TrailsResponse,
} from "@xy-planning-network/trees"
import User from "@/types/user"

const UsersAPI = {
  get(opts?: RequestOptions) {
    return BaseAPI.get<TrailsResponse<User>>("/users", opts)
  },
}

const id = ref<number>(0)

UsersAPI.get()
  .then((result) => {
    id.value = result.data.id
  })
  .catch((e: HttpError | Error) => {
    console.log(e)
  })
```

Let's imagine we received a 401 unauthorized status code, and we want to check against that:

```ts
UsersAPI.get()
  .then((result) => {
    id.value = result.data.id
  })
  .catch((e: HttpError | Error) => {
    if (hasHttpErrStatus(e, 401)) {
      // do something meaningful here
    }
    
    console.log(e)
  })
```

If you want to access the status and response properties on the `HttpError` use the available type guard `isHttpError`.  This is a user defined type guard.  It appears to return a boolean, but what it actually does is assert that `e` is in fact an `HttpError` and inside the scope of the conditional block you can safely access the properties available on `HttpError`.  Outside that block, `e` may still be an `Error` type, so `status` access is prohibited.


```ts
UsersAPI.get()
  .then((result) => {
    id.value = result.data.id
  })
  .catch((e: HttpError | Error) => {
    if (isHttpError(e)) {
      // This is an HttpError!
      console.log(e.status)
    }

    console.log(e)
  })
```

Most errors will be `HttpErrors`, but we can't safely assume that all will be.  This is especially true in more complex promise chains where somewhere up the chain a rejection that is not, when we don't leverage type generics and access a property on a result that doesn't exist, or when a response interface changes on the server, but the client interface isn't aware.

```ts
UsersAPI.get()
  .then((result) => {
    const { fuManchu } = result.data
  })
  .catch((e: HttpError | Error) => {
    // Error: fuManchu does not exist
    console.log(e)
  })
```

## How to review this:

- Start by looking through the interface and type declarations in `src/api/client.ts`, specifically the `HttpClient` interface.  This should help you get a baseline for what working with BaseAPI will feel like.  You should notice very little has changed there.
- Next look closely at the additional convenience interfaces like `HttpPromise`, `TrailsPromise`, `TrailsResponse` etc. It may be hard to make sense of them at first, since using generic has not been a common practice, but most we're pretty heavily thought out or derived while updating existing apps.  Now is a good time to nitpick names and descriptions for clarity and intuitiveness.
- Jump into the implementation of BaseAPI, again not much has actually changed here, but inspect how it handles errors from axios and note the addition of 3 functions, two helpers and a type guard.