### PR TITLE
RadioCards: when disabled, has a regular cursor

### DIFF
--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -118,7 +118,7 @@ const nameAttr = computed(() => {
           :class="[
             checked ? 'border-transparent' : 'border-gray-300',
             active ? 'border-blue-500 ring-2 ring-blue-500' : '',
-            disabled ? 'cursor-auto opacity-75' : '',
+            disabled ? 'cursor-not-allowed opacity-75' : '',
           ]"
         >
           <div class="flex-1 flex pr-1">

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -114,11 +114,11 @@ const nameAttr = computed(() => {
         v-slot="{ active, checked, disabled }"
       >
         <div
+          class="relative bg-white border rounded-lg shadow-sm p-4 flex cursor-pointer focus:outline-none"
           :class="[
             checked ? 'border-transparent' : 'border-gray-300',
             active ? 'border-blue-500 ring-2 ring-blue-500' : '',
-            'relative bg-white border rounded-lg shadow-sm p-4 flex cursor-pointer focus:outline-none',
-            disabled ? 'opacity-75' : '',
+            disabled ? 'cursor-auto opacity-75' : '',
           ]"
         >
           <div class="flex-1 flex pr-1">


### PR DESCRIPTION
Opted for the regular cursor instead of `cursor-not-allowed`. Personally, not a huge fan of that cursor style and encourages someone to think something's broken or not in an expected state.