### PR TITLE
refactor api base url configurability, cleanup vite configs

### DIFF
--- a/dev/serve.ts
+++ b/dev/serve.ts
@@ -10,6 +10,7 @@ import ClickToCopy from "./helpers/ClickToCopy.vue"
 import ComponentLayout from "./helpers/ComponentLayout.vue"
 import PropsTable from "./helpers/PropsTable.vue"
 import "./main.css"
+import { setBaseAPIDefaults } from "@/api/base"
 import { useAppFlashes } from "@/composables/useFlashes"
 import Highlight from "@point-hub/vue-highlight"
 import "highlight.js/styles/atom-one-dark.css"
@@ -20,6 +21,7 @@ import typescript from "highlight.js/lib/languages/typescript"
 Highlight.registerLanguage("html", html)
 Highlight.registerLanguage("typescript", typescript)
 
+setBaseAPIDefaults({ baseURL: "/" })
 useAppFlashes().configure({ email: "support@trees.com" })
 
 const app = createApp(Serve)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@vue/eslint-config-typescript": "^11.0.3",
         "autoprefixer": "^10.4.14",
         "copyfiles": "^2.4.1",
-        "deepmerge": "^4.3.1",
         "eslint": "^8.42.0",
         "eslint-plugin-vue": "^9.14.1",
         "postcss": "^8.4.21",
@@ -35,7 +34,6 @@
         "tsc-alias": "^1.8.5",
         "typescript": "^5.0.4",
         "vite": "^4.3.9",
-        "vite-plugin-environment": "^1.1.3",
         "vue-tsc": "^1.2.0"
       },
       "engines": {
@@ -1606,15 +1604,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -3752,15 +3741,6 @@
         }
       }
     },
-    "node_modules/vite-plugin-environment": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-environment/-/vite-plugin-environment-1.1.3.tgz",
-      "integrity": "sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==",
-      "dev": true,
-      "peerDependencies": {
-        "vite": ">= 2.7"
-      }
-    },
     "node_modules/vue": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
@@ -4987,12 +4967,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
     },
     "delayed-stream": {
@@ -6505,13 +6479,6 @@
         "postcss": "^8.4.23",
         "rollup": "^3.21.0"
       }
-    },
-    "vite-plugin-environment": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-environment/-/vite-plugin-environment-1.1.3.tgz",
-      "integrity": "sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==",
-      "dev": true,
-      "requires": {}
     },
     "vue": {
       "version": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@vue/eslint-config-typescript": "^11.0.3",
     "autoprefixer": "^10.4.14",
     "copyfiles": "^2.4.1",
-    "deepmerge": "^4.3.1",
     "eslint": "^8.42.0",
     "eslint-plugin-vue": "^9.14.1",
     "postcss": "^8.4.21",
@@ -53,7 +52,6 @@
     "tsc-alias": "^1.8.5",
     "typescript": "^5.0.4",
     "vite": "^4.3.9",
-    "vite-plugin-environment": "^1.1.3",
     "vue-tsc": "^1.2.0"
   },
   "dependencies": {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -30,7 +30,7 @@ const apiDelayReqIntercept = (
 }
 
 const apiAxiosInstance = axios.create({
-  baseURL: process.env.VUE_APP_BASE_API_URL || "/api/v1",
+  baseURL: "/api/v1",
   paramsSerializer: {
     indexes: null, // array indexes format (null - no brackets, false (default) - empty brackets, true - brackets with indexes)
   },
@@ -128,6 +128,13 @@ const BaseAPI: HttpClient = {
 }
 
 export default BaseAPI
+
+interface BaseAPIDefaults {
+  baseURL: string
+}
+export const setBaseAPIDefaults = (config: BaseAPIDefaults) => {
+  apiAxiosInstance.defaults = { ...apiAxiosInstance.defaults, ...config }
+}
 
 /**
  * A type guard for checking if a variable is in the shape of a HttpError

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,5 +1,9 @@
 import { App, Plugin } from "vue"
-import BaseAPI, { isHttpCancel, isHttpError } from "@/api/base"
+import BaseAPI, {
+  isHttpCancel,
+  isHttpError,
+  setBaseAPIDefaults,
+} from "@/api/base"
 import type {
   HttpPromise,
   HttpError,
@@ -35,7 +39,7 @@ export * from "@/composables/index"
 export * from "@/lib-components/index"
 
 // Http Client exports
-export { BaseAPI, isHttpCancel, isHttpError }
+export { BaseAPI, isHttpCancel, isHttpError, setBaseAPIDefaults }
 export type {
   HttpPromise,
   HttpError,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,67 +1,36 @@
 import { resolve } from "path"
 import { defineConfig, UserConfig } from "vite"
 import vue from "@vitejs/plugin-vue"
-import Environment from "vite-plugin-environment"
-import deepmerge from "deepmerge"
-
-// TODO: support and preserve import.meta.env in lib build if possible
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
-  const config = {
-    /**
-     * Build (npm run build) specific configuration
-     */
+  return {
+    base: command === "serve" ? "/trees/" : "/",
     build: {
-      build: {
-        // TODO: determine if there is a need for an iife bundle
-        lib: {
-          entry: resolve(__dirname, "src/entry.ts"),
-          name: "Trees",
-          fileName: (format) => `trees.${format}.js`,
-        },
-        rollupOptions: {
-          // make sure to externalize deps that shouldn't be bundled
-          // into your library
-          // TODO: possibly externalize axios among other libs
-          external: ["vue"],
-          output: {
-            exports: "named",
-            // Provide global variables to use in the UMD build
-            // for externalized deps
-            globals: {
-              vue: "Vue",
-            },
+      lib: {
+        entry: resolve(__dirname, "src/entry.ts"),
+        name: "Trees",
+        fileName: (format) => `trees.${format}.js`,
+      },
+      rollupOptions: {
+        // make sure to externalize deps that shouldn't be bundled
+        // into your library
+        external: ["vue"],
+        output: {
+          exports: "named",
+          // Provide global variables to use in the UMD build
+          // for externalized deps
+          globals: {
+            vue: "Vue",
           },
         },
       },
-      define: {
-        // ensure that this stays a variable
-        "process.env.VUE_APP_BASE_API_URL": "process.env.VUE_APP_BASE_API_URL",
-      },
-    } as UserConfig,
-    /**
-     * Serve (npm run dev) specific configuration
-     */
-    serve: {
-      base: "/trees/",
-      plugins: [
-        Environment({
-          VUE_APP_BASE_API_URL: "",
-        }),
-      ],
-    } as UserConfig,
-  }
-
-  return deepmerge(
-    {
-      plugins: [vue()],
-      resolve: {
-        alias: {
-          "@": resolve(__dirname, "src"),
-        },
+    },
+    plugins: [vue()],
+    resolve: {
+      alias: {
+        "@": resolve(__dirname, "src"),
       },
     },
-    config[command]
-  )
+  }
 })

--- a/vite.docs.config.ts
+++ b/vite.docs.config.ts
@@ -1,19 +1,13 @@
 import { resolve } from "path"
 import { defineConfig } from "vite"
 import vue from "@vitejs/plugin-vue"
-import Environment from "vite-plugin-environment"
 
 export default defineConfig({
   base: "/trees/",
   build: {
     outDir: resolve(__dirname, "trees"),
   },
-  plugins: [
-    vue(),
-    Environment({
-      VUE_APP_BASE_API_URL: "/",
-    }),
-  ],
+  plugins: [vue()],
   resolve: {
     alias: {
       "@": resolve(__dirname, "src"),


### PR DESCRIPTION
# What this does

- refactors how the baseURL is set on the BaseAPI instance
- removes vite-environment-plugin from vite configs
- refactors vite docs and dev configs to remove needless complexity

## Why

- Setting lib vars via an ENV var doesn't play as nicely in JS module land as it does with backend code
- There's been confusion about what baseURL should be in dev vs prod like environments.  It's going to be easier mid-term for the apps to just know that `/api/v1` is the baseURL in all environments.
- With the introduction of a subdomain on portal, it's preferred that the baseURL is set without a hostname
- `process.env` is dying a slow death as a pattern generally in client side JavaScript
- It cleans up the apps Vite configs just a little more, removing an entry that is only there to prevent an error in dev mode

## Why not make this a field on ReqOptions

Mainly because the point of the `baseURL` is to set a default that works on the majority of your calls with `BaseAPI`, I don't think the intention was for it to be a per-request configuration variable.  

The ability to make a call to a different API sub route already exists without changes.

```ts
// How this already works
// -> The origin is also exposed on InitialVueProps and could be configured as a Vite env
BaseAPI.get(`${window.location.origin}/api/v2/resource-path`, { skipLoader: true })

// A little weird if you ask me and non-trivial to support
BaseAPI.get("/resource-path", { baseURL: "/api/v2", skipLoader: true })
```

## Do we actually need `setBaseAPIDefaults`

Not currently as it relates to existing XYPN products.  The Trees dev site is the only place setting `baseURL`, but it doesn't need to since it doesn't make any relative API calls - that could change though with some updates to the docs.  And it is still an open library, so it seems reasonable to expose this option and maintain the status quo of configurability.  Something gained, but nothing lost.