### PR TITLE
fix: v-model number directive not applying on BaseInput component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xy-planning-network/trees",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
         "@headlessui/vue": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xy-planning-network/trees",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "",
   "license": "MIT",
   "repository": "github:xy-planning-network/trees",

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -19,7 +19,7 @@ const props = withDefaults(
   }
 )
 
-const emit = defineEmits(["update:model-value"])
+const emit = defineEmits(["update:modelValue"])
 
 const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
 
@@ -80,7 +80,7 @@ const isTextType = computed((): boolean => {
     :value="modelValue"
     v-bind="$attrs"
     @input="
-      emit('update:model-value', ($event.target as HTMLInputElement).value)
+      emit('update:modelValue', ($event.target as HTMLInputElement).value)
     "
   />
   <InputHelp :id="`${uuid}-help`" :text="help"></InputHelp>

--- a/src/lib-components/forms/TextArea.vue
+++ b/src/lib-components/forms/TextArea.vue
@@ -16,7 +16,7 @@ withDefaults(
   }
 )
 const attrs = useAttrs()
-const emit = defineEmits(["update:model-value"])
+const emit = defineEmits(["update:modelValue"])
 const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
 </script>
 
@@ -47,7 +47,7 @@ const uuid = (attrs.id as string) || Uniques.CreateIdAttribute()
     :value="modelValue"
     v-bind="$attrs"
     @input="
-      emit('update:model-value', ($event.target as HTMLInputElement).value)
+      emit('update:modelValue', ($event.target as HTMLInputElement).value)
     "
   />
   <InputHelp :id="`${uuid}-help`" :text="help"></InputHelp>


### PR DESCRIPTION
A poor search and replace on `@update:model-value` listeners resulted in redefining emitted events from `defineEmits(["update:modelValue"])` to `defineEmits(["update:model-value"])`. The v-model directives are not applied in the later case.

The `BaseInput` and `TextArea` components appeared to be the only components affected.

I'll plan to follow this up with an eslint rule to enforce some consistency in the event names and have it error when `update:model-value` is used.  An existing optional rule in `vue/eslint`, unfortunately, considers `update:model-value` as valid and doesn't appear to be a suitable option.