### PR TITLE
Style cleanup on tables and <ActionsDropdown />

### DIFF
--- a/src/lib-components/lists/DataTable.vue
+++ b/src/lib-components/lists/DataTable.vue
@@ -34,12 +34,12 @@ const { columns, hasActions, isEmptyCellValue, rows } = useTable(
           class="overflow-hidden border-b border-gray-200 shadow sm:rounded-lg"
         >
           <table class="min-w-full divide-y divide-gray-200">
-            <thead>
+            <thead class="bg-gray-100">
               <tr>
                 <th
                   v-for="(col, idx) in columns"
                   :key="idx"
-                  class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase bg-gray-50 leading-4"
+                  class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase leading-4"
                   :class="col.alignment"
                 >
                   {{ col.title }}
@@ -48,12 +48,16 @@ const { columns, hasActions, isEmptyCellValue, rows } = useTable(
                 <!--Table Actions Header-->
                 <th
                   v-if="hasActions"
-                  class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase bg-gray-50 leading-4"
+                  class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase leading-4"
                 />
               </tr>
             </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
-              <tr v-for="(row, rowIdx) in rows" :key="rowIdx">
+            <tbody class="bg-white">
+              <tr
+                v-for="(row, rowIdx) in rows"
+                :key="rowIdx"
+                class="even:bg-gray-50"
+              >
                 <template v-for="(cell, cellIdx) in row.cells" :key="cellIdx">
                   <component
                     :is="'td'"
@@ -87,7 +91,7 @@ const { columns, hasActions, isEmptyCellValue, rows } = useTable(
 
               <tr v-if="rows.length === 0">
                 <td
-                  :colspan="columns.length"
+                  :colspan="columns.length + (hasActions ? 1 : 0)"
                   class="px-6 py-4 text-sm text-gray-700 whitespace-nowrap leading-5"
                 >
                   No items were found!

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -304,7 +304,7 @@ loadAndRender()
           </tr>
         </thead>
 
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="bg-white">
           <tr
             v-for="(row, rowIdx) in rows"
             :key="rowIdx"

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -244,54 +244,56 @@ loadAndRender()
               class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase bg-gray-50 leading-4"
               :class="col.alignment"
             >
-              <span v-if="col.title">{{ col.title }}</span>
-              <span
-                v-if="col.sort"
-                class="cursor-pointer"
-                @click.prevent="handleSort(col.sort as string)"
-              >
-                <svg
-                  v-if="currentSort !== col.sort"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  class="h-5 inline"
+              <div class="flex items-center gap-2">
+                <span v-if="col.title">{{ col.title }}</span>
+                <span
+                  v-if="col.sort"
+                  class="cursor-pointer"
+                  @click.prevent="handleSort(col.sort as string)"
                 >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M8 9l4-4 4 4m0 6l-4 4-4-4"
-                  />
-                </svg>
-                <svg
-                  v-else-if="currentSortDirection == 'desc'"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  class="h-5 inline"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
-                <svg
-                  v-else
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  class="h-5 inline"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
-              </span>
+                  <svg
+                    v-if="currentSort !== col.sort"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    class="h-5 inline"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M8 9l4-4 4 4m0 6l-4 4-4-4"
+                    />
+                  </svg>
+                  <svg
+                    v-else-if="currentSortDirection == 'desc'"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    class="h-5 inline"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z"
+                      clip-rule="evenodd"
+                    />
+                  </svg>
+                  <svg
+                    v-else
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    class="h-5 inline"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                      clip-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </div>
             </th>
 
             <!--Table Actions Header-->
@@ -306,6 +308,7 @@ loadAndRender()
           <tr
             v-for="(row, rowIdx) in rows"
             :key="rowIdx"
+            class="even:bg-gray-50"
             @click="$emit('click:row', row.rowData)"
           >
             <template v-for="(cell, cellIdx) in row.cells" :key="cellIdx">
@@ -341,7 +344,7 @@ loadAndRender()
 
           <tr v-if="!hasContent">
             <td
-              :colspan="rows.length"
+              :colspan="columns.length + (hasActions ? 1 : 0)"
               class="px-6 py-4 text-sm text-gray-700 whitespace-nowrap leading-5"
             >
               No items were found!

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -244,7 +244,7 @@ loadAndRender()
               class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase bg-gray-50 leading-4"
               :class="col.alignment"
             >
-              <div class="flex items-center gap-2">
+              <div class="inline-flex items-center gap-2">
                 <span v-if="col.title">{{ col.title }}</span>
                 <span
                   v-if="col.sort"

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -236,21 +236,23 @@ loadAndRender()
       class="relative z-0 min-w-full align-middle border-b border-gray-200 shadow sm:rounded-lg overflow-x-auto"
     >
       <table class="min-w-full divide-y divide-gray-200">
-        <thead>
+        <thead class="bg-gray-100">
           <tr>
             <th
               v-for="(col, idx) in columns"
               :key="idx"
-              class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase bg-gray-50 leading-4"
+              class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase leading-4"
               :class="col.alignment"
             >
-              <div class="inline-flex items-center gap-2">
+              <div
+                class="inline-flex items-center gap-2"
+                :class="{ 'cursor-pointer': col.sort }"
+                @click.prevent="
+                  col.sort ? handleSort(col.sort as string) : undefined
+                "
+              >
                 <span v-if="col.title">{{ col.title }}</span>
-                <span
-                  v-if="col.sort"
-                  class="cursor-pointer"
-                  @click.prevent="handleSort(col.sort as string)"
-                >
+                <span v-if="col.sort">
                   <svg
                     v-if="currentSort !== col.sort"
                     xmlns="http://www.w3.org/2000/svg"
@@ -299,7 +301,7 @@ loadAndRender()
             <!--Table Actions Header-->
             <th
               v-if="hasActions"
-              class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase bg-gray-50 leading-4"
+              class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase leading-4"
             />
           </tr>
         </thead>

--- a/src/lib-components/navigation/ActionsDropdown.vue
+++ b/src/lib-components/navigation/ActionsDropdown.vue
@@ -29,7 +29,7 @@ const { floatingStyles } = useFloating(trigger, wrapper, {
   <Menu as="div" class="relative flex justify-end items-center">
     <MenuButton
       ref="trigger"
-      class="w-8 h-8 bg-white inline-flex items-center justify-center text-gray-700 rounded-full hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+      class="w-8 h-8 inline-flex items-center justify-center text-gray-700 rounded-full hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
       :disabled="!hasActions"
     >
       <span class="sr-only">Open options</span>


### PR DESCRIPTION
On `<DynamicTable />`...
- A column header title & sort button may not flow nicely when the title is longer. So, wrap it in a `flex` container
- Adds `bg-gray-50` on even rows to help visually differentiate
    - Also removes `bg-white` from the `<ActionsDropdown />` menu icon since that may or may not mesh with the row's background color
- Fixes the default "No items found..." row length to fill in when overflowing

_Before_
<img width="1216" alt="Screenshot 2024-04-22 at 12 20 41 PM" src="https://github.com/xy-planning-network/trees/assets/27823069/87c338bc-c648-4f63-aa16-252f2aa5a1db">
<img width="1144" alt="Screenshot 2024-04-22 at 12 20 47 PM" src="https://github.com/xy-planning-network/trees/assets/27823069/02d4afbd-96ae-4243-a329-159f4e52cfb4">

_After_

https://github.com/xy-planning-network/trees/assets/27823069/da0d5854-1fe3-4278-a932-898c9972bf76

<img width="1204" alt="Screenshot 2024-04-23 at 11 02 49 AM" src="https://github.com/xy-planning-network/trees/assets/27823069/d7a5e59f-ac61-4483-a166-953d90c5780f">