### PR TITLE
add datetime-local to RFC 3339 handling in BaseInput

### DIFF
--- a/src/composables/forms.ts
+++ b/src/composables/forms.ts
@@ -243,3 +243,20 @@ export const looseToNumber = (val: any): any => {
   const n = parseFloat(val)
   return isNaN(n) ? val : n
 }
+
+/**
+ * converts an RFC 3339 string to a datetime-local input value string
+ * used with BaseInput<type=datetime-local> as a v-model modifier
+ * @param dt RFC 3339 date string
+ * @returns string
+ */
+export const toDatetimeLocal = (dt: any): string => {
+  if (typeof dt !== "string" || dt === "") {
+    return ""
+  }
+
+  const date = new Date(dt)
+  date.setMinutes(date.getMinutes() - date.getTimezoneOffset())
+
+  return date.toISOString().slice(0, 16)
+}

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -8,6 +8,7 @@ import {
   emailPattern,
   looseToNumber,
   phonePattern,
+  toDatetimeLocal,
 } from "@/composables/forms"
 import type { TextLikeInput } from "@/composables/forms"
 import { computed, ref } from "vue"
@@ -57,14 +58,28 @@ const typeAttributes = computed(() => {
 const onInput = (e: Event) => {
   let val = (e.target as HTMLInputElement).value
 
-  if (props.type === "number") {
-    val = looseToNumber(val)
+  switch (props.type) {
+    case "datetime-local":
+      val = val ? new Date(val).toISOString() : val
+      break
+    case "number":
+      val = looseToNumber(val)
+      break
   }
 
   modelState.value = val
 
   inputValidation(e)
 }
+
+const inputValue = computed(() => {
+  switch (props.type) {
+    case "datetime-local":
+      return toDatetimeLocal(modelState.value)
+    default:
+      return modelState.value
+  }
+})
 </script>
 
 <template>
@@ -91,7 +106,7 @@ const onInput = (e: Event) => {
       ]"
       :placeholder="placeholder"
       :type="type"
-      :value="modelState"
+      :value="inputValue"
       v-bind="{ ...typeAttributes, ...$attrs }"
       @input="onInput"
       @invalid="onInvalid"


### PR DESCRIPTION
# What this does

- handles read/write v-model transformation when BaseInput is type=datetime-local

## Note

vue@3.4 ships with custom v-model modifiers and a `defineModel` macro, which might be a cleaner long term path, but I don't expect many more of these kinds of two-way transforms being necessary, so I'd rather ship something out now, and look more closely at defineModel + useModal before reaching for them.