### PR TITLE
feature: inline alert component

### DIFF
--- a/dev/content/Elements.vue
+++ b/dev/content/Elements.vue
@@ -2,6 +2,8 @@
 import { ref } from "vue"
 import ColorRow from "../../dev/helpers/ColorRow.vue"
 import colors from "../../config/theme/colors"
+import PropsTable from "../../dev/helpers/PropsTable.vue"
+import { InputOption } from "@/composables/forms"
 
 const badgePrimary = ref<HTMLElement>()
 const badgeInfo = ref<HTMLElement>()
@@ -25,17 +27,110 @@ const weights = [
   "font-bold",
   "font-extrabold",
 ]
+
+const alertTypes = ["alert", "warn", "info", "success"] as const
+const alertOptions: InputOption[] = alertTypes.map((t) => {
+  return { label: `${t.charAt(0).toUpperCase()}${t.slice(1)}`, value: t }
+})
+const alertSelection = ref<(typeof alertTypes)[number]>("alert")
+const alert = (msg: string) => window.alert(msg)
+const alertProps = [
+  { name: "btnLink", required: false, type: "string" },
+  { name: "btnText", required: false, type: "string" },
+  { name: "content", required: true, type: "string | string[]" },
+  { name: "dismissable", required: false, type: "boolean" },
+  { name: "secondaryBtnLink", required: false, type: "string" },
+  { name: "secondaryBtnText", required: false, type: "string" },
+  { name: "title", required: false, type: "string" },
+  { name: "type", required: true, type: "alert | warn | info | success" },
+]
 </script>
+
 <template>
   <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
     <div class="max-w-3xl mx-auto space-y-8">
       <ComponentLayout :css-component="true" title="Colors">
-        <template #description> </template>
         <div
           class="grid grid-cols-[repeat(auto-fit,minmax(8rem,1fr))] gap-x-2 gap-y-8 sm:grid-cols-1"
         >
           <ColorRow name="" :colors="colors['xy-blue']" code="xy-blue" />
           <ColorRow name="" :colors="colors['xy-green']" code="xy-green" />
+        </div>
+      </ComponentLayout>
+
+      <ComponentLayout :css-component="false" title="Alerts">
+        <template #description
+          >Sometimes you need to get their attention and sometimes they need
+          some direction. Alerts, we got em.</template
+        >
+
+        <div class="space-y-8">
+          <div v-for="t in alertTypes" :key="t">
+            <p class="font-medium text-sm mb-1">
+              {{ `${t.charAt(0).toUpperCase()}${t.slice(1)}` }}
+            </p>
+            <InlineAlert
+              ref="alertComponent"
+              content="Arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit."
+              title="Orci eu lobortis elementum"
+              :type="t"
+            />
+          </div>
+
+          <Select
+            v-model="alertSelection"
+            label="Alert Type"
+            :options="alertOptions"
+          />
+
+          <div>
+            <p class="font-medium text-sm mb-1">Simple Content</p>
+            <InlineAlert
+              content="Arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit."
+              :type="alertSelection"
+            />
+          </div>
+
+          <div>
+            <p class="font-medium text-sm mb-1">List Content</p>
+            <InlineAlert
+              :content="[
+                'Arcu cursus euismod quis viverra nibh.',
+                'Cras pulvinar mattis nunc sed blandit.',
+              ]"
+              title="Orci eu lobortis elementum"
+              :type="alertSelection"
+            />
+          </div>
+
+          <div>
+            <p class="font-medium text-sm mb-1">With Actions</p>
+            <InlineAlert
+              btn-text="Learn More"
+              btn-link="https://theuselessweb.com/"
+              content="Arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit."
+              secondary-btn-text="Announce it"
+              title="Orci eu lobortis elementum"
+              :type="alertSelection"
+              @click:secondary.prevent="alert('Clicked It!')"
+            />
+          </div>
+
+          <div>
+            <p class="font-medium text-sm mb-1">Dismissable</p>
+            <InlineAlert
+              btn-text="Learn More"
+              btn-link="https://theuselessweb.com/"
+              content="Arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit."
+              :dismissable="true"
+              secondary-btn-text="Announce it"
+              title="Orci eu lobortis elementum"
+              :type="alertSelection"
+              @click:secondary.prevent="alert('Clicked It!')"
+            />
+          </div>
+
+          <PropsTable :props="alertProps" />
         </div>
       </ComponentLayout>
 

--- a/dev/content/Elements.vue
+++ b/dev/content/Elements.vue
@@ -28,21 +28,21 @@ const weights = [
   "font-extrabold",
 ]
 
-const alertTypes = ["alert", "warn", "info", "success"] as const
-const alertOptions: InputOption[] = alertTypes.map((t) => {
+const alertKinds = ["alert", "warn", "info", "success"] as const
+const alertOptions: InputOption[] = alertKinds.map((t) => {
   return { label: `${t.charAt(0).toUpperCase()}${t.slice(1)}`, value: t }
 })
-const alertSelection = ref<(typeof alertTypes)[number]>("alert")
+const alertSelection = ref<(typeof alertKinds)[number]>("alert")
 const alert = (msg: string) => window.alert(msg)
 const alertProps = [
   { name: "btnLink", required: false, type: "string" },
   { name: "btnText", required: false, type: "string" },
   { name: "content", required: true, type: "string | string[]" },
   { name: "dismissable", required: false, type: "boolean" },
+  { name: "kind", required: true, type: "alert | warn | info | success" },
   { name: "secondaryBtnLink", required: false, type: "string" },
   { name: "secondaryBtnText", required: false, type: "string" },
   { name: "title", required: false, type: "string" },
-  { name: "type", required: true, type: "alert | warn | info | success" },
 ]
 </script>
 
@@ -65,15 +65,15 @@ const alertProps = [
         >
 
         <div class="space-y-8">
-          <div v-for="t in alertTypes" :key="t">
+          <div v-for="kind in alertKinds" :key="kind">
             <p class="font-medium text-sm mb-1">
-              {{ `${t.charAt(0).toUpperCase()}${t.slice(1)}` }}
+              {{ `${kind.charAt(0).toUpperCase()}${kind.slice(1)}` }}
             </p>
             <InlineAlert
               ref="alertComponent"
               content="Arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit."
+              :kind="kind"
               title="Orci eu lobortis elementum"
-              :type="t"
             />
           </div>
 
@@ -87,7 +87,7 @@ const alertProps = [
             <p class="font-medium text-sm mb-1">Simple Content</p>
             <InlineAlert
               content="Arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit."
-              :type="alertSelection"
+              :kind="alertSelection"
             />
           </div>
 
@@ -98,8 +98,8 @@ const alertProps = [
                 'Arcu cursus euismod quis viverra nibh.',
                 'Cras pulvinar mattis nunc sed blandit.',
               ]"
+              :kind="alertSelection"
               title="Orci eu lobortis elementum"
-              :type="alertSelection"
             />
           </div>
 
@@ -109,9 +109,9 @@ const alertProps = [
               btn-text="Learn More"
               btn-link="https://theuselessweb.com/"
               content="Arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit."
+              :kind="alertSelection"
               secondary-btn-text="Announce it"
               title="Orci eu lobortis elementum"
-              :type="alertSelection"
               @click:secondary.prevent="alert('Clicked It!')"
             />
           </div>
@@ -125,7 +125,7 @@ const alertProps = [
               :dismissable="true"
               secondary-btn-text="Announce it"
               title="Orci eu lobortis elementum"
-              :type="alertSelection"
+              :kind="alertSelection"
               @click:secondary.prevent="alert('Clicked It!')"
             />
           </div>

--- a/src/lib-components/forms/InputLabel.vue
+++ b/src/lib-components/forms/InputLabel.vue
@@ -38,6 +38,6 @@ const labelDisplay = computed((): string => {
     v-bind="$attrs"
   >
     {{ labelDisplay }}
-    <span v-if="props.required" class="text-red-700/80">*</span>
+    <span v-if="props.required" class="text-red-700/80" aria-hidden>*</span>
   </component>
 </template>

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -5,7 +5,7 @@ import InputHelp from "./InputHelp.vue"
 import InputError from "./InputError.vue"
 import { useInputField, defaultInputProps } from "@/composables/forms"
 import type { MultiChoiceInput, ColumnedInput } from "@/composables/forms"
-import { computed, ref, watch } from "vue"
+import { computed, ref } from "vue"
 
 defineOptions({
   inheritAttrs: false,

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -8,6 +8,7 @@ import { default as DateFilter } from "./layout/DateFilter.vue"
 import { default as DetailList } from "./lists/DetailList.vue"
 import { default as DownloadCell } from "./lists/DownloadCell.vue"
 import { default as Flash } from "./overlays/Flash.vue"
+import { default as InlineAlert } from "./indicators/InlineAlert.vue"
 import { default as Modal } from "./overlays/Modal.vue"
 import { default as SidebarLayout } from "./layout/SidebarLayout.vue"
 import { default as Popover } from "./overlays/Popover/Popover.vue"
@@ -48,6 +49,7 @@ export {
   DetailList,
   DownloadCell,
   Flash,
+  InlineAlert,
   Modal,
   SidebarLayout,
   Slideover,

--- a/src/lib-components/indicators/InlineAlert.vue
+++ b/src/lib-components/indicators/InlineAlert.vue
@@ -181,10 +181,9 @@ const icon = computed(() => {
         </div>
       </div>
 
-      <div class="ml-auto pl-3">
+      <div v-if="dismissable" class="ml-auto pl-3">
         <div class="-mx-1.5 -my-1.5">
           <button
-            v-if="dismissable"
             class="inline-flex rounded-md p-1.5 focus:outline-none focus:ring-2 focus:ring-offset-2"
             :class="display.btnClose"
             type="button"

--- a/src/lib-components/indicators/InlineAlert.vue
+++ b/src/lib-components/indicators/InlineAlert.vue
@@ -19,7 +19,7 @@ const props = withDefaults(
     secondaryBtnLink?: string
     secondaryBtnText?: string
     title?: string
-    type: "alert" | "warn" | "info" | "success"
+    kind: "alert" | "warn" | "info" | "success"
   }>(),
   {
     btnLink: "",
@@ -50,10 +50,9 @@ const display = computed(() => {
     btnClose: "",
     contentColor: "",
     iconColor: "",
-    titleColor: "",
   }
 
-  switch (props.type) {
+  switch (props.kind) {
     case "alert":
       display.bgColor = "bg-red-50"
       display.btnAction =
@@ -62,7 +61,6 @@ const display = computed(() => {
         "bg-red-50 text-red-600 hover:bg-red-100 focus:ring-red-600 focus:ring-offset-red-50"
       display.contentColor = "text-red-800"
       display.iconColor = "text-red-400"
-      display.titleColor = "text-red-800"
       break
     case "info":
       display.bgColor = "bg-blue-50"
@@ -72,7 +70,6 @@ const display = computed(() => {
         "bg-blue-50 text-blue-600 hover:bg-blue-100 focus:ring-blue-600 focus:ring-offset-blue-50"
       display.contentColor = "text-blue-800"
       display.iconColor = "text-blue-400"
-      display.titleColor = "text-blue-800"
       break
     case "success":
       display.bgColor = "bg-emerald-50"
@@ -82,7 +79,6 @@ const display = computed(() => {
         "bg-emerald-50 text-emerald-600 hover:bg-emerald-100 focus:ring-emerald-600 focus:ring-offset-emerald-50"
       display.contentColor = "text-emerald-800"
       display.iconColor = "text-emerald-400"
-      display.titleColor = "text-emerald-800"
       break
     case "warn":
       display.bgColor = "bg-amber-50"
@@ -92,7 +88,6 @@ const display = computed(() => {
         "bg-amber-50 text-amber-600 hover:bg-amber-100 focus:ring-amber-600 focus:ring-offset-amber-50"
       display.contentColor = "text-amber-800"
       display.iconColor = "text-amber-400"
-      display.titleColor = "text-amber-800"
       break
   }
 
@@ -101,7 +96,7 @@ const display = computed(() => {
 
 const icon = computed(() => {
   let icon = null
-  switch (props.type) {
+  switch (props.kind) {
     case "alert":
       icon = XCircleIcon
       break
@@ -135,7 +130,7 @@ const icon = computed(() => {
         <h3
           v-if="title"
           class="text-sm leading-snug font-semibold mb-1.5"
-          :class="display.titleColor"
+          :class="display.contentColor"
         >
           {{ title }}
         </h3>

--- a/src/lib-components/indicators/InlineAlert.vue
+++ b/src/lib-components/indicators/InlineAlert.vue
@@ -121,7 +121,7 @@ const icon = computed(() => {
 </script>
 
 <template>
-  <div v-if="visible" class="rounded-lg p-4" :class="[display.bgColor]">
+  <div v-if="visible" class="rounded-lg p-4" :class="display.bgColor">
     <div class="flex">
       <div class="flex-shrink-0">
         <component
@@ -140,7 +140,7 @@ const icon = computed(() => {
           {{ title }}
         </h3>
 
-        <div class="text-sm" :class="[display.contentColor]">
+        <div class="text-sm" :class="display.contentColor">
           <ul
             v-if="Array.isArray(content)"
             role="list"

--- a/src/lib-components/indicators/InlineAlert.vue
+++ b/src/lib-components/indicators/InlineAlert.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+import { computed, ref } from "vue"
+
+import {
+  CheckCircleIcon,
+  InformationCircleIcon,
+  ExclamationIcon,
+  XCircleIcon,
+} from "@heroicons/vue/solid"
+
+import { XIcon } from "@heroicons/vue/outline"
+
+const props = withDefaults(
+  defineProps<{
+    btnLink?: string
+    btnText?: string
+    content: string | string[]
+    dismissable?: boolean
+    secondaryBtnLink?: string
+    secondaryBtnText?: string
+    title?: string
+    type: "alert" | "warn" | "info" | "success"
+  }>(),
+  {
+    btnLink: "",
+    btnText: "",
+    dismissable: false,
+    secondaryBtnLink: "",
+    secondaryBtnText: "",
+    title: "",
+  }
+)
+
+const emit = defineEmits<{
+  close: [closed: true]
+  click: [e: Event]
+  "click:secondary": [e: Event]
+}>()
+
+const visible = ref(true)
+const close = () => {
+  visible.value = false
+  emit("close", true)
+}
+
+const display = computed(() => {
+  const display = {
+    bgColor: "",
+    btnAction: "",
+    btnClose: "",
+    contentColor: "",
+    iconColor: "",
+    titleColor: "",
+  }
+
+  switch (props.type) {
+    case "alert":
+      display.bgColor = "bg-red-50"
+      display.btnAction =
+        "bg-red-50 text-red-900 hover:bg-red-100 focus:ring-red-600 focus:ring-offset-red-50"
+      display.btnClose =
+        "bg-red-50 text-red-600 hover:bg-red-100 focus:ring-red-600 focus:ring-offset-red-50"
+      display.contentColor = "text-red-800"
+      display.iconColor = "text-red-400"
+      display.titleColor = "text-red-800"
+      break
+    case "info":
+      display.bgColor = "bg-blue-50"
+      display.btnAction =
+        "bg-blue-50 text-blue-900 hover:bg-blue-100 focus:ring-blue-600 focus:ring-offset-blue-50"
+      display.btnClose =
+        "bg-blue-50 text-blue-600 hover:bg-blue-100 focus:ring-blue-600 focus:ring-offset-blue-50"
+      display.contentColor = "text-blue-800"
+      display.iconColor = "text-blue-400"
+      display.titleColor = "text-blue-800"
+      break
+    case "success":
+      display.bgColor = "bg-emerald-50"
+      display.btnAction =
+        "bg-emerald-50 text-emerald-900 hover:bg-emerald-100 focus:ring-emerald-600 focus:ring-offset-emerald-50"
+      display.btnClose =
+        "bg-emerald-50 text-emerald-600 hover:bg-emerald-100 focus:ring-emerald-600 focus:ring-offset-emerald-50"
+      display.contentColor = "text-emerald-800"
+      display.iconColor = "text-emerald-400"
+      display.titleColor = "text-emerald-800"
+      break
+    case "warn":
+      display.bgColor = "bg-amber-50"
+      display.btnAction =
+        "bg-amber-50 text-amber-900 hover:bg-amber-100 focus:ring-amber-600 focus:ring-offset-amber-50"
+      display.btnClose =
+        "bg-amber-50 text-amber-600 hover:bg-amber-100 focus:ring-amber-600 focus:ring-offset-amber-50"
+      display.contentColor = "text-amber-800"
+      display.iconColor = "text-amber-400"
+      display.titleColor = "text-amber-800"
+      break
+  }
+
+  return display
+})
+
+const icon = computed(() => {
+  let icon = null
+  switch (props.type) {
+    case "alert":
+      icon = XCircleIcon
+      break
+    case "info":
+      icon = InformationCircleIcon
+      break
+    case "success":
+      icon = CheckCircleIcon
+      break
+    case "warn":
+      icon = ExclamationIcon
+      break
+  }
+
+  return icon
+})
+</script>
+
+<template>
+  <div v-if="visible" class="rounded-lg p-4" :class="[display.bgColor]">
+    <div class="flex">
+      <div class="flex-shrink-0">
+        <component
+          :is="icon"
+          class="h-5 w-5"
+          :class="display.iconColor"
+          aria-hidden="true"
+        />
+      </div>
+      <div class="ml-2.5">
+        <h3
+          v-if="title"
+          class="text-sm leading-snug font-semibold mb-1.5"
+          :class="display.titleColor"
+        >
+          {{ title }}
+        </h3>
+
+        <div class="text-sm" :class="[display.contentColor]">
+          <ul
+            v-if="Array.isArray(content)"
+            role="list"
+            class="list-disc space-y-1 pl-5"
+          >
+            <li v-for="(item, index) in content" :key="index">{{ item }}</li>
+          </ul>
+          <p v-else>{{ content }}</p>
+        </div>
+
+        <div v-if="btnText || secondaryBtnText" class="mt-4">
+          <div
+            class="flex flex-col gap-y-1.5 -mx-2 sm:flex-row sm:gap-x-3 sm:items-center"
+          >
+            <div v-if="btnText">
+              <a
+                class="inline-flex rounded-md px-2 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2"
+                :class="display.btnAction"
+                :href="btnLink"
+                :role="btnLink ? 'link' : 'button'"
+                @click="$emit('click', $event)"
+              >
+                {{ btnText }}
+              </a>
+            </div>
+            <div v-if="secondaryBtnText">
+              <a
+                class="inline-flex rounded-md px-2 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2"
+                :class="display.btnAction"
+                :href="secondaryBtnLink"
+                :role="secondaryBtnLink ? 'link' : 'button'"
+                @click="$emit('click:secondary', $event)"
+              >
+                {{ secondaryBtnText }}
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="ml-auto pl-3">
+        <div class="-mx-1.5 -my-1.5">
+          <button
+            v-if="dismissable"
+            class="inline-flex rounded-md p-1.5 focus:outline-none focus:ring-2 focus:ring-offset-2"
+            :class="display.btnClose"
+            type="button"
+            @click="close"
+          >
+            <span class="sr-only">close</span>
+            <XIcon class="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
# What this does

- adds the `InlineAlert` component

## Notes

- styling is mostly a copy/paste from the existing alert in Archive/Tailwind UI
- prop names diverge a bit from what's currently in use in Portal and Archive and does not support slots
- component API attempts to stay close to CTACard for consistency, but does diverge a bit

### General Types

<img width="801" alt="Screenshot 2023-10-13 at 4 49 16 PM" src="https://github.com/xy-planning-network/trees/assets/3856703/114edd89-5aee-45ce-b160-34d5ec5d8161">

### Variations via Props

<img width="763" alt="Screenshot 2023-10-16 at 10 23 25 AM" src="https://github.com/xy-planning-network/trees/assets/3856703/1fe5fa0b-7f9a-4f80-9d05-35dbfe1ed96c">

