### PR TITLE
bumps axios@1.5.0 and sets config value for params indexes

### DIFF
--- a/dev/content/Tools/UseBaseAPI.vue
+++ b/dev/content/Tools/UseBaseAPI.vue
@@ -24,7 +24,7 @@ const { result, error, isLoading, isFinished, isAborted, hasFetched, execute, ab
   )
 
 const fetch = (opt: ReqOptions = {}, shouldAbort = false,) => {
-  execute({ query: Date.now() }, opt)
+  execute({ query: Date.now(), filters: ["one", "two", "three"]}, opt)
   .then((response) => {
     // you could do something with this data variable
     // which has a Type of TrailsRespPaged<Conifer>, but the result

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@floating-ui/vue": "^1.0.1",
         "@headlessui/vue": "^1.4.2",
         "@heroicons/vue": "^1.0.5",
-        "axios": "^0.27.2",
+        "axios": "^1.5.0",
         "flatpickr": "^4.6.9"
       },
       "devDependencies": {
@@ -1266,12 +1266,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3019,6 +3020,11 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -4621,12 +4627,13 @@
       }
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "balanced-match": {
@@ -5881,6 +5888,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@floating-ui/vue": "^1.0.1",
     "@headlessui/vue": "^1.4.2",
     "@heroicons/vue": "^1.0.5",
-    "axios": "^0.27.2",
+    "axios": "^1.5.0",
     "flatpickr": "^4.6.9"
   },
   "peerDependencies": {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,4 +1,8 @@
-import axios, { AxiosResponse, AxiosRequestConfig } from "axios"
+import axios, {
+  AxiosResponse,
+  AxiosRequestConfig,
+  InternalAxiosRequestConfig,
+} from "axios"
 import {
   HTTP_ERR_CANCEL,
   HTTP_ERR,
@@ -14,9 +18,11 @@ import { useAppSpinner } from "@/composables/useSpinner"
  * @param config ReqOptions
  * @returns ReqOptions
  */
-const apiDelayReqIntercept = (config: ReqOptions & AxiosRequestConfig) => {
+const apiDelayReqIntercept = (
+  config: ReqOptions & InternalAxiosRequestConfig
+) => {
   const delay = config.withDelay || 0
-  return new Promise((resolve) => {
+  return new Promise<ReqOptions & InternalAxiosRequestConfig>((resolve) => {
     setTimeout(() => {
       resolve(config)
     }, Math.max(delay, 0))
@@ -25,6 +31,9 @@ const apiDelayReqIntercept = (config: ReqOptions & AxiosRequestConfig) => {
 
 const apiAxiosInstance = axios.create({
   baseURL: process.env.VUE_APP_BASE_API_URL || "/api/v1",
+  paramsSerializer: {
+    indexes: null, // array indexes format (null - no brackets, false (default) - empty brackets, true - brackets with indexes)
+  },
   responseType: "json",
   withCredentials: true,
 })


### PR DESCRIPTION
# What this does

- bumps axios@1.5.0
- implements axios interface changes
- set's the `paramsSerializer.indexes` option to null on the axios instance used by BaseAPI