### PR TITLE
2. extract input types, normalize props as much as possible

### DIFF
--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -1,77 +1,18 @@
 <script setup lang="ts">
 import { ref } from "vue"
+import type { InputOption } from "@/composables/forms"
 
-const commonProps = [
-  { name: "label", required: false, type: "string" },
-  { name: "help", required: false, type: "string" },
-]
-const isChecked = ref(true)
-const checkboxCopy = `<Checkbox label="I'm here to party!" help="Get notified when the party starts." v-model="checked" />`
-const checkboxProps = [
-  { name: "emphasis", required: false, type: "boolean" },
-  { name: "label", required: false, type: "string" },
-  { name: "modelValue", required: true, type: "boolean" },
-]
-const dateRange = ref({ maxDate: 0, minDate: 0 })
-const dateRangePickerCopy = `<DateRangePicker v-model="dateRange" />`
-const dateRangePickerProps = [
-  { name: "maxRange", required: false, type: "number" },
-  {
-    name: "modelValue",
-    required: true,
-    type: "{ minDate: number; maxDate: number; }",
-  },
-  { name: "startDate", required: false, type: "number" },
-  ...commonProps,
-]
-const inputCopy = `<BaseInput type="text" label="What's your lide moto?" help="No wrong ansswers here." placeholder="It's good to be alive"/>`
-const inputErrorCopy = `<BaseInput type="text" placeholder="Broken" class="xy-input-error" />`
-const multiCheckboxCopy = `<MultiCheckboxes v-model="selected" label="Make Some Selections" help="Select all that apply." :options="options" />`
-const multiCheckboxProps = [
-  {
-    name: "options",
-    required: true,
-    type: "Array<{ disabled?: boolean, help?: string; label: string; value: number | string }>",
-  },
-  { name: "modelValue", required: true, type: "string" },
-  { name: "legend", required: false, type: "string" },
-]
-const multiCheckboxSelection = ref(["val2", 4])
-const radioCopy = `<Radio :options="options" v-model="selected" />`
-const radioProps = [
-  {
-    name: "options",
-    required: true,
-    type: "Array<{ disabled?: boolean, help?: string, label: string; value: number | string }>",
-  },
-  { name: "modelValue", required: true, type: "string" },
-  { name: "help", required: false, type: "string" },
-  { name: "legend", required: false, type: "string" },
-]
-const radioSelection = ref<string | number>("val1")
-const selectCopy = `<Select :options="options" placeholder="Select an option that you fancy" />`
-const selectProps = [
-  { name: "design", required: false, type: "string" },
-  {
-    name: "options",
-    required: true,
-    type: "Array<{ label: string; value: string | number }>",
-  },
-  { name: "placeholder", required: false, type: "string" },
-  { name: "modelValue", required: true, type: "string" },
-  ...commonProps,
-]
-const options = [
+const options: InputOption[] = [
   {
     label: "You could select this",
     help: "It's really quite nice.",
-    value: "val1",
+    value: "One",
     disabled: false,
   },
   {
     label: "This is an option",
     help: "Ah, indeed it is an option.",
-    value: "val2",
+    value: "Two",
   },
   {
     label: "Feeling good about this one?",
@@ -86,29 +27,14 @@ const options = [
   },
 ]
 
-const selected = ref("")
-
-const yesOrNoRadioCopy = `<YesOrNoRadio v-model="selected" />`
-const yesOrNoRadioSelection = ref(undefined)
-const yesOrNoRadioProps = [
-  { name: "help", required: false, type: "string" },
-  { name: "legend", required: false, type: "string" },
-  { name: "name", required: false, type: "string" },
-  { name: "modelValue", required: false, type: "boolean" },
-]
-
-const textarea = ref("")
-const textareaProps = [
-  { name: "modelValue", required: false, type: "string" },
-  ...commonProps,
-]
-const textareaCopy = `<TextArea v-model="textarea" />`
-
-const baseInputProps = [
-  { name: "type", required: true, type: "string" },
-  { name: "modelValue", required: false, type: "string | number" },
-  ...commonProps,
-]
+// test generic options and sublabel slot availability
+const radioCardOptions = options.map((opt) => {
+  return {
+    ...opt,
+    sublabel: typeof opt.value === "string" ? opt.value : `$${opt.value}.00`,
+    onSale: typeof opt.value === "string" ? false : true,
+  }
+})
 
 const textLikeInputs = [
   "date",
@@ -125,31 +51,114 @@ const textLikeInputs = [
   "week",
 ] as const
 
-const inputTypes = textLikeInputs.map((type) => {
+const inputTypes: InputOption[] = textLikeInputs.map((type) => {
   return {
     label: type,
     value: type,
   }
 })
 
+/**
+ * v-models
+ */
 const inputTypeSelected = ref<(typeof textLikeInputs)[number]>("text")
-const customInputTypeVal = ref("")
+const inputVals = ref<Record<string, any>>({})
+const toggleValue = ref(undefined)
 
+/**
+ * Copy Help
+ */
+const checkboxCopy = `<Checkbox label="I'm here to party!" help="Get notified when the party starts." v-model="checked" />`
+const dateRangePickerCopy = `<DateRangePicker v-model="dateRange" />`
+const inputCopy = `<BaseInput type="text" label="What's your lide moto?" help="No wrong ansswers here." placeholder="It's good to be alive" />`
+const inputErrorCopy = `<BaseInput type="text" label="Broken" error="This input has an error." />`
+const multiCheckboxCopy = `<MultiCheckboxes v-model="selected" label="Make Some Selections" help="Select all that apply." :options="options" />`
+const radioCopy = `<Radio :options="options" v-model="selected" />`
+const selectCopy = `<Select :options="options" placeholder="Select an option that you fancy" />`
+const yesOrNoRadioCopy = `<YesOrNoRadio v-model="selected" />`
+const textareaCopy = `<TextArea v-model="textarea" />`
 const inputLabelCopy = `<InputLabel label="I'm labeling something..." />`
+const toggleCopy = `<Toggle v-model="toggleValue"></Toggle>`
+const inputHelpCopy = `<InputHelp text="I'm just here to hint." />`
+
+/**
+ * Props
+ */
 const inputLabelProps = [
   { name: "label", required: false, type: "string" },
   { name: "tag", required: false, type: "string" },
 ]
 
-const inputHelpCopy = `<InputHelp text="I'm just here to hint." />`
 const inputHelpProps = [
   { name: "text", required: false, type: "string" },
   { name: "tag", required: false, type: "string" },
 ]
-const toggleValue = ref(undefined)
-const toggleCopy = `<Toggle v-model="toggleValue"></Toggle>`
-const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
+
+const inputCommonProps = [
+  { name: "error", required: false, type: "string" },
+  { name: "label", required: false, type: "string" },
+  { name: "help", required: false, type: "string" },
+  { name: "placeholder", required: false, type: "string" },
+]
+
+const inputOptionsProp = {
+  name: "options",
+  required: true,
+  type: `{
+    disabled?: boolean
+    help?: string
+    label: string
+    sublabel?: string
+    value: string | number
+  }[]`,
+}
+
+const booleanInputProps = [
+  { name: "modelValue", required: false, type: "boolean | null" },
+  ...inputCommonProps,
+]
+
+const dateRangeInputProps = [
+  {
+    name: "modelValue",
+    required: false,
+    type: `{minDate: number, maxDate: number}`,
+  },
+  { name: "maxRange", required: false, type: "number" },
+  { name: "startDate", required: false, type: "number" },
+  ...inputCommonProps,
+]
+
+const textLikeInputProps = [
+  { name: "type", required: true, type: textLikeInputs.join(" | ") },
+  { name: "modelValue", required: false, type: "string | number | null" },
+  ...inputCommonProps,
+]
+
+const textareaInputProps = [
+  { name: "modelValue", required: false, type: "string | number | null" },
+  ...inputCommonProps,
+]
+
+const optionsInputProps = [
+  inputOptionsProp,
+  { name: "modelValue", required: false, type: "string | number | null" },
+  ...inputCommonProps,
+]
+
+const multichoiceInputProps = [
+  inputOptionsProp,
+  { name: "modelValue", required: false, type: "(string | number)[] | null" },
+  ...inputCommonProps,
+]
+
+const toggleProps = [
+  { name: "modelValue", required: false, type: "boolean" },
+  { name: "label", required: false, type: "string" },
+  { name: "help", required: false, type: "string" },
+]
 </script>
+
 <template>
   <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
     <div class="max-w-3xl mx-auto">
@@ -190,6 +199,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           <div class="mt-1">
             <form @submit.prevent>
               <BaseInput
+                v-model="inputVals['baseInput']"
                 help="No wrong answers here."
                 type="text"
                 label="What's your life moto?"
@@ -207,7 +217,8 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           </label>
           <div class="mt-1">
             <BaseInput
-              class="xy-input-error"
+              v-model="inputVals['baseInput-broken']"
+              error="This one is borked."
               type="text"
               label="Broken"
               placeholder="An invalid input"
@@ -217,7 +228,11 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
 
         <div>
           <div class="mt-1 space-y-3">
-            <BaseInput :disabled="true" type="text" label="Disabled" />
+            <BaseInput
+              :disabled="true"
+              type="text"
+              label="Disabled without placeholder"
+            />
 
             <BaseInput
               :disabled="true"
@@ -227,10 +242,10 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             />
 
             <BaseInput
+              model-value="A disabled input with a value"
               :disabled="true"
               type="text"
               label="Disabled with value"
-              value="A disabled input"
             />
           </div>
         </div>
@@ -245,14 +260,17 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               class="mb-8"
             />
             <BaseInput
-              v-model="customInputTypeVal"
+              v-model="inputVals[`baseInput-${inputTypeSelected}`]"
               :help="`Some help text for a ${inputTypeSelected}`"
               :type="inputTypeSelected"
               :label="`Here's an example of an <input type='${inputTypeSelected}'>`"
               :placeholder="`A placeholder for a ${inputTypeSelected}`"
-            ></BaseInput>
-            <div class="mt-4"><b>Value:</b> {{ customInputTypeVal }}</div>
-            <PropsTable :props="baseInputProps" />
+            />
+            <div class="mt-4">
+              <b>Value:</b> {{ inputVals[inputTypeSelected] }}
+            </div>
+
+            <PropsTable :props="textLikeInputProps" />
           </div>
         </div>
       </ComponentLayout>
@@ -268,7 +286,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           </label>
           <div class="mt-1">
             <TextArea
-              v-model="textarea"
+              v-model="inputVals['textarea']"
               label="How about it?"
               help="In your own words."
               placeholder="Don't be shy now..."
@@ -276,7 +294,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
 
             <div class="mt-4">
               <TextArea
-                v-model="textarea"
+                v-model="inputVals['textarea']"
                 :disabled="true"
                 label="How about it (disabled)?"
                 help="In your own words."
@@ -285,15 +303,15 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
 
             <div class="mt-4">
               <TextArea
-                v-model="textarea"
+                v-model="inputVals['textarea']"
                 label="How about it (invalid)?"
                 help="In your own words."
                 error="This field has an error."
               />
             </div>
 
-            <div class="mt-4"><b>Value:</b> {{ textarea }}</div>
-            <PropsTable :props="textareaProps" />
+            <div class="mt-4"><b>Value:</b> {{ inputVals["textarea"] }}</div>
+            <PropsTable :props="textareaInputProps" />
           </div>
         </div>
       </ComponentLayout>
@@ -310,26 +328,26 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           </label>
           <div class="mt-1 space-y-8">
             <Checkbox
-              v-model="isChecked"
+              v-model="inputVals['checkbox']"
               label="I'm here to party!"
               help="Get notified when the party starts."
             />
 
             <Checkbox
-              v-model="isChecked"
+              v-model="inputVals['checkbox']"
               :disabled="true"
               label="I'm here to party! (disabled)"
               help="Get notified when the party starts."
             />
 
             <Checkbox
-              v-model="isChecked"
+              v-model="inputVals['checkbox']"
               label="I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party! I'm here to party!"
             />
 
             <form @submit.prevent>
               <Checkbox
-                v-model="isChecked"
+                v-model="inputVals['checkbox']"
                 label="Invalid state focus"
                 help="This one is required."
                 required
@@ -338,8 +356,8 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               <button type="submit" class="xy-btn mt-2">Submit</button>
             </form>
 
-            <div class="mt-4"><b>Value:</b> {{ isChecked }}</div>
-            <PropsTable :props="checkboxProps" />
+            <div class="mt-4"><b>Value:</b> {{ inputVals["checkbox"] }}</div>
+            <PropsTable :props="booleanInputProps" />
           </div>
         </div>
       </ComponentLayout>
@@ -362,9 +380,14 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             <ClickToCopy :value="dateRangePickerCopy" />
           </label>
           <div class="mt-1">
-            <DateRangePicker v-model="dateRange" :max-range="365" />
-            <div class="mt-4"><b>Value:</b> {{ dateRange }}</div>
-            <PropsTable :props="dateRangePickerProps" />
+            <DateRangePicker
+              v-model="inputVals['dateRangePicker']"
+              :max-range="365"
+            />
+            <div class="mt-4">
+              <b>Value:</b> {{ inputVals["dateRangePicker"] }}
+            </div>
+            <PropsTable :props="dateRangeInputProps" />
           </div>
         </div>
       </ComponentLayout>
@@ -380,7 +403,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           </label>
           <div class="mt-1 space-y-8">
             <MultiCheckboxes
-              v-model="multiCheckboxSelection"
+              v-model="inputVals['multiCheckboxes']"
               label="Make Basic Selections"
               :options="
                 options.map((option) => ({
@@ -392,7 +415,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             />
 
             <MultiCheckboxes
-              v-model="multiCheckboxSelection"
+              v-model="inputVals['multiCheckboxes']"
               label="Make Complex Selections"
               help="Select all that apply."
               :options="options"
@@ -400,7 +423,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             />
 
             <MultiCheckboxes
-              v-model="multiCheckboxSelection"
+              v-model="inputVals['multiCheckboxes']"
               label="Lay it out in a grid"
               :columns="2"
               help="Set the columns prop to 2 or 3"
@@ -409,8 +432,10 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               <template #legend>In A Grid Too</template>
             </MultiCheckboxes>
 
-            <div class="mt-2"><b>Value:</b> {{ multiCheckboxSelection }}</div>
-            <PropsTable :props="multiCheckboxProps" />
+            <div class="mt-2">
+              <b>Value:</b> {{ inputVals["multiCheckboxes"] }}
+            </div>
+            <PropsTable :props="multichoiceInputProps" />
           </div>
         </div>
       </ComponentLayout>
@@ -427,7 +452,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           </label>
           <div class="mt-1 space-y-8">
             <Radio
-              v-model="radioSelection"
+              v-model="inputVals['radio']"
               label="Make Basic Choice"
               :options="
                 options.map((option) => ({
@@ -439,7 +464,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             />
 
             <Radio
-              v-model="radioSelection"
+              v-model="inputVals['radio']"
               label="Make Complex Choice"
               help="Only one - I know it's hard!"
               :options="options"
@@ -447,7 +472,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             />
 
             <Radio
-              v-model="radioSelection"
+              v-model="inputVals['radio']"
               label="Lay it out in a grid"
               help="Set the columns prop to 2 or 3"
               :options="options"
@@ -468,17 +493,10 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             <div class="">
               <form>
                 <RadioCards
+                  v-model="inputVals['radio']"
                   label="Cards Any One?"
                   help="Just use the RadioCards component."
-                  :options="
-                    options.map((option) => ({
-                      disabled: option.disabled,
-                      help: option.help,
-                      label: option.label,
-                      value: option.value,
-                      sublabel: '$499/mo',
-                    }))
-                  "
+                  :options="radioCardOptions"
                   :columns="2"
                   required
                 />
@@ -489,22 +507,18 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
 
             <div class="">
               <RadioCards
-                v-model="radioSelection"
+                v-model="inputVals['radio']"
                 :disabled="true"
                 label="Need a complex sublabel on your cards?"
                 help="The sublabel display is supported by both options.sublabel and a named slot #sublabel."
-                :options="
-                  options.map((option) => ({
-                    disabled: option.disabled,
-                    help: option.help,
-                    label: option.label,
-                    value: option.value,
-                  }))
-                "
+                :options="radioCardOptions"
                 :columns="2"
               >
-                <template #sublabel="{ option, checked }">
-                  {{ option.value }}:{{ checked }}
+                <template #sublabel="{ option }">
+                  {{ option.sublabel }}
+                  <span v-if="option.onSale" class="text-green-700">
+                    On Sale!
+                  </span>
                 </template>
               </RadioCards>
             </div>
@@ -528,8 +542,8 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
               </ul>
             </div>
 
-            <div class="mt-4"><b>Value:</b> {{ radioSelection }}</div>
-            <PropsTable :props="radioProps" />
+            <div class="mt-4"><b>Value:</b> {{ inputVals["radio"] }}</div>
+            <PropsTable :props="optionsInputProps" />
           </div>
         </div>
       </ComponentLayout>
@@ -558,13 +572,13 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           </label>
           <div class="space-y-6">
             <Select
-              v-model="selected"
+              v-model="inputVals['select']"
               :options="options"
               label="Lets make a selection"
             />
 
             <Select
-              v-model="selected"
+              v-model="inputVals['select']"
               :options="options"
               label="Lets make a selection"
               help="Disabled select input"
@@ -572,7 +586,7 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             />
 
             <Select
-              v-model="selected"
+              v-model="inputVals['select']"
               :options="options"
               label="Lets make a selection"
               help="Invalid select input"
@@ -580,8 +594,8 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
             />
           </div>
 
-          <div class="mt-4"><b>Value:</b> {{ selected }}</div>
-          <PropsTable :props="selectProps" />
+          <div class="mt-4"><b>Value:</b> {{ inputVals["select"] }}</div>
+          <PropsTable :props="optionsInputProps" />
         </div>
       </ComponentLayout>
 
@@ -597,19 +611,21 @@ const toggleProps = [{ name: "modelValue", required: true, type: "string" }]
           </label>
           <div class="mt-1">
             <YesOrNoRadio
-              v-model="yesOrNoRadioSelection"
+              v-model="inputVals['yesOrNoRadio']"
               label="Is this thing on?"
               help="Only one way to find out."
             ></YesOrNoRadio>
             <div class="mt-2">
               <YesOrNoRadio
-                v-model="yesOrNoRadioSelection"
+                v-model="inputVals['yesOrNoRadio']"
                 label="Is this thing on? (disabled)"
                 disabled
               ></YesOrNoRadio>
             </div>
-            <div class="mt-4"><b>Value:</b> {{ yesOrNoRadioSelection }}</div>
-            <PropsTable :props="yesOrNoRadioProps" />
+            <div class="mt-4">
+              <b>Value:</b> {{ inputVals["yesOrNoRadio"] }}
+            </div>
+            <PropsTable :props="optionsInputProps" />
           </div>
         </div>
       </ComponentLayout>

--- a/dev/helpers/PropsTable.vue
+++ b/dev/helpers/PropsTable.vue
@@ -35,7 +35,10 @@ defineProps<{
         <tr v-for="prop in props" :key="prop.name">
           <td class="p-2 text-sm text-gray-700" v-text="prop.name"></td>
           <td class="p-2 text-sm text-gray-700" v-text="prop.required"></td>
-          <td class="p-2 text-sm text-gray-700" v-text="prop.type"></td>
+          <td
+            class="p-2 text-sm text-gray-700 whitespace-pre-wrap"
+            v-text="prop.type"
+          ></td>
         </tr>
       </tbody>
     </table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "tsc-alias": "^1.8.5",
         "typescript": "^5.0.4",
         "vite": "^4.3.9",
-        "vue-tsc": "^1.2.0"
+        "vue-tsc": "^1.8.18"
       },
       "engines": {
         "node": ">=12"
@@ -924,81 +924,30 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "1.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.3.0-alpha.0.tgz",
-      "integrity": "sha512-W3uMzecHPcbwddPu4SJpUcPakRBK/y/BP+U0U6NiPpUX1tONLC4yCawt+QBJqtgJ+sfD6ztf5PyvPL3hQRqfOA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.10.3.tgz",
+      "integrity": "sha512-7Qgwu9bWUHN+cLrOkCbIVBkL+RVPREhvY07wY89dGxi4mY9mQCsUVRRp64F61lX7Nc27meMnvy0sWlzY0x6oQQ==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "1.3.0-alpha.0"
+        "@volar/source-map": "1.10.3"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "1.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.3.0-alpha.0.tgz",
-      "integrity": "sha512-jSdizxWFvDTvkPYZnO6ew3sBZUnS0abKCbuopkc0JrIlFbznWC/fPH3iPFIMS8/IIkRxq1Jh9VVG60SmtsdaMQ==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.10.3.tgz",
+      "integrity": "sha512-QE9nwK3xsdBQGongHnC9SCR0itx7xUKQFsUDn5HbZY3pHpyXxdY1hSBG0eh9mE+aTKoM4KlqMvrb+19Tv9vS1Q==",
       "dev": true,
       "dependencies": {
-        "muggle-string": "^0.2.2"
+        "muggle-string": "^0.3.1"
       }
     },
     "node_modules/@volar/typescript": {
-      "version": "1.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.3.0-alpha.0.tgz",
-      "integrity": "sha512-5UItyW2cdH2mBLu4RrECRNJRgtvvzKrSCn2y3v/D61QwIDkGx4aeil6x8RFuUL5TFtV6QvVHXnsOHxNgd+sCow==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.10.3.tgz",
+      "integrity": "sha512-n0ar6xGYpRoSvgGMetm/JXP0QAXx+NOUvxCaWCfCjiFivQRSLJeydYDijhoGBUl5KSKosqq9In5L3e/m2TqTcQ==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "1.3.0-alpha.0"
-      }
-    },
-    "node_modules/@volar/vue-language-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.2.0.tgz",
-      "integrity": "sha512-w7yEiaITh2WzKe6u8ZdeLKCUz43wdmY/OqAmsB/PGDvvhTcVhCJ6f0W/RprZL1IhqH8wALoWiwEh/Wer7ZviMQ==",
-      "dev": true,
-      "dependencies": {
-        "@volar/language-core": "1.3.0-alpha.0",
-        "@volar/source-map": "1.3.0-alpha.0",
-        "@vue/compiler-dom": "^3.2.47",
-        "@vue/compiler-sfc": "^3.2.47",
-        "@vue/reactivity": "^3.2.47",
-        "@vue/shared": "^3.2.47",
-        "minimatch": "^6.1.6",
-        "muggle-string": "^0.2.2",
-        "vue-template-compiler": "^2.7.14"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@volar/vue-language-core/node_modules/minimatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@volar/vue-typescript": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.2.0.tgz",
-      "integrity": "sha512-zjmRi9y3J1EkG+pfuHp8IbHmibihrKK485cfzsHjiuvJMGrpkWvlO5WVEk8oslMxxeGC5XwBFE9AOlvh378EPA==",
-      "dev": true,
-      "dependencies": {
-        "@volar/typescript": "1.3.0-alpha.0",
-        "@volar/vue-language-core": "1.2.0"
+        "@volar/language-core": "1.10.3"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -1085,6 +1034,54 @@
         }
       }
     },
+    "node_modules/@vue/language-core": {
+      "version": "1.8.18",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.18.tgz",
+      "integrity": "sha512-byTi+mwSL7XnVRtfWE3MJy3HQryoVSQ3lymauXviegn3G1wwwlSOUljzQe3w5PyesOnBEIxYoavfKzMJnExrBA==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "~1.10.3",
+        "@volar/source-map": "~1.10.3",
+        "@vue/compiler-dom": "^3.3.0",
+        "@vue/reactivity": "^3.3.0",
+        "@vue/shared": "^3.3.0",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.3.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
@@ -1140,6 +1137,16 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
+    },
+    "node_modules/@vue/typescript": {
+      "version": "1.8.18",
+      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.18.tgz",
+      "integrity": "sha512-3M+lu+DUwJW0fNwd/rLE0FenmELxcC6zxgm/YZ25jSTi+uNGj9L5XvXvf20guC69gQvZ+cg49tTxbepfFVuNNQ==",
+      "dev": true,
+      "dependencies": {
+        "@volar/typescript": "~1.10.3",
+        "@vue/language-core": "1.8.18"
+      }
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -2622,9 +2629,9 @@
       "dev": true
     },
     "node_modules/muggle-string": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.2.2.tgz",
-      "integrity": "sha512-YVE1mIJ4VpUMqZObFndk9CJu6DBJR/GB13p3tXuNbwD4XExaI5EOuRl6BHeIDxIqXZVxSfAC+y6U1Z/IxCfKUg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
       "dev": true
     },
     "node_modules/mylas": {
@@ -3262,9 +3269,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3813,13 +3820,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.2.0.tgz",
-      "integrity": "sha512-rIlzqdrhyPYyLG9zxsVRa+JEseeS9s8F2BbVVVWRRsTZvJO2BbhLEb2HW3MY+DFma0378tnIqs+vfTzbcQtRFw==",
+      "version": "1.8.18",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.18.tgz",
+      "integrity": "sha512-AwQxBB9SZX308TLL1932P1JByuMsXC2jLfRBGt8SBdm1e3cXkDlFaXUAqibfKnoQ1ZC2zO2NSbeBNdSjOcdvJw==",
       "dev": true,
       "dependencies": {
-        "@volar/vue-language-core": "1.2.0",
-        "@volar/vue-typescript": "1.2.0"
+        "@vue/language-core": "1.8.18",
+        "@vue/typescript": "1.8.18",
+        "semver": "^7.5.4"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -4453,77 +4461,30 @@
       "requires": {}
     },
     "@volar/language-core": {
-      "version": "1.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.3.0-alpha.0.tgz",
-      "integrity": "sha512-W3uMzecHPcbwddPu4SJpUcPakRBK/y/BP+U0U6NiPpUX1tONLC4yCawt+QBJqtgJ+sfD6ztf5PyvPL3hQRqfOA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.10.3.tgz",
+      "integrity": "sha512-7Qgwu9bWUHN+cLrOkCbIVBkL+RVPREhvY07wY89dGxi4mY9mQCsUVRRp64F61lX7Nc27meMnvy0sWlzY0x6oQQ==",
       "dev": true,
       "requires": {
-        "@volar/source-map": "1.3.0-alpha.0"
+        "@volar/source-map": "1.10.3"
       }
     },
     "@volar/source-map": {
-      "version": "1.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.3.0-alpha.0.tgz",
-      "integrity": "sha512-jSdizxWFvDTvkPYZnO6ew3sBZUnS0abKCbuopkc0JrIlFbznWC/fPH3iPFIMS8/IIkRxq1Jh9VVG60SmtsdaMQ==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.10.3.tgz",
+      "integrity": "sha512-QE9nwK3xsdBQGongHnC9SCR0itx7xUKQFsUDn5HbZY3pHpyXxdY1hSBG0eh9mE+aTKoM4KlqMvrb+19Tv9vS1Q==",
       "dev": true,
       "requires": {
-        "muggle-string": "^0.2.2"
+        "muggle-string": "^0.3.1"
       }
     },
     "@volar/typescript": {
-      "version": "1.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.3.0-alpha.0.tgz",
-      "integrity": "sha512-5UItyW2cdH2mBLu4RrECRNJRgtvvzKrSCn2y3v/D61QwIDkGx4aeil6x8RFuUL5TFtV6QvVHXnsOHxNgd+sCow==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.10.3.tgz",
+      "integrity": "sha512-n0ar6xGYpRoSvgGMetm/JXP0QAXx+NOUvxCaWCfCjiFivQRSLJeydYDijhoGBUl5KSKosqq9In5L3e/m2TqTcQ==",
       "dev": true,
       "requires": {
-        "@volar/language-core": "1.3.0-alpha.0"
-      }
-    },
-    "@volar/vue-language-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.2.0.tgz",
-      "integrity": "sha512-w7yEiaITh2WzKe6u8ZdeLKCUz43wdmY/OqAmsB/PGDvvhTcVhCJ6f0W/RprZL1IhqH8wALoWiwEh/Wer7ZviMQ==",
-      "dev": true,
-      "requires": {
-        "@volar/language-core": "1.3.0-alpha.0",
-        "@volar/source-map": "1.3.0-alpha.0",
-        "@vue/compiler-dom": "^3.2.47",
-        "@vue/compiler-sfc": "^3.2.47",
-        "@vue/reactivity": "^3.2.47",
-        "@vue/shared": "^3.2.47",
-        "minimatch": "^6.1.6",
-        "muggle-string": "^0.2.2",
-        "vue-template-compiler": "^2.7.14"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-          "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
-      }
-    },
-    "@volar/vue-typescript": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.2.0.tgz",
-      "integrity": "sha512-zjmRi9y3J1EkG+pfuHp8IbHmibihrKK485cfzsHjiuvJMGrpkWvlO5WVEk8oslMxxeGC5XwBFE9AOlvh378EPA==",
-      "dev": true,
-      "requires": {
-        "@volar/typescript": "1.3.0-alpha.0",
-        "@volar/vue-language-core": "1.2.0"
+        "@volar/language-core": "1.10.3"
       }
     },
     "@vue/compiler-core": {
@@ -4593,6 +4554,42 @@
         "vue-eslint-parser": "^9.1.1"
       }
     },
+    "@vue/language-core": {
+      "version": "1.8.18",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.18.tgz",
+      "integrity": "sha512-byTi+mwSL7XnVRtfWE3MJy3HQryoVSQ3lymauXviegn3G1wwwlSOUljzQe3w5PyesOnBEIxYoavfKzMJnExrBA==",
+      "dev": true,
+      "requires": {
+        "@volar/language-core": "~1.10.3",
+        "@volar/source-map": "~1.10.3",
+        "@vue/compiler-dom": "^3.3.0",
+        "@vue/reactivity": "^3.3.0",
+        "@vue/shared": "^3.3.0",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.3.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "@vue/reactivity": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
@@ -4645,6 +4642,16 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
+    },
+    "@vue/typescript": {
+      "version": "1.8.18",
+      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.18.tgz",
+      "integrity": "sha512-3M+lu+DUwJW0fNwd/rLE0FenmELxcC6zxgm/YZ25jSTi+uNGj9L5XvXvf20guC69gQvZ+cg49tTxbepfFVuNNQ==",
+      "dev": true,
+      "requires": {
+        "@volar/typescript": "~1.10.3",
+        "@vue/language-core": "1.8.18"
+      }
     },
     "acorn": {
       "version": "8.8.2",
@@ -5726,9 +5733,9 @@
       "dev": true
     },
     "muggle-string": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.2.2.tgz",
-      "integrity": "sha512-YVE1mIJ4VpUMqZObFndk9CJu6DBJR/GB13p3tXuNbwD4XExaI5EOuRl6BHeIDxIqXZVxSfAC+y6U1Z/IxCfKUg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
       "dev": true
     },
     "mylas": {
@@ -6146,9 +6153,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -6536,13 +6543,14 @@
       }
     },
     "vue-tsc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.2.0.tgz",
-      "integrity": "sha512-rIlzqdrhyPYyLG9zxsVRa+JEseeS9s8F2BbVVVWRRsTZvJO2BbhLEb2HW3MY+DFma0378tnIqs+vfTzbcQtRFw==",
+      "version": "1.8.18",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.18.tgz",
+      "integrity": "sha512-AwQxBB9SZX308TLL1932P1JByuMsXC2jLfRBGt8SBdm1e3cXkDlFaXUAqibfKnoQ1ZC2zO2NSbeBNdSjOcdvJw==",
       "dev": true,
       "requires": {
-        "@volar/vue-language-core": "1.2.0",
-        "@volar/vue-typescript": "1.2.0"
+        "@vue/language-core": "1.8.18",
+        "@vue/typescript": "1.8.18",
+        "semver": "^7.5.4"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "tsc-alias": "^1.8.5",
     "typescript": "^5.0.4",
     "vite": "^4.3.9",
-    "vue-tsc": "^1.2.0"
+    "vue-tsc": "^1.8.18"
   },
   "dependencies": {
     "@floating-ui/vue": "^1.0.1",

--- a/src/composables/forms.ts
+++ b/src/composables/forms.ts
@@ -1,5 +1,78 @@
-import { computed, ref, useAttrs } from "vue"
+import { computed, useAttrs } from "vue"
 import Uniques from "@/helpers/Uniques"
+
+export interface Input {
+  modelValue?: any
+  error?: string
+  label?: string
+  help?: string
+  placeholder?: string
+}
+
+export interface InputOption {
+  disabled?: boolean
+  help?: string
+  label: string
+  sublabel?: string
+  value: string | number
+}
+
+export interface BooleanInput extends Input {
+  modelValue?: boolean | null
+}
+
+export interface DateRangeInput extends Input {
+  modelValue?: {
+    minDate: number
+    maxDate: number
+  }
+  maxRange?: number
+  startDate?: number
+}
+
+export interface TextLikeInput extends Input {
+  modelValue?: string | number | null
+  type: TextInputType
+}
+
+export interface TextareaInput extends Input {
+  modelValue?: string | number | null
+}
+
+export interface OptionsInput extends Input {
+  modelValue?: string | number | null
+  options: InputOption[]
+}
+
+export interface MultiChoiceInput extends Input {
+  modelValue?: (string | number)[] | null
+  options: InputOption[]
+}
+
+export interface ColumnedInput {
+  columns?: 2 | 3
+}
+
+export const defaultInputProps = {
+  error: "",
+  label: "",
+  help: "",
+  placeholder: "",
+}
+
+export type TextInputType =
+  | "date"
+  | "datetime-local"
+  | "email"
+  | "month"
+  | "number"
+  | "password"
+  | "search"
+  | "tel"
+  | "text"
+  | "time"
+  | "url"
+  | "week"
 
 export const useInputField = () => {
   const attrs = useAttrs()

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -1,41 +1,14 @@
 <script setup lang="ts">
 import InputLabel from "./InputLabel.vue"
 import InputHelp from "./InputHelp.vue"
-import { useInputField } from "@/composables/forms"
+import { useInputField, defaultInputProps } from "@/composables/forms"
+import type { TextLikeInput } from "@/composables/forms"
 
 defineOptions({
   inheritAttrs: false,
 })
 
-type TextLikeInputs =
-  | "date"
-  | "datetime-local"
-  | "email"
-  | "month"
-  | "number"
-  | "password"
-  | "search"
-  | "tel"
-  | "text"
-  | "time"
-  | "url"
-  | "week"
-
-withDefaults(
-  defineProps<{
-    type: TextLikeInputs
-    help?: string
-    label?: string
-    modelValue?: string | number
-    error?: string
-  }>(),
-  {
-    help: "",
-    label: "",
-    modelValue: "",
-    error: "",
-  }
-)
+withDefaults(defineProps<TextLikeInput>(), defaultInputProps)
 
 defineEmits(["update:modelValue"])
 const { inputID } = useInputField()
@@ -61,6 +34,7 @@ const { inputID } = useInputField()
           ? 'text-red-900 ring-red-700 placeholder:text-red-300 focus:ring-red-700'
           : 'text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-xy-blue-500',
       ]"
+      :placeholder="placeholder"
       :type="type"
       :value="modelValue"
       v-bind="$attrs"

--- a/src/lib-components/forms/Checkbox.vue
+++ b/src/lib-components/forms/Checkbox.vue
@@ -1,25 +1,15 @@
 <script setup lang="ts">
 import InputLabel from "./InputLabel.vue"
 import InputHelp from "./InputHelp.vue"
-import { useInputField } from "@/composables/forms"
+import { useInputField, defaultInputProps } from "@/composables/forms"
+import type { BooleanInput } from "@/composables/forms"
 
 defineOptions({
   inheritAttrs: false,
 })
 
-withDefaults(
-  defineProps<{
-    label?: string
-    help?: string
-    modelValue: boolean
-    error?: string
-  }>(),
-  {
-    label: "",
-    help: "",
-    error: "",
-  }
-)
+withDefaults(defineProps<BooleanInput>(), defaultInputProps)
+
 const emits = defineEmits(["update:modelValue"])
 const { inputID, isDisabled } = useInputField()
 </script>
@@ -31,7 +21,7 @@ const { inputID, isDisabled } = useInputField()
         :id="inputID"
         :aria-labelledby="label ? `${inputID}-label` : undefined"
         :aria-describedby="help ? `${inputID}-help` : undefined"
-        :checked="modelValue"
+        :checked="modelValue || undefined"
         :class="[
           'h-4 w-4 rounded text-xy-blue cursor-pointer',
           'disabled:bg-gray-100 disabled:border-gray-200  disabled:cursor-not-allowed disabled:opacity-100',

--- a/src/lib-components/forms/DateRangePicker.vue
+++ b/src/lib-components/forms/DateRangePicker.vue
@@ -3,30 +3,25 @@ import flatpickr from "flatpickr"
 import "flatpickr/dist/flatpickr.min.css"
 import { onMounted } from "vue"
 import BaseInput from "./BaseInput.vue"
-import { useInputField } from "@/composables/forms"
+import { defaultInputProps, useInputField } from "@/composables/forms"
+import type { DateRangeInput } from "@/composables/forms"
 
 defineOptions({
   inheritAttrs: false,
 })
 
-const props = withDefaults(
-  defineProps<{
-    modelValue: {
-      minDate: number
-      maxDate: number
+const props = withDefaults(defineProps<DateRangeInput>(), {
+  ...defaultInputProps,
+  maxRange: 0,
+  modelValue: () => {
+    return {
+      maxDate: 0,
+      minDate: 0,
     }
-    maxRange?: number
-    startDate?: number
-    label?: string
-    help?: string
-  }>(),
-  {
-    maxRange: 0,
-    startDate: 0,
-    label: "",
-    help: "",
-  }
-)
+  },
+  placeholder: "mm-dd-yyyy range",
+  startDate: 0,
+})
 
 const emits = defineEmits(["update:modelValue"])
 const { inputID } = useInputField()
@@ -94,9 +89,10 @@ onMounted(() => {
 <template>
   <BaseInput
     :id="inputID"
-    type="text"
-    placeholder="mm-dd-yyyy range"
-    :label="label"
+    :error="error"
     :help="help"
+    :label="label"
+    :placeholder="placeholder"
+    type="text"
   />
 </template>

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -2,7 +2,8 @@
 import FieldsetLegend from "./FieldsetLegend.vue"
 import InputLabel from "./InputLabel.vue"
 import InputHelp from "./InputHelp.vue"
-import { useInputField } from "@/composables/forms"
+import { useInputField, defaultInputProps } from "@/composables/forms"
+import type { MultiChoiceInput, ColumnedInput } from "@/composables/forms"
 
 defineOptions({
   inheritAttrs: false,
@@ -12,25 +13,8 @@ type CheckboxValue = string | number
 type ModelValue = CheckboxValue[]
 
 const props = withDefaults(
-  defineProps<{
-    options: {
-      disabled?: boolean
-      help?: string
-      label: string
-      value: CheckboxValue
-    }[]
-    help?: string
-    label?: string
-    modelValue: ModelValue
-    columns?: 2 | 3
-    error?: string
-  }>(),
-  {
-    help: "",
-    label: "",
-    columns: undefined,
-    error: "",
-  }
+  defineProps<MultiChoiceInput & ColumnedInput>(),
+  defaultInputProps
 )
 
 const emit = defineEmits<{
@@ -40,7 +24,8 @@ const emit = defineEmits<{
 const { inputID, isDisabled } = useInputField()
 
 const onChange = (checked: boolean, val: CheckboxValue) => {
-  let updateModelValue = [...props.modelValue]
+  // TODO: test this undefined scenario
+  let updateModelValue = props.modelValue ? [...props.modelValue] : []
 
   if (checked) {
     updateModelValue.push(val)
@@ -84,7 +69,7 @@ const onChange = (checked: boolean, val: CheckboxValue) => {
               :aria-describedby="
                 option.help ? `${inputID}-${index}-help` : undefined
               "
-              :checked="modelValue.includes(option.value)"
+              :checked="modelValue?.includes(option.value)"
               :disabled="option.disabled"
               :class="[
                 'h-4 w-4 rounded cursor-pointer',

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -2,34 +2,14 @@
 import FieldsetLegend from "./FieldsetLegend.vue"
 import InputHelp from "./InputHelp.vue"
 import InputLabel from "./InputLabel.vue"
-import { useInputField } from "@/composables/forms"
+import { useInputField, defaultInputProps } from "@/composables/forms"
+import type { OptionsInput, ColumnedInput } from "@/composables/forms"
 
 defineOptions({
   inheritAttrs: false,
 })
 
-withDefaults(
-  defineProps<{
-    options: {
-      disabled?: boolean
-      help?: string
-      label: string
-      value: string | number
-    }[]
-    help?: string
-    label?: string
-    modelValue?: string | number
-    columns?: 2 | 3
-    error?: string
-  }>(),
-  {
-    help: "",
-    label: "",
-    modelValue: undefined,
-    columns: undefined,
-    error: "",
-  }
-)
+withDefaults(defineProps<OptionsInput & ColumnedInput>(), defaultInputProps)
 
 defineEmits(["update:modelValue"])
 const { inputID, isDisabled } = useInputField()
@@ -95,7 +75,6 @@ const { inputID, isDisabled } = useInputField()
                   : 'cursor-pointer'
               "
             />
-
             <InputHelp :id="`${inputID}-${index}-help`" :text="option.help" />
           </div>
         </div>

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="T extends InputOption">
 import {
   RadioGroup,
   RadioGroupDescription,
@@ -10,7 +10,12 @@ import { computed, ref } from "vue"
 import InputLabel from "./InputLabel.vue"
 import InputHelp from "./InputHelp.vue"
 import FieldsetLegend from "./FieldsetLegend.vue"
-import { useInputField } from "@/composables/forms"
+import { defaultInputProps, useInputField } from "@/composables/forms"
+import type {
+  ColumnedInput,
+  InputOption,
+  OptionsInput,
+} from "@/composables/forms"
 
 defineOptions({
   inheritAttrs: false,
@@ -20,41 +25,19 @@ defineOptions({
  * NOTE (spk) headless UI introduced a "name" prop that includes a hidden field
  * to use the modelValue inside of forms.  It does not however resolve the issue of
  * supporting HTML5 form validation, so we'll add our own hidden radio buttons to support both.
- *
- * The headless technique does include supporting complex modelValues such as objects, which we may
- * need in the future.  We can revist required validation at that time using a singular hidden checkbox.
  */
 
-type ModelValue = string | number
-
-type RadioCard = {
-  disabled?: boolean
-  help?: string
-  label: string
-  sublabel?: string
-  value: ModelValue
+interface RadioCards extends OptionsInput {
+  options: T[]
 }
 
 const props = withDefaults(
-  defineProps<{
-    columns?: 2 | 3
-    help?: string
-    label?: string
-    modelValue?: ModelValue
-    options: RadioCard[]
-    error?: string
-  }>(),
-  {
-    columns: undefined,
-    help: "",
-    label: "",
-    modelValue: undefined,
-    error: "",
-  }
+  defineProps<RadioCards & ColumnedInput>(),
+  defaultInputProps
 )
 
 const emit = defineEmits<{
-  (e: "update:modelValue", modelValue: ModelValue): void
+  (e: "update:modelValue", modelValue: RadioCards["modelValue"]): void
 }>()
 
 const { inputID, isDisabled, isRequired, nameAttr } = useInputField()
@@ -74,7 +57,7 @@ const checkedState = computed(() => {
   return props.modelValue
 })
 
-const onChange = (val: ModelValue) => {
+const onChange = (val: RadioCards["modelValue"]) => {
   internalState.value = val
   invalid.value = false
   emit("update:modelValue", val)

--- a/src/lib-components/forms/Select.vue
+++ b/src/lib-components/forms/Select.vue
@@ -1,28 +1,17 @@
 <script setup lang="ts">
 import InputLabel from "./InputLabel.vue"
 import InputHelp from "./InputHelp.vue"
-import { useInputField } from "@/composables/forms"
+import { defaultInputProps, useInputField } from "@/composables/forms"
+import type { OptionsInput } from "@/composables/forms"
 
 defineOptions({
   inheritAttrs: false,
 })
 
-withDefaults(
-  defineProps<{
-    label?: string
-    help?: string
-    placeholder?: string
-    options: { label: string; value: string | number }[]
-    modelValue: string | number | undefined
-    error?: string
-  }>(),
-  {
-    label: "",
-    help: "",
-    placeholder: "Select an option",
-    error: "",
-  }
-)
+withDefaults(defineProps<OptionsInput>(), {
+  ...defaultInputProps,
+  placeholder: "Select an option",
+})
 
 const emit = defineEmits(["update:modelValue"])
 const { inputID } = useInputField()
@@ -55,17 +44,12 @@ const { inputID } = useInputField()
       },
     }"
     >
-      <option
-        v-if="placeholder"
-        value=""
-        disabled
-        selected
-        v-text="placeholder"
-      />
+      <option value="" disabled selected v-text="placeholder" />
       <option
         v-for="option in options"
         :key="option.value"
         :value="option.value"
+        :disabled="option.disabled"
         v-text="option.label"
       />
     </select>

--- a/src/lib-components/forms/TextArea.vue
+++ b/src/lib-components/forms/TextArea.vue
@@ -1,26 +1,14 @@
 <script setup lang="ts">
 import InputLabel from "./InputLabel.vue"
 import InputHelp from "./InputHelp.vue"
-import { useInputField } from "@/composables/forms"
+import { useInputField, defaultInputProps } from "@/composables/forms"
+import type { TextareaInput } from "@/composables/forms"
 
 defineOptions({
   inheritAttrs: false,
 })
 
-withDefaults(
-  defineProps<{
-    help?: string
-    label?: string
-    modelValue?: string | number
-    error?: string
-  }>(),
-  {
-    help: "",
-    label: "",
-    modelValue: "",
-    error: "",
-  }
-)
+withDefaults(defineProps<TextareaInput>(), defaultInputProps)
 
 const emit = defineEmits(["update:modelValue"])
 const { inputID } = useInputField()
@@ -45,7 +33,7 @@ const { inputID } = useInputField()
           ? 'text-red-900 ring-red-700 placeholder:text-red-300 focus:ring-red-700'
           : 'text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-xy-blue-500',
       ]"
-      :value="modelValue"
+      :value="modelValue || undefined"
       v-bind="$attrs"
       @input="
         emit('update:modelValue', ($event.target as HTMLInputElement).value)

--- a/src/lib-components/forms/Toggle.vue
+++ b/src/lib-components/forms/Toggle.vue
@@ -15,12 +15,11 @@ defineOptions({
 
 withDefaults(
   defineProps<{
-    modelValue?: boolean | undefined
+    modelValue?: boolean
     label?: string
     help?: string
   }>(),
   {
-    modelValue: undefined,
     label: "",
     help: "",
   }

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -1,26 +1,14 @@
 <script setup lang="ts">
 import InputLabel from "./InputLabel.vue"
 import InputHelp from "./InputHelp.vue"
-import { useInputField } from "@/composables/forms"
+import { useInputField, defaultInputProps } from "@/composables/forms"
+import type { BooleanInput } from "@/composables/forms"
 
 defineOptions({
   inheritAttrs: false,
 })
 
-withDefaults(
-  defineProps<{
-    modelValue?: boolean
-    help?: string
-    label?: string
-    error?: string
-  }>(),
-  {
-    modelValue: undefined,
-    help: "",
-    label: "",
-    error: "",
-  }
-)
+withDefaults(defineProps<BooleanInput>(), defaultInputProps)
 
 const emits = defineEmits(["update:modelValue"])
 const { inputID, isDisabled, nameAttr } = useInputField()


### PR DESCRIPTION
> PR 2 of 3 related to [Form Input Updates](https://www.notion.so/xylabs/8f16954aa3494675837f0cceb6a21c95?v=9d015d84f6fa48fe837c8ad0f6ab5be8&p=ecae8501d1924fa88b6561c05235759b&pm=s)

# What this does

- Attempts to normalize form input props as much as possible and extracts types as needed (this is part of the broader goal of developing a form schema and simplifying new input development)
- Adds generic to `RadioCards` option type to help support type inference inside the `sublabel` slot (primarily support Portal's use case with benefits)
- Establishes that v-model is an optional prop across all inputs (this seems to be desirable from a flexibility standpoint, and as we dig further into partial updates)
- Bumps vue-tsc@latest to get generic component support

## Notes

- PR 3 catches a small handful of inconsistencies in the way events and attributes are bound to inputs