### PR TITLE
Spk/datetime input

### DIFF
--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue"
-import type { InputOption } from "@/composables/forms"
+import { InputOption, TextInputType, textInputTypes } from "@/composables/forms"
 
 const options: InputOption[] = [
   {
@@ -36,22 +36,7 @@ const radioCardOptions = options.map((opt) => {
   }
 })
 
-const textLikeInputs = [
-  "date",
-  "datetime-local",
-  "email",
-  "month",
-  "number",
-  "password",
-  "search",
-  "tel",
-  "text",
-  "time",
-  "url",
-  "week",
-] as const
-
-const inputTypes: InputOption[] = textLikeInputs.map((type) => {
+const inputTypes: InputOption[] = textInputTypes.map((type) => {
   return {
     label: type,
     value: type,
@@ -61,15 +46,16 @@ const inputTypes: InputOption[] = textLikeInputs.map((type) => {
 /**
  * v-models
  */
-const inputTypeSelected = ref<(typeof textLikeInputs)[number]>("text")
+const inputTypeSelected = ref<TextInputType>("text")
 const inputVals = ref<Record<string, any>>({})
 const toggleValue = ref(undefined)
-
+const dateTimeInput = ref<string>("2015-08-01T15:30:00.000Z")
 /**
  * Copy Help
  */
 const checkboxCopy = `<Checkbox label="I'm here to party!" help="Get notified when the party starts." v-model="checked" />`
 const dateRangePickerCopy = `<DateRangePicker v-model="dateRange" />`
+const dateTimeCopy = `<DateTime v-model="dateTime" label="Select a date and time" help="Use your local timezone!" />`
 const inputCopy = `<BaseInput type="text" label="What's your lide moto?" help="No wrong ansswers here." placeholder="It's good to be alive" />`
 const multiCheckboxCopy = `<MultiCheckboxes v-model="selected" label="Make Some Selections" help="Select all that apply." :options="options" />`
 const radioCopy = `<Radio :options="options" v-model="selected" />`
@@ -130,8 +116,17 @@ const dateRangeInputProps = [
   ...inputCommonProps,
 ]
 
+const dateTimeInputProps = [
+  {
+    name: "modelValue",
+    required: false,
+    type: `string`,
+  },
+  ...inputCommonProps,
+]
+
 const textLikeInputProps = [
-  { name: "type", required: true, type: textLikeInputs.join(" | ") },
+  { name: "type", required: true, type: textInputTypes.join(" | ") },
   { name: "modelValue", required: false, type: "string | number | null" },
   ...inputCommonProps,
 ]
@@ -356,6 +351,38 @@ const toggleProps = [
               <b>Value:</b> {{ inputVals["dateRangePicker"] }}
             </div>
             <PropsTable :props="dateRangeInputProps" />
+          </div>
+        </div>
+      </ComponentLayout>
+
+      <ComponentLayout class="mt-8" title="Date Time Input">
+        <template #description>
+          The DateTime input wraps the HTML datetime-local type input and
+          handles the v-model mutations necessary to adhere to the RFC 3339 date
+          format. Like BaseInput, this component will forward attributes like
+          disabled, max, min, required, and step.
+        </template>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="dateTimeCopy" />
+          </label>
+          <div class="mt-1">
+            <DateTime v-model="inputVals['dateTimeLocal']" required />
+
+            <div class="mt-4">
+              <b>Value:</b> {{ inputVals["dateTimeLocal"] }}
+            </div>
+
+            <div class="mt-4">
+              <DateTime
+                v-model="dateTimeInput"
+                label="Was this adjusted to your browsers timezone?"
+                help="Initialized with 2015-08-01T15:30:00.000Z"
+                disabled
+              />
+            </div>
+            <PropsTable :props="dateTimeInputProps" />
           </div>
         </div>
       </ComponentLayout>
@@ -696,6 +723,8 @@ const toggleProps = [
             <Radio :options="options" required label="Select an option" />
 
             <DateRangePicker label="Pick a date range!" required />
+
+            <DateTime label="Pick a date and time local to you!" required />
 
             <RadioCards
               label="Cards can be required"

--- a/src/composables/forms.ts
+++ b/src/composables/forms.ts
@@ -31,6 +31,10 @@ export interface DateRangeInput extends Input {
   startDate?: number
 }
 
+export interface DateTimeInput extends Input {
+  modelValue?: string | null
+}
+
 export interface TextLikeInput extends Input {
   modelValue?: string | number | null
   type: TextInputType
@@ -63,19 +67,21 @@ export const defaultInputProps = {
   placeholder: "",
 }
 
-export type TextInputType =
-  | "date"
-  | "datetime-local"
-  | "email"
-  | "month"
-  | "number"
-  | "password"
-  | "search"
-  | "tel"
-  | "text"
-  | "time"
-  | "url"
-  | "week"
+export const textInputTypes = [
+  "date",
+  "email",
+  "month",
+  "number",
+  "password",
+  "search",
+  "tel",
+  "text",
+  "time",
+  "url",
+  "week",
+] as const
+
+export type TextInputType = (typeof textInputTypes)[number]
 
 /**
  * useInputField provides a number of computed values, refs, and methods to support
@@ -242,4 +248,21 @@ export const phonePattern = String.raw`[0-9]{10}|[0-9]{3}-[0-9]{3}-[0-9]{4}`
 export const looseToNumber = (val: any): any => {
   const n = parseFloat(val)
   return isNaN(n) ? val : n
+}
+
+/**
+ * converts an RFC 3339 string to a datetime-local input value string
+ * used with BaseInput<type=datetime-local> as a v-model modifier
+ * @param dt RFC 3339 date string
+ * @returns string
+ */
+export const toDatetimeLocal = (dt: any): string => {
+  if (typeof dt !== "string" || dt === "") {
+    return ""
+  }
+
+  const date = new Date(dt)
+  date.setMinutes(date.getMinutes() - date.getTimezoneOffset())
+
+  return date.toISOString().slice(0, 16)
 }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -15,7 +15,6 @@ import type {
   TrailsResp,
   TrailsRespPaged,
 } from "@/api/client"
-import type * as InputTypes from "@/composables/forms"
 import {
   emailPattern,
   looseToNumber,
@@ -64,7 +63,7 @@ export type {
 }
 
 // Forms exports
-export type { InputTypes }
+export type * from "@/composables/forms"
 export {
   emailPattern,
   looseToNumber,

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -15,10 +15,12 @@ import type {
   TrailsResp,
   TrailsRespPaged,
 } from "@/api/client"
+import type * as InputTypes from "@/composables/forms"
 import {
   emailPattern,
   looseToNumber,
   phonePattern,
+  textInputTypes,
   useInputField,
 } from "@/composables/forms"
 import { useModel } from "@/composables/setupHelpers"
@@ -62,7 +64,14 @@ export type {
 }
 
 // Forms exports
-export { emailPattern, looseToNumber, phonePattern, useInputField }
+export type { InputTypes }
+export {
+  emailPattern,
+  looseToNumber,
+  phonePattern,
+  textInputTypes,
+  useInputField,
+}
 
 // Setup helpers
 export { useModel }

--- a/src/lib-components/forms/DateTimeInput.vue
+++ b/src/lib-components/forms/DateTimeInput.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import InputLabel from "./InputLabel.vue"
+import InputHelp from "./InputHelp.vue"
+import InputError from "./InputError.vue"
+import {
+  useInputField,
+  defaultInputProps,
+  toDatetimeLocal,
+} from "@/composables/forms"
+import type { DateTimeInput } from "@/composables/forms"
+import { computed, ref } from "vue"
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = withDefaults(defineProps<DateTimeInput>(), defaultInputProps)
+
+defineEmits(["update:modelValue", "update:error"])
+const input = ref<HTMLInputElement | null>(null)
+const {
+  errorState,
+  modelState,
+  inputID,
+  isRequired,
+  onInvalid,
+  inputValidation,
+} = useInputField(props)
+
+const inputValue = computed(() => toDatetimeLocal(modelState.value))
+
+const onInput = (e: Event) => {
+  let val = (e.target as HTMLInputElement).value
+
+  modelState.value = val ? new Date(val).toISOString() : val
+
+  inputValidation(e)
+}
+</script>
+
+<template>
+  <div>
+    <InputLabel
+      :id="`${inputID}-label`"
+      class="mb-2"
+      :for="inputID"
+      :label="label"
+      :required="isRequired"
+    />
+    <input
+      :id="inputID"
+      ref="input"
+      :aria-labelledby="label ? `${inputID}-label` : undefined"
+      :aria-describedby="help ? `${inputID}-help` : undefined"
+      :aria-errormessage="errorState ? `${inputID}-error` : undefined"
+      :class="[
+        'block w-full rounded-md border-0 py-2 shadow-sm ring-1 ring-inset focus:ring-2 sm:text-sm sm:leading-6',
+        'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-700 disabled:ring-gray-200',
+        errorState
+          ? 'text-red-900 ring-red-700 placeholder:text-red-300 focus:ring-red-700'
+          : 'text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-xy-blue-500',
+      ]"
+      :placeholder="placeholder"
+      type="datetime-local"
+      :value="inputValue"
+      v-bind="$attrs"
+      @input="onInput"
+      @invalid="onInvalid"
+    />
+    <InputHelp :id="`${inputID}-help`" class="mt-1" :text="help" />
+    <InputError :id="`${inputID}-error`" class="mt-0.5" :text="errorState" />
+  </div>
+</template>

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -30,6 +30,7 @@ import { default as XYSpinner } from "./indicators/XYSpinner.vue"
 import { default as BaseInput } from "./forms/BaseInput.vue"
 import { default as Checkbox } from "./forms/Checkbox.vue"
 import { default as DateRangePicker } from "./forms/DateRangePicker.vue"
+import { default as DateTime } from "./forms/DateTimeInput.vue"
 import { default as InputError } from "./forms/InputError.vue"
 import { default as InputHelp } from "./forms/InputHelp.vue"
 import { default as InputLabel } from "./forms/InputLabel.vue"
@@ -68,6 +69,7 @@ export {
   BaseInput,
   Checkbox,
   DateRangePicker,
+  DateTime,
   InputError,
   InputHelp,
   InputLabel,
@@ -109,6 +111,7 @@ export interface TreesComponents {
   BaseInput: typeof BaseInput
   Checkbox: typeof Checkbox
   DateRangePicker: typeof DateRangePicker
+  DateTime: typeof DateTime
   InputError: typeof InputError
   InputHelp: typeof InputHelp
   InputLabel: typeof InputLabel


### PR DESCRIPTION
# What this does

- adds `DateTime` input for handling v-model mutations of date strings in RFC 3339 format
- exports `textInputTypes` to remove small TODO from FieldsSchema work in portal

## Notes

See [#1220](https://github.com/xy-planning-network/college-try/pull/1220) for the bump in portal with a small tweak to FieldsSchema.