### PR TITLE
<DynamicTable /> shades rows on hover when clickable

### DIFF
--- a/dev/content/Lists.vue
+++ b/dev/content/Lists.vue
@@ -10,6 +10,7 @@ import {
 import type {
   TableColumns,
   TableActions,
+  TableRowData,
   DynamicTableOptions,
 } from "@/composables/table"
 import NeedleTag from "./examples/NeedleTags.vue"
@@ -113,10 +114,15 @@ const dynamicTableActions: TableActions<Conifer> = {
 }
 
 const dynamicTableOptions: DynamicTableOptions = {
+  clickable: true,
   dateSearch: true,
   refreshTrigger: 0,
   search: true,
   url: "https://my-json-server.typicode.com/xy-planning-network/trees/conifers",
+}
+
+const handleDynamicTableOnClick = (e: TableRowData) => {
+  window.alert("You clicked: " + e.name)
 }
 
 const tableCopy = `<DynamicTable :table-columns="tableColumns" :table-options="tableOptions" />`
@@ -260,6 +266,7 @@ const tableProps = [
               :table-columns="tableColumns"
               :table-options="dynamicTableOptions"
               :table-actions="dynamicTableActions"
+              @click:row="handleDynamicTableOnClick"
             />
             <PropsTable :props="tableProps" />
           </div>

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -3,6 +3,7 @@ import { ActionItem } from "@/composables/nav"
 import { DateRangeProps } from "./date"
 
 export interface DynamicTableOptions {
+  clickable?: boolean
   dateSearch?: boolean | DateRangeProps
   defaultSort?: string
   defaultSortDirection?: string

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -306,6 +306,9 @@ loadAndRender()
           <tr
             v-for="(row, rowIdx) in rows"
             :key="rowIdx"
+            :class="{
+              'hover:bg-gray-50 cursor-pointer': tableOptions.clickable,
+            }"
             @click="$emit('click:row', row.rowData)"
           >
             <template v-for="(cell, cellIdx) in row.cells" :key="cellIdx">


### PR DESCRIPTION
This PR adds `DynamicTableOptions.clickable`. When `clickable` and the cursor hovers over a row, additional styling applies to help differentiate the fact that is the target of a click.

https://github.com/xy-planning-network/trees/assets/27823069/455c810b-fd29-48e5-811d-45e5b31c4757

