### PR TITLE
Adds limit handling to DateRangePicker and pass through prop on DynamicTable

### DIFF
--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -15,6 +15,7 @@ const checkboxProps = [
 const dateRange = ref({ maxDate: 0, minDate: 0 })
 const dateRangePickerCopy = `<DateRangePicker v-model="dateRange" />`
 const dateRangePickerProps = [
+  { name: "maxRange", required: false, type: "number" },
   {
     name: "modelValue",
     required: true,
@@ -325,7 +326,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             <ClickToCopy :value="dateRangePickerCopy" />
           </label>
           <div class="mt-1">
-            <DateRangePicker v-model="dateRange" />
+            <DateRangePicker v-model="dateRange" :max-range="365" />
             <div class="mt-4"><b>Value:</b> {{ dateRange }}</div>
             <PropsTable :props="dateRangePickerProps" />
           </div>

--- a/src/composables/date.ts
+++ b/src/composables/date.ts
@@ -2,3 +2,10 @@ export interface DateRange {
   minDate: number
   maxDate: number
 }
+
+export interface DateRangeProps {
+  help?: string
+  label?: string
+  maxRange?: number
+  startDate?: number
+}

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -2,6 +2,7 @@ import { VNodeChild } from "vue"
 import { ActionItem } from "@/composables/nav"
 
 export interface DynamicTableOptions {
+  dateSearchMaxRange?: number
   dateSearch?: boolean
   defaultSort?: string
   defaultSortDirection?: string

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -1,9 +1,9 @@
 import { VNodeChild } from "vue"
 import { ActionItem } from "@/composables/nav"
+import { DateRangeProps } from "./date"
 
 export interface DynamicTableOptions {
-  dateSearchMaxRange?: number
-  dateSearch?: boolean
+  dateSearch?: boolean | DateRangeProps
   defaultSort?: string
   defaultSortDirection?: string
   refreshTrigger: number

--- a/src/lib-components/forms/DateRangePicker.vue
+++ b/src/lib-components/forms/DateRangePicker.vue
@@ -11,13 +11,13 @@ const props = withDefaults(
       minDate: number
       maxDate: number
     }
-    allowedRangeInDays?: number
+    maxRange?: number
     startDate?: number
     label?: string
     help?: string
   }>(),
   {
-    allowedRangeInDays: 0,
+    maxRange: 0,
     startDate: 0,
     label: "",
     help: "",
@@ -55,26 +55,32 @@ onMounted(() => {
     },
   }
 
-  if (props.allowedRangeInDays) {
+  if (props.maxRange) {
     // Set the range to a prefilled value given the allowed range
     const daysAgo = new Date()
-    opts.defaultDate = [
-      daysAgo.setDate(daysAgo.getDate() - props.allowedRangeInDays),
-      new Date(),
-    ]
+    const minDate = daysAgo.setDate(daysAgo.getDate() - props.maxRange)
+    const maxDate = new Date()
+    opts.defaultDate = [minDate, maxDate]
+    updateModelValue({
+      minDate: Math.floor(minDate / 1000),
+      maxDate: Math.floor(maxDate.getTime() / 1000),
+    })
 
     // Handle onChange to dynamically adjust maxDate to x days ahead of the selected start date
     opts.onChange = (selectedDates, _, self) => {
       if (selectedDates.length === 1) {
         // Clone date so as to not change selectedDates[0] value
         var daysAhead = new Date(selectedDates[0].getTime())
-        daysAhead.setDate(daysAhead.getDate() + props.allowedRangeInDays)
+        var daysBefore = new Date(selectedDates[0].getTime())
+        daysAhead.setDate(daysAhead.getDate() + props.maxRange)
+        daysBefore.setDate(daysBefore.getDate() - props.maxRange)
         const now = new Date()
 
         if (daysAhead > now) {
           daysAhead = now
         }
 
+        self.set("minDate", daysBefore)
         self.set("maxDate", daysAhead)
       }
     }

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -181,6 +181,7 @@ loadAndRender()
       <div v-if="tableOptions.dateSearch" class="w-full max-w-lg lg:max-w-xs">
         <DateRangePicker
           v-model="dateRange"
+          :allowed-range-in-days="tableOptions.dateSearchMaxRange"
           @update:model-value="dateRangeChanged"
         />
       </div>

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -12,6 +12,7 @@ import type {
 } from "@/composables/table"
 import { useAppFlasher } from "@/composables/useFlashes"
 import { TrailsRespPaged } from "@/api/client"
+import { DateRangeProps } from "@/composables/date"
 import { useTable } from "@/composables/useTable"
 import TableActionButtons from "./TableActionButtons.vue"
 
@@ -121,6 +122,12 @@ const handleSort = (selectedSort: string): void => {
   loadAndRender()
 }
 
+const dateSearchProps = computed((): DateRangeProps => {
+  if (typeof props.tableOptions.dateSearch === "object")
+    return props.tableOptions.dateSearch
+  return {}
+})
+
 const hasContent = computed((): boolean => {
   return rows.value.length ? true : false
 })
@@ -181,7 +188,7 @@ loadAndRender()
       <div v-if="tableOptions.dateSearch" class="w-full max-w-lg lg:max-w-xs">
         <DateRangePicker
           v-model="dateRange"
-          :allowed-range-in-days="tableOptions.dateSearchMaxRange"
+          v-bind="{ ...dateSearchProps }"
           @update:model-value="dateRangeChanged"
         />
       </div>


### PR DESCRIPTION
For naming, I went as explicit as possible on the DateRangePicker and on the DynamicTable, I wanted to keep it as close to `dateSearch` as possible so it's obvious they are related. Considered moving `dateSearch` + `dateSearchMaxRange` into a nested object on the type but this is already nested so skipped that. 

On the implementation, there are a handful of ways to approach, but using maxDate kept the component redraw in the existing logic. I am assuming that a date should be prefilled when using the range, but this could be a separate prop in the future.