### PR TITLE
composables for tab history and search params history

### DIFF
--- a/dev/content/Navigation.vue
+++ b/dev/content/Navigation.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue"
 import User from "@/composables/user"
-import { ActionItem } from "@/composables/nav"
+import { ActionItem, useTabHistory } from "@/composables/nav"
 
 defineProps<{
   user: User
@@ -11,7 +11,6 @@ const actionsDropdownCopy = `<ActionsDropdown :items="items" />`
 const actionsDropdownProps = [
   { name: "items", required: true, type: "ActionMenuItem[]" },
 ]
-const currentTab = ref("tab1")
 const showMenuItem = ref(false)
 const menuItems = computed((): ActionItem[] => {
   return [
@@ -41,12 +40,15 @@ const paginatorProps = [
     type: "{ page: number; perPage: number; totalItems: number; totalPages: number; }",
   },
 ]
-const tabs = [
+
+const { activeTab, tabs } = useTabHistory([
   { label: "Tab 1", value: "tab1" },
   { label: "Tab 2", value: "tab2" },
-]
-const tabsCopy = `<Tabs :tabs="tabs" :pill-design="false" v-model="currentTab" />`
+])
+const tabsCopy = `<Tabs v-model="activeTab" :tabs="tabs" :pill-design="false" />`
+const tabsPillDesign = ref(true)
 const tabsProps = [
+  { name: "modelValue", required: true, type: "string" },
   {
     name: "tabs",
     required: true,
@@ -57,7 +59,6 @@ const tabsProps = [
     required: false,
     type: "boolean",
   },
-  { name: "modelValue", required: true, type: "string" },
 ]
 </script>
 <template>
@@ -106,7 +107,8 @@ const tabsProps = [
       <ComponentLayout class="mt-8" title="Tabs">
         <template #description>
           These are used to display different groups of content. It turns into a
-          select on mobile.
+          select on mobile. When combined with the `useTabHistory` composable,
+          the activeTab will be synced with window.location.search params.
         </template>
 
         <div>
@@ -114,9 +116,16 @@ const tabsProps = [
             <ClickToCopy :value="tabsCopy" />
           </label>
           <div class="mt-1">
-            <Tabs v-model="currentTab" :pill-design="true" :tabs="tabs" />
+            <div class="my-6">
+              <Toggle v-model="tabsPillDesign" label="Use Pill Design" />
+            </div>
+            <Tabs
+              v-model="activeTab"
+              :pill-design="tabsPillDesign"
+              :tabs="tabs"
+            />
             <div class="bg-white shadow rounded-lg px-4 py-5 sm:px-6">
-              <span v-if="currentTab === 'tab1'" class="xy-badge-yellow">
+              <span v-if="activeTab === 'tab1'" class="xy-badge-yellow">
                 Tab 1 Content
               </span>
               <span v-else class="xy-badge-blue"> Tab 2 Content </span>

--- a/dev/content/Navigation.vue
+++ b/dev/content/Navigation.vue
@@ -43,7 +43,7 @@ const paginatorProps = [
   },
 ]
 
-const { activeTab, tabs } = useTabHistory([
+const { activeTab, isActiveTab, tabs } = useTabHistory([
   { label: "Tab 1", value: "tab1" },
   { label: "Tab 2", value: "tab2" },
 ])
@@ -127,10 +127,12 @@ const tabsProps = [
               :tabs="tabs"
             />
             <div class="bg-white shadow rounded-lg px-4 py-5 sm:px-6">
-              <span v-if="activeTab === 'tab1'" class="xy-badge-yellow">
+              <span v-if="isActiveTab('tab1')" class="xy-badge-yellow">
                 Tab 1 Content
               </span>
-              <span v-else class="xy-badge-blue"> Tab 2 Content </span>
+              <span v-if="isActiveTab('tab2')" class="xy-badge-blue">
+                Tab 2 Content
+              </span>
             </div>
 
             <div class="my-10">
@@ -144,7 +146,7 @@ const tabsProps = [
                 <!-- prettier-ignore -->
                 <CodeSample>{{`
 <script setup lang="ts">
-const {activeTab, tabs} = useTabHistory(
+const {activeTab, isActiveTab, tabs} = useTabHistory(
     [{label: "Tab One", value: "tab-1"}, {label: "Tab Two", value: "tab-2"}]
 })
 </script>
@@ -155,8 +157,8 @@ const {activeTab, tabs} = useTabHistory(
                 <CodeSample language="html">{{`
 <template>
     <Tabs v-model="activeTab" :tabs="tabs" />
-    <div v-if="activeTab === 'tab-1'">Tab 1 Content</div>
-    <div v-if="activeTab === 'tab-2'">Tab 2 Content</div>
+    <div v-if="isActiveTab('tab-1')">Tab 1 Content</div>
+    <div v-if="isActiveTab('tab-2')">Tab 2 Content</div>
 </template>
 `}}</CodeSample>
               </ProseBase>

--- a/dev/content/Navigation.vue
+++ b/dev/content/Navigation.vue
@@ -145,21 +145,21 @@ const tabsProps = [
                 <h5>Script Setup</h5>
                 <!-- prettier-ignore -->
                 <CodeSample>{{`
-<script setup lang="ts">
+<script setup lang="ts"&gt;
 const {activeTab, isActiveTab, tabs} = useTabHistory(
     [{label: "Tab One", value: "tab-1"}, {label: "Tab Two", value: "tab-2"}]
 })
-</script>
+</script&gt;
 `}}</CodeSample>
 
                 <h5>Template</h5>
                 <!-- prettier-ignore -->
                 <CodeSample language="html">{{`
-<template>
+<template&gt;
     <Tabs v-model="activeTab" :tabs="tabs" />
     <div v-if="isActiveTab('tab-1')">Tab 1 Content</div>
     <div v-if="isActiveTab('tab-2')">Tab 2 Content</div>
-</template>
+</template&gt;
 `}}</CodeSample>
               </ProseBase>
             </div>

--- a/dev/content/Navigation.vue
+++ b/dev/content/Navigation.vue
@@ -2,6 +2,8 @@
 import { computed, ref } from "vue"
 import User from "@/composables/user"
 import { ActionItem, useTabHistory } from "@/composables/nav"
+import ProseBase from "../helpers/ProseBase.vue"
+import CodeSample from "../helpers/CodeSample.vue"
 
 defineProps<{
   user: User
@@ -107,8 +109,8 @@ const tabsProps = [
       <ComponentLayout class="mt-8" title="Tabs">
         <template #description>
           These are used to display different groups of content. It turns into a
-          select on mobile. When combined with the `useTabHistory` composable,
-          the activeTab will be synced with window.location.search params.
+          select on mobile. When combined with the useTabHistory composable, the
+          activeTab will be synced with window.location.search params.
         </template>
 
         <div>
@@ -129,6 +131,35 @@ const tabsProps = [
                 Tab 1 Content
               </span>
               <span v-else class="xy-badge-blue"> Tab 2 Content </span>
+            </div>
+
+            <div class="my-10">
+              <ProseBase>
+                <h4>Example Usage with useTabHistory</h4>
+                <p>
+                  Note: if you don't wish to track the tab state on the url,
+                  just pass your ref and tabs directly to the component.
+                </p>
+                <h5>Script Setup</h5>
+                <!-- prettier-ignore -->
+                <CodeSample>{{`
+<script setup lang="ts">
+const {activeTab, tabs} = useTabHistory(
+    [{label: "Tab One", value: "tab-1"}, {label: "Tab Two", value: "tab-2"}]
+})
+</script>
+`}}</CodeSample>
+
+                <h5>Template</h5>
+                <!-- prettier-ignore -->
+                <CodeSample language="html">{{`
+<template>
+    <Tabs v-model="activeTab" :tabs="tabs" />
+    <div v-if="activeTab === 'tab-1'">Tab 1 Content</div>
+    <div v-if="activeTab === 'tab-2'">Tab 2 Content</div>
+</template>
+`}}</CodeSample>
+              </ProseBase>
             </div>
             <PropsTable :props="tabsProps" />
           </div>

--- a/dev/content/Tools.vue
+++ b/dev/content/Tools.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import BaseAPI from "./Tools/BaseAPI.vue"
 import UseBaseAPI from "./Tools/UseBaseAPI.vue"
+import UseUrlSearchParams from "./Tools/UseUrlSearchParams.vue"
 </script>
 
 <template>
@@ -8,6 +9,7 @@ import UseBaseAPI from "./Tools/UseBaseAPI.vue"
     <div class="max-w-3xl mx-auto space-y-8">
       <BaseAPI />
       <UseBaseAPI />
+      <UseUrlSearchParams />
     </div>
   </div>
 </template>

--- a/dev/content/Tools/UseUrlSearchParams.vue
+++ b/dev/content/Tools/UseUrlSearchParams.vue
@@ -4,16 +4,20 @@ import CodeSample from "../../helpers/CodeSample.vue"
 import ProseBase from "../../helpers/ProseBase.vue"
 
 interface SearchParams {
-    q: string
-    isActive: boolean
+  q: string
+  isActive: boolean
+  attributes: string[]
 }
  
 // NOTE: this should tyically come from the server in the form
 // of a page prop.  Though some exceptions may exist.
 const initialParams: SearchParams = {
-    q: "",
-    isActive: false
+  q: "",
+  isActive: false,
+  attributes: []
 }
+
+const attrOpts = [{label: "Type One", value: "type-one"}, {label: "Type Two", value: "type-two"}, {label: "Type Three", value: "type-three"}]
  
 const searchParams = useUrlSearchParams(initialParams)
  
@@ -29,12 +33,14 @@ const searchParams = useUrlSearchParams(initialParams)
     <ProseBase>
       <h4>Example Usage:</h4>
       <h5>Script Setup</h5>
+      <!-- prettier-ignore -->
       <CodeSample>{{
         `
-<script setup lang="ts">
+<script setup lang="ts"&gt;
 interface SearchParams {
    q: string
    isActive: boolean
+   attributes: string[]
 }
 
 // If you're attempting to hydrate fields with a request that contains search params.
@@ -49,11 +55,13 @@ const searchParams = useUrlSearchParams(props.initialParam)
       }}</CodeSample>
 
       <h5>Template</h5>
+      <!-- prettier-ignore -->
       <CodeSample language="html">{{
         `
-<template>
+<template&gt;
     <BaseInput v-model="searchParams.q" label="Search" type="search" />
     <Checkbox v-model="searchParams.isActive" label="Is Active" />
+    <MultiCheckboxes v-model="searchParams.attributes" label="Attributes" :options="attrOpts" />
 </template&gt;
         `
       }}</CodeSample>
@@ -63,6 +71,7 @@ const searchParams = useUrlSearchParams(props.initialParam)
         <h5>Use the input controls to mutate the search params ref and check the browser url for updates to the query string.</h5>
         <BaseInput v-model="searchParams.q" label="Search" type="search" />
         <Checkbox v-model="searchParams.isActive" label="Is Active" />
+        <MultiCheckboxes v-model="searchParams.attributes" label="Attributes" :options="attrOpts" />
     </div>
   </ComponentLayout>
 </template>

--- a/dev/content/Tools/UseUrlSearchParams.vue
+++ b/dev/content/Tools/UseUrlSearchParams.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { useUrlSearchParams } from "@/composables";
+import CodeSample from "../../helpers/CodeSample.vue"
+import ProseBase from "../../helpers/ProseBase.vue"
+
+interface SearchParams {
+    q: string
+    isActive: boolean
+}
+ 
+// NOTE: this should tyically come from the server in the form
+// of a page prop.  Though some exceptions may exist.
+const initialParams: SearchParams = {
+    q: "",
+    isActive: false
+}
+ 
+const searchParams = useUrlSearchParams(initialParams)
+ 
+</script>
+
+<template>
+  <ComponentLayout :show-badge="false" title="useUrlSearchParams">
+    <template #description>
+      useUrlSearchParams is a composable methods that keeps the values of a
+      record of params updates in the browser url.
+    </template>
+
+    <ProseBase>
+      <h4>Example Usage:</h4>
+      <h5>Script Setup</h5>
+      <CodeSample>{{
+        `
+<script setup lang="ts">
+interface SearchParams {
+   q: string
+   isActive: boolean
+}
+
+// If you're attempting to hydrate fields with a request that contains search params.
+// Parse the params on the server and send them as a page prop to your search component.
+const props = defineProps<{
+    initialParams: SearchParams
+}>
+
+const searchParams = useUrlSearchParams(props.initialParam) 
+</script&gt;
+        `
+      }}</CodeSample>
+
+      <h5>Template</h5>
+      <CodeSample language="html">{{
+        `
+<template>
+    <BaseInput v-model="searchParams.q" label="Search" type="search" />
+    <Checkbox v-model="searchParams.isActive" label="Is Active" />
+</template&gt;
+        `
+      }}</CodeSample>
+    </ProseBase>
+
+    <div class="space-y-5">
+        <h5>Use the input controls to mutate the search params ref and check the browser url for updates to the query string.</h5>
+        <BaseInput v-model="searchParams.q" label="Search" type="search" />
+        <Checkbox v-model="searchParams.isActive" label="Is Active" />
+    </div>
+  </ComponentLayout>
+</template>

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -51,6 +51,12 @@ import type { FlashMessage, FlashType, FlashStore, Flasher } from "./useFlashes"
 export type { FlashMessage, FlashType, FlashStore, Flasher }
 export { useFlashes, useAppFlashes, useAppFlasher }
 
+// navigation
+import type { UseTabHistoryOpts } from "./nav"
+export type { UseTabHistoryOpts }
+import { useTabHistory } from "./nav"
+export { useTabHistory }
+
 // spinner
 import { useSpinnerDisplay, useAppSpinner } from "./useSpinner"
 export { useSpinnerDisplay, useAppSpinner }

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -52,10 +52,10 @@ export type { FlashMessage, FlashType, FlashStore, Flasher }
 export { useFlashes, useAppFlashes, useAppFlasher }
 
 // navigation
-import type { UseTabHistoryOpts } from "./nav"
-export type { UseTabHistoryOpts }
-import { useTabHistory } from "./nav"
-export { useTabHistory }
+import type { URLParams, URLParamValue, UseTabHistoryOpts } from "./nav"
+export type { URLParams, URLParamValue, UseTabHistoryOpts }
+import { useUrlSearchParams, useTabHistory } from "./nav"
+export { useUrlSearchParams, useTabHistory }
 
 // spinner
 import { useSpinnerDisplay, useAppSpinner } from "./useSpinner"

--- a/src/composables/nav.ts
+++ b/src/composables/nav.ts
@@ -1,4 +1,11 @@
-import type { Component, FunctionalComponent, RenderFunction } from "vue"
+import {
+  Component,
+  FunctionalComponent,
+  MaybeRef,
+  RenderFunction,
+  ref,
+  watch,
+} from "vue"
 
 export interface Item {
   icon?: Component | RenderFunction
@@ -20,4 +27,88 @@ export interface ActionItem {
   icon?: FunctionalComponent | RenderFunction
   label: string
   show?: boolean | ((...args: any[]) => boolean)
+}
+
+export interface UseTabHistoryOpts {
+  /**
+   * The initial value of activeTab.
+   * The default value is tabs[0].value.
+   *
+   * When a valid tab value is found on window.location.search
+   * it will replace the initial value.
+   */
+  initial?: string
+
+  /**
+   * The param name to use on window.location.search.
+   * The default is "tab".
+   */
+  paramName?: string
+}
+
+/**
+ * useTabNav
+ *
+ * Example Usage:
+ *
+ * const {activeTab, tabs} = useTabNav({
+ *    tabs: [{label: "Tab One", value: "tab-1"}, {label: "Tab Two", value: "tab-2"}]
+ *    useHistory: true,
+ * })
+ *
+ * <Tabs v-model="activeTab" :tabs="tabs" />
+ *
+ * <div v-if="activeTab === 'tab-1'">Tab 1 Content</div>
+ * <div v-if="activeTab === 'tab-2'">Tab 2 Content</div>
+ *
+ * @param opts UseUrlTabParamOpts
+ */
+
+export const useTabHistory = (
+  initialTabs: MaybeRef<
+    {
+      label: string
+      value: string
+    }[]
+  >,
+  opts?: UseTabHistoryOpts
+) => {
+  const tabs = ref(initialTabs)
+  const config = {
+    initial: tabs?.value[0]?.value || "",
+    paramName: "tab",
+    ...opts,
+  }
+  const activeTab = ref(config.initial)
+
+  const isTab = (tab: string) => {
+    return tabs.value.find((t) => t.value === tab) ? true : false
+  }
+
+  // Kick off history tracking by applying the existing value
+  // on window.location.search if it is a valid tab option.
+  const params = new URLSearchParams(window.location.search)
+  const initialParam = params.get(config.paramName)
+
+  if (initialParam && isTab(initialParam)) {
+    activeTab.value = initialParam
+  }
+
+  watch(activeTab, (tab) => {
+    const params = new URLSearchParams(window.location.search)
+    params.set(config.paramName, tab.toString())
+
+    const queryString = params.toString() !== "" ? `?${params.toString()}` : ""
+
+    window.history.replaceState(
+      { tab: tab },
+      document.title,
+      `${window.location.pathname}${queryString}`
+    )
+  })
+
+  return {
+    activeTab,
+    tabs,
+  }
 }

--- a/src/composables/nav.ts
+++ b/src/composables/nav.ts
@@ -244,19 +244,26 @@ export const useUrlSearchParams = <T>(initial: URLParams<T>) => {
       for (const key in p) {
         const val = p[key]
 
-        // remove the current key(s) to avoid doubling up on existing values
-        params.delete(key)
-
         // avoid setting nullish values
         if (val == null || val == undefined) {
+          params.delete(key)
           continue
         }
 
         // append array types as multiple key:value pairs
         if (Array.isArray(val)) {
+          // remove the current key(s) to avoid doubling up on existing values
+          params.delete(key)
+
           val.forEach((val) => {
             params.append(key, val.toString())
           })
+          continue
+        }
+
+        // avoid setting falsey (zero) values until a truthy value was previously set
+        // otherwise all zero-valued keys will be populated with every mutation
+        if (!params.has(key) && !val) {
           continue
         }
 


### PR DESCRIPTION
# What this does

- adds `useTabHistory` for supporting tab navigation state via the browser query string: `?tab=my-tab`
- adds `useUrlSearchParams` for supporting complex search params state via the browser query string: `?q=find+me+something&q=also+this&isActive=true`

## Notes:

This is aimed at supporting [#1091](https://github.com/xy-planning-network/college-try/pull/1091) on Portal and establishing a common path forward for existing browser history/state support via query strings.

I ultimately landed on using a query param with `useTabHistory` since it keeps the `#` fragment free for anchors.  i.e. `/setting?tab=advisor-profile#fees`.