### PR TITLE
integrate floating UI's useFloating composable on Popover, Tooltip, and ActionsDropdown

### DIFF
--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -68,7 +68,7 @@ const popoverProps = [
   {
     name: "position",
     required: false,
-    type: "PopoverPosition - default: undefined",
+    type: "PopoverPosition - default: auto",
   },
 ]
 
@@ -81,7 +81,7 @@ const tooltipProps = [
   {
     name: "position",
     required: false,
-    type: "PopoverPosition - default: undefined",
+    type: "PopoverPosition - default: auto",
   },
 ]
 
@@ -427,7 +427,7 @@ useAppFlasher.info("Sticky!", true)
               href="https://floating-ui.com/docs/autoplacement"
               >autoPlacement</a
             >
-            middleware It will be used anytime the position prop is undefined.
+            middleware It will be used anytime the position prop is "auto".
           </p>
           <div class="grid gap-4 grid-cols-5">
             <div v-for="index in 5" :key="index">

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -2,11 +2,11 @@
 import { ref } from "vue"
 import { CheckIcon } from "@heroicons/vue/outline"
 import { ExclamationIcon } from "@heroicons/vue/outline"
-import { PopoverPosition } from "@/lib-components/overlays/Popover/Popover.vue"
 import { useAppFlasher } from "@/composables/useFlashes"
 import { useAppSpinner } from "@/composables"
 import ProseBase from "../helpers/ProseBase.vue"
 import CodeSample from "../helpers/CodeSample.vue"
+import type { Placement } from "@floating-ui/vue"
 
 const contentModalCopy = `<ContentModal v-model="open" :content="content" :title="title"></ContentModal>`
 
@@ -44,15 +44,19 @@ const spinner = function (): void {
   }, 15000)
 }
 
-const popoverPositions: PopoverPosition[] = [
-  "top-left",
-  "top-center",
-  "top-right",
-  "bottom-left",
-  "bottom-center",
-  "bottom-right",
-  "left",
+const popoverPositions: Placement[] = [
+  "top",
   "right",
+  "bottom",
+  "left",
+  "top-start",
+  "top-end",
+  "right-start",
+  "right-end",
+  "bottom-start",
+  "bottom-end",
+  "left-start",
+  "left-end",
 ]
 
 const popoverProps = [
@@ -64,7 +68,7 @@ const popoverProps = [
   {
     name: "position",
     required: false,
-    type: "PopoverPosition - default: auto",
+    type: "PopoverPosition - default: undefined",
   },
 ]
 
@@ -77,7 +81,7 @@ const tooltipProps = [
   {
     name: "position",
     required: false,
-    type: "PopoverPosition - default: auto",
+    type: "PopoverPosition - default: undefined",
   },
 ]
 
@@ -359,7 +363,7 @@ useAppFlasher.info("Sticky!", true)
           </div>
 
           <div class="mt-8 flex justify-center">
-            <Popover>
+            <Popover position="bottom">
               <template #button>
                 <span class="xy-btn">Hi, hello, nice to meet you...</span>
               </template>
@@ -417,11 +421,13 @@ useAppFlasher.info("Sticky!", true)
 
         <div class="mt-8">
           <p class="mb-4">
-            <strong>Auto positioning</strong> favors left to right positioning.
-            i.e. if there appears to be space available to the right of the
-            trigger the tooltip content will flow toward the right. Top and
-            bottom positioning is prioritized by the current viewport, giving
-            preference where more visible space currently exists.
+            <strong>Auto positioning</strong> is managed by floating-ui's
+            <a
+              class="text-xy-blue underline"
+              href="https://floating-ui.com/docs/autoplacement"
+              >autoPlacement</a
+            >
+            middleware It will be used anytime the position prop is undefined.
           </p>
           <div class="grid gap-4 grid-cols-5">
             <div v-for="index in 5" :key="index">

--- a/dev/content/Overlays.vue
+++ b/dev/content/Overlays.vue
@@ -470,8 +470,8 @@ useAppFlasher.info("Sticky!", true)
             </thead>
             <tbody>
               <tr>
-                <td>Popover/Tooltip</td>
-                <td>z-10</td>
+                <td>Popover/Tooltip/ActionsDropdown</td>
+                <td>z-[5]</td>
               </tr>
               <tr>
                 <td>App Sidebar Mobile Nav</td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.6.7",
       "license": "MIT",
       "dependencies": {
+        "@floating-ui/vue": "^1.0.1",
         "@headlessui/vue": "^1.4.2",
         "@heroicons/vue": "^1.0.5",
         "axios": "^0.27.2",
@@ -468,6 +469,53 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-vX1WVAdPjZg9DkDkC+zEx/tKtnST6/qcNpwcjeBgco3XRNHz5PUA+ivi/yr6G3o0kMR60uKBJcfOdfzOFI7PMQ=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.3.0.tgz",
+      "integrity": "sha512-qIAwejE3r6NeA107u4ELDKkH8+VtgRKdXqtSPaKflL2S2V+doyN+Wt9s5oHKXPDo4E8TaVXaHT3+6BbagH31xw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.3.0"
+      }
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.0.1.tgz",
+      "integrity": "sha512-HZmmNWaztKYKOQxXvMzJYCYtfgG07cL/bPQvZ92AFG3Ktw71bvvLKXsZDAyIxGpqRo9WiTPsYknnSuLV2H/riA==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.2.9",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
+      "integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@headlessui/vue": {
@@ -4000,6 +4048,36 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
       "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
       "dev": true
+    },
+    "@floating-ui/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-vX1WVAdPjZg9DkDkC+zEx/tKtnST6/qcNpwcjeBgco3XRNHz5PUA+ivi/yr6G3o0kMR60uKBJcfOdfzOFI7PMQ=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.3.0.tgz",
+      "integrity": "sha512-qIAwejE3r6NeA107u4ELDKkH8+VtgRKdXqtSPaKflL2S2V+doyN+Wt9s5oHKXPDo4E8TaVXaHT3+6BbagH31xw==",
+      "requires": {
+        "@floating-ui/core": "^1.3.0"
+      }
+    },
+    "@floating-ui/vue": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.0.1.tgz",
+      "integrity": "sha512-HZmmNWaztKYKOQxXvMzJYCYtfgG07cL/bPQvZ92AFG3Ktw71bvvLKXsZDAyIxGpqRo9WiTPsYknnSuLV2H/riA==",
+      "requires": {
+        "@floating-ui/dom": "^1.2.9",
+        "vue-demi": ">=0.13.0"
+      },
+      "dependencies": {
+        "vue-demi": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
+          "integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
+          "requires": {}
+        }
+      }
     },
     "@headlessui/vue": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "vue-tsc": "^1.2.0"
   },
   "dependencies": {
+    "@floating-ui/vue": "^1.0.1",
     "@headlessui/vue": "^1.4.2",
     "@heroicons/vue": "^1.0.5",
     "axios": "^0.27.2",

--- a/src/lib-components/navigation/ActionsDropdown.vue
+++ b/src/lib-components/navigation/ActionsDropdown.vue
@@ -3,7 +3,8 @@ import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue"
 import { DotsVerticalIcon } from "@heroicons/vue/solid"
 import type { ActionItem } from "@/composables/nav"
 import { useActionItems } from "@/composables/useActionItems"
-import { toRef } from "vue"
+import { ref, toRef } from "vue"
+import { useFloating, autoUpdate } from "@floating-ui/vue"
 
 const props = withDefaults(
   defineProps<{
@@ -15,10 +16,19 @@ const props = withDefaults(
 )
 
 const { actions, hasActions } = useActionItems(toRef(props, "actions"))
+
+const trigger = ref<HTMLElement | null>(null)
+const wrapper = ref<HTMLElement | null>(null)
+const { floatingStyles } = useFloating(trigger, wrapper, {
+  placement: "bottom-end",
+  strategy: "fixed",
+  whileElementsMounted: autoUpdate,
+})
 </script>
 <template>
   <Menu as="div" class="relative flex justify-end items-center">
     <MenuButton
+      ref="trigger"
       class="w-8 h-8 bg-white inline-flex items-center justify-center text-gray-700 rounded-full hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
       :disabled="!hasActions"
     >
@@ -33,35 +43,37 @@ const { actions, hasActions } = useActionItems(toRef(props, "actions"))
       leave-from-class="transform opacity-100 scale-100"
       leave-to-class="transform opacity-0 scale-95"
     >
-      <MenuItems
-        class="z-10 mx-3 origin-top-right absolute right-7 top-0 w-48 mt-1 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 divide-y divide-gray-200 focus:outline-none"
-      >
-        <div class="py-1">
-          <template v-for="(action, idx) in actions" :key="idx">
-            <MenuItem v-slot="{ active }: { active: boolean }" as="div">
-              <button
-                type="submit"
-                :disabled="action.disabled"
-                :class="[
-                  active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
-                  'block w-full text-left px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed',
-                ]"
-                @click="action.onClick"
-              >
-                <span class="relative inline-flex items-center gap-x-1.5">
-                  <component
-                    :is="action.icon"
-                    v-if="action.icon"
-                    class="-ml-0.5 h-4 w-4 text-gray-400"
-                    aria-hidden="true"
-                  />
-                  {{ action.label }}
-                </span>
-              </button>
-            </MenuItem>
-          </template>
-        </div>
-      </MenuItems>
+      <div ref="wrapper" class="z-10" :style="floatingStyles">
+        <MenuItems
+          class="w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 divide-y divide-gray-200 focus:outline-none"
+        >
+          <div class="py-1">
+            <template v-for="(action, idx) in actions" :key="idx">
+              <MenuItem v-slot="{ active }: { active: boolean }" as="div">
+                <button
+                  type="submit"
+                  :disabled="action.disabled"
+                  :class="[
+                    active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                    'block w-full text-left px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed',
+                  ]"
+                  @click="action.onClick"
+                >
+                  <span class="relative inline-flex items-center gap-x-1.5">
+                    <component
+                      :is="action.icon"
+                      v-if="action.icon"
+                      class="-ml-0.5 h-4 w-4 text-gray-400"
+                      aria-hidden="true"
+                    />
+                    {{ action.label }}
+                  </span>
+                </button>
+              </MenuItem>
+            </template>
+          </div>
+        </MenuItems>
+      </div>
     </transition>
   </Menu>
 </template>

--- a/src/lib-components/navigation/ActionsDropdown.vue
+++ b/src/lib-components/navigation/ActionsDropdown.vue
@@ -43,7 +43,7 @@ const { floatingStyles } = useFloating(trigger, wrapper, {
       leave-from-class="transform opacity-100 scale-100"
       leave-to-class="transform opacity-0 scale-95"
     >
-      <div ref="wrapper" class="z-10" :style="floatingStyles">
+      <div ref="wrapper" class="z-[5]" :style="floatingStyles">
         <MenuItems
           class="w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 divide-y divide-gray-200 focus:outline-none"
         >

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -1,229 +1,59 @@
-<script lang="ts">
-export type PopoverPosition =
-  | "top-left"
-  | "top-center"
-  | "top-right"
-  | "bottom-left"
-  | "bottom-center"
-  | "bottom-right"
-  | "left"
-  | "right"
-  | "auto"
-  | "none"
-</script>
 <script lang="ts" setup>
-import { throttle } from "@/helpers/Throttle"
 import {
   Popover as HeadlessPopover,
   PopoverButton as HeadlessPopoverButton,
   PopoverPanel as HeadlessPopoverPanel,
 } from "@headlessui/vue"
-import { computed, onMounted, onUnmounted, ref } from "vue"
+import { computed, ref } from "vue"
+import {
+  useFloating,
+  offset,
+  autoPlacement,
+  autoUpdate,
+  shift,
+} from "@floating-ui/vue"
+import type { Placement } from "@floating-ui/vue"
 
 const props = withDefaults(
   defineProps<{
     as?: string
-    position?: PopoverPosition
+    position?: Placement
   }>(),
   {
     as: "div",
-    position: "auto",
+    position: undefined,
   }
 )
 
-const getViewportDimensions = () => {
-  return {
-    vw: document.documentElement.clientWidth,
-    vh: document.documentElement.clientHeight,
-  }
-}
-
-const trigger = ref<typeof HeadlessPopoverButton>()
-const wrapper = ref<typeof HeadlessPopoverPanel>()
-const viewport = ref<{ vw: number; vh: number }>(getViewportDimensions())
-
-const classes = computed(() => {
-  const classes = {
-    wrapper: "",
-    content: "",
+const trigger = ref<HTMLElement | null>(null)
+const wrapper = ref<HTMLElement | null>(null)
+const middleware = computed(() => {
+  const middleware = [offset(5), shift()]
+  if (!props.position) {
+    middleware.push(autoPlacement())
   }
 
-  if (props.position === "none") {
-    return classes
-  }
-
-  // defaults classes when positioning
-  classes.wrapper = "h-0 flex w-screen"
-  classes.content = "absolute"
-
-  // merge static positioning classes
-  if (props.position !== "auto") {
-    classes.wrapper += ` ${staticPosition.value.wrapper}`
-    classes.content += ` ${staticPosition.value.content}`
-  }
-
-  return classes
+  return middleware
 })
 
-const staticPosition = computed(() => {
-  let wrapperClasses = ""
-  let contentClasses = ""
-
-  switch (props.position) {
-    case "top-left":
-      wrapperClasses = "top-0 right-0 -translate-y-full justify-end"
-      contentClasses = "bottom-full"
-      break
-    case "top-center":
-      wrapperClasses =
-        "top-0 -translate-y-full -translate-x-full left-1/2 justify-end"
-      contentClasses = "bottom-full translate-x-1/2"
-      break
-    case "top-right":
-      wrapperClasses =
-        "top-0 -translate-y-full left-0 -translate-x-full justify-end"
-      contentClasses = "bottom-full translate-x-full"
-      break
-    case "bottom-left":
-      wrapperClasses = "top-full right-0 justify-end"
-      contentClasses = "top-full"
-      break
-    case "bottom-center":
-      wrapperClasses = "top-full -translate-x-full left-1/2 justify-end"
-      contentClasses = "top-full translate-x-1/2"
-      break
-    case "bottom-right":
-      wrapperClasses = "top-full left-0 -translate-x-full justify-end"
-      contentClasses = "top-full translate-x-full"
-      break
-    case "left":
-      wrapperClasses =
-        "top-1/2 left-0 -translate-y-1/2 -translate-x-full justify-end"
-      contentClasses = "-translate-y-1/2"
-      break
-    case "right":
-      wrapperClasses = "top-1/2 -translate-y-1/2 right-0 justify-end"
-      contentClasses = "translate-x-full -translate-y-1/2"
-      break
-  }
-
-  return {
-    wrapper: wrapperClasses,
-    content: contentClasses,
-  }
+const { floatingStyles } = useFloating(trigger, wrapper, {
+  middleware: middleware,
+  placement: props.position,
+  strategy: "fixed",
+  whileElementsMounted: autoUpdate,
 })
-
-const autoPosition = computed(() => {
-  if (!wrapper?.value?.el || !trigger?.value?.el) {
-    return {}
-  }
-
-  const { vw, vh } = viewport.value
-
-  // avoid bumping up against the edge of the browser when possible
-  const offset = 10
-
-  // base the anchor rectangle off of the entire trigger dom element to move around it
-  const anchorRect: DOMRect = trigger.value.el.getBoundingClientRect()
-  // the content rectangle is best calculated by our first child (content) element inside the wrapper
-  const contentRect: DOMRect =
-    wrapper.value.el.firstChild.getBoundingClientRect()
-  const distToBottom = vh - anchorRect.bottom
-  // NOTE: edge case - there may be more space below in the viewport
-  // but less document space for display
-  // the inverse could also be true - but will be very rare
-  // occurring with unreasonably large popover content
-  const positionAbove = anchorRect.top > distToBottom
-  const distToRight = vw - anchorRect.left
-  const flowLeft = anchorRect.left > distToRight
-
-  // translate the content container on the x axis to the correct position
-  // considering the flow the content should take
-  let xPos = 0
-  if (flowLeft) {
-    if (contentRect.width > anchorRect.right) {
-      xPos =
-        anchorRect.right -
-        contentRect.width +
-        (contentRect.width - anchorRect.right)
-    } else {
-      xPos = anchorRect.right - contentRect.width
-    }
-
-    if (vw > contentRect.width + offset) {
-      xPos = xPos + offset
-    }
-  } else {
-    if (contentRect.width > distToRight) {
-      xPos = anchorRect.left - (contentRect.width - distToRight)
-    } else {
-      xPos = anchorRect.left
-    }
-
-    if (vw > contentRect.width + offset) {
-      xPos = xPos - offset
-    }
-  }
-
-  return {
-    wrapper: {
-      top: positionAbove ? "auto" : `100%`,
-      bottom: positionAbove ? "100%" : `auto`,
-      transform: `translate(${anchorRect.left * -1}px, 0)`, // pin to left of window
-      width: `${vw}px`,
-    },
-    content: {
-      top: positionAbove ? "auto" : `100%`,
-      bottom: positionAbove ? "100%" : `auto`,
-      transform: `translate(${xPos}px, 0)`,
-    },
-  }
-})
-
-if (props.position === "auto") {
-  const throttledSetPositions = throttle(() => {
-    viewport.value = getViewportDimensions()
-  })
-
-  onMounted(() => {
-    window.addEventListener("resize", throttledSetPositions)
-    window.addEventListener("scroll", throttledSetPositions)
-  })
-
-  onUnmounted(() => {
-    window.removeEventListener("resize", throttledSetPositions)
-    window.removeEventListener("scroll", throttledSetPositions)
-  })
-}
 </script>
 
 <template>
-  <HeadlessPopover v-slot="{ open, close }" class="relative flex" :as="as">
+  <HeadlessPopover v-slot="{ open, close }" :as="as" class="relative">
     <HeadlessPopoverButton ref="trigger">
       <slot name="button" :open="open" :close="close"></slot>
     </HeadlessPopoverButton>
 
-    <transition
-      enter-active-class="transition-opacity transition-faster ease-out-quad"
-      leave-active-class="transition-opacity transition-fastest ease-in-quad"
-      enter-from-class="opacity-0"
-      enter-to-class="opacity-100"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-0"
-    >
-      <HeadlessPopoverPanel
-        ref="wrapper"
-        class="absolute z-10"
-        :class="classes.wrapper"
-        :style="position === 'auto' ? autoPosition.wrapper : {}"
-      >
-        <div
-          :class="classes.content"
-          :style="position === 'auto' ? autoPosition.content : {}"
-        >
-          <slot :open="open" :close="close"></slot>
-        </div>
+    <div ref="wrapper" class="z-10" :style="floatingStyles">
+      <HeadlessPopoverPanel>
+        <slot :open="open" :close="close"></slot>
       </HeadlessPopoverPanel>
-    </transition>
+    </div>
   </HeadlessPopover>
 </template>

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -50,7 +50,7 @@ const { floatingStyles } = useFloating(trigger, wrapper, {
       <slot name="button" :open="open" :close="close"></slot>
     </HeadlessPopoverButton>
 
-    <div ref="wrapper" class="z-10" :style="floatingStyles">
+    <div ref="wrapper" class="z-[5]" :style="floatingStyles">
       <HeadlessPopoverPanel>
         <slot :open="open" :close="close"></slot>
       </HeadlessPopoverPanel>

--- a/src/lib-components/overlays/Popover/Popover.vue
+++ b/src/lib-components/overlays/Popover/Popover.vue
@@ -17,11 +17,11 @@ import type { Placement } from "@floating-ui/vue"
 const props = withDefaults(
   defineProps<{
     as?: string
-    position?: Placement
+    position?: Placement | "auto"
   }>(),
   {
     as: "div",
-    position: undefined,
+    position: "auto",
   }
 )
 
@@ -29,16 +29,28 @@ const trigger = ref<HTMLElement | null>(null)
 const wrapper = ref<HTMLElement | null>(null)
 const middleware = computed(() => {
   const middleware = [offset(5), shift()]
-  if (!props.position) {
+  if (props.position === "auto") {
     middleware.push(autoPlacement())
   }
 
   return middleware
 })
 
+/**
+ * floating-ui's placement property does not support a direct "auto"
+ * mode. Passing undefined is expected when auto position is used.
+ */
+const placement = computed(() => {
+  if (props.position === "auto") {
+    return undefined
+  }
+
+  return props.position
+})
+
 const { floatingStyles } = useFloating(trigger, wrapper, {
   middleware: middleware,
-  placement: props.position,
+  placement: placement,
   strategy: "fixed",
   whileElementsMounted: autoUpdate,
 })

--- a/src/lib-components/overlays/Tooltip.vue
+++ b/src/lib-components/overlays/Tooltip.vue
@@ -8,11 +8,11 @@ import type { Placement } from "@floating-ui/vue"
 withDefaults(
   defineProps<{
     as?: string
-    position?: Placement
+    position?: Placement | "auto"
   }>(),
   {
     as: "span",
-    position: undefined,
+    position: "auto",
   }
 )
 

--- a/src/lib-components/overlays/Tooltip.vue
+++ b/src/lib-components/overlays/Tooltip.vue
@@ -1,17 +1,18 @@
 <script lang="ts" setup>
-import Popover, { PopoverPosition } from "./Popover/Popover.vue"
+import Popover from "./Popover/Popover.vue"
 import { InformationCircleIcon } from "@heroicons/vue/outline"
 import { ref } from "vue"
+import type { Placement } from "@floating-ui/vue"
 
 // props
 withDefaults(
   defineProps<{
     as?: string
-    position?: PopoverPosition
+    position?: Placement
   }>(),
   {
     as: "span",
-    position: "auto",
+    position: undefined,
   }
 )
 
@@ -20,7 +21,7 @@ const popoverHover = ref(false)
 const popoverTimeout = ref()
 
 // functions
-const closePopover = (close: any): void => {
+const closePopover = (close: () => void): void => {
   popoverHover.value = false
   if (popoverTimeout.value) clearTimeout(popoverTimeout.value)
   popoverTimeout.value = setTimeout(() => {
@@ -36,9 +37,9 @@ const hoverPopover = (e: MouseEvent, open: boolean): void => {
 
 <template>
   <Popover :position="position" :as="as">
-    <template #button="{ open, close }">
+    <template #button="{ open, close }: { open: boolean, close: () => void }">
       <div
-        class="leading-none w-4 h-4"
+        class="leading-none relative w-4 h-4"
         @mouseover="hoverPopover($event, open)"
         @mouseleave="closePopover(close)"
       >
@@ -49,13 +50,15 @@ const hoverPopover = (e: MouseEvent, open: boolean): void => {
         ></div>
       </div>
     </template>
-    <template #default="{ close }">
+    <template #default="{ close }: { close: () => void }">
       <div
-        class="w-full max-w-xs bg-white rounded-md px-3 py-2 border border-gray-100 drop-shadow-md text-xs text-gray-900 leading-snug font-medium"
+        class="sm:min-w-max bg-white rounded-md px-3 py-2 border border-gray-100 drop-shadow-md text-xs text-gray-900 leading-snug font-medium"
         @mouseover.prevent="popoverHover = true"
         @mouseleave.prevent="closePopover(close)"
       >
-        <slot></slot>
+        <div class="max-w-xs">
+          <slot></slot>
+        </div>
       </div>
     </template>
   </Popover>


### PR DESCRIPTION
While reviewing #36 I noticed that there were a few runtime errors on the popover auto placement strategy from the bump to Vue 3.3, so it seemed like as good a time as any to integrate a 3rd party and solve the table actions dropdown display bug as well.

[Floating-UI](https://floating-ui.com/docs/vue) is the successor to PopperJS and has first class Vue support.  It does add a little heft to the bundle, but the trade-off seems worthwhile.