### PR TITLE
Open up <DetailList /> to more configuration

### DIFF
--- a/dev/content/Lists.vue
+++ b/dev/content/Lists.vue
@@ -29,7 +29,7 @@ const cardsProps = [
     type: "{ primary: string; secondary: string }",
   },
 ]
-const detailListCopy = `<DetailList :config="detailListConfig"></DetailList>`
+const detailListCopy = `<DetailList url="things"></DetailList>`
 const detailListProps = [
   { name: "url", required: true, type: "string" },
   { name: "borderless", required: false, type: "boolean" },

--- a/dev/content/Lists.vue
+++ b/dev/content/Lists.vue
@@ -12,6 +12,7 @@ import type {
   TableActions,
   DynamicTableOptions,
 } from "@/composables/table"
+import { DetailListConfig } from "@/composables/list"
 import NeedleTag from "./examples/NeedleTags.vue"
 import { conifers } from "../../db.json"
 import { Conifer } from "./types/tree"
@@ -29,13 +30,19 @@ const cardsProps = [
     type: "{ primary: string; secondary: string }",
   },
 ]
-const detailListCopy = `<DetailList title="Things" url="/things"></DetailList>`
+const detailListCopy = `<DetailList :config="detailListConfig"></DetailList>`
 const detailListProps = [
-  { name: "refreshTrigger", required: false, type: "number" },
-  { name: "reloadTrigger", required: false, type: "number" },
-  { name: "title", required: true, type: "string" },
   { name: "url", required: true, type: "string" },
+  { name: "alwaysHideNav", required: false, type: "boolean" },
+  { name: "dateSearch", required: false, type: "boolean | DateRangeProps " },
+  { name: "defaultSort", required: false, type: "string" },
+  { name: "defaultSortDir", required: false, type: "SortDir" },
+  { name: "perPage", required: false, type: "number" },
 ]
+const detailListConfig: DetailListConfig = {
+  url: "https://my-json-server.typicode.com/xy-planning-network/trees/things",
+  dateSearch: true,
+}
 
 const staticTableCopy = `<DataTable :table-columns="tableColumns" />`
 
@@ -162,10 +169,7 @@ const tableProps = [
             <ClickToCopy :value="detailListCopy" />
           </label>
           <div class="mt-1">
-            <DetailList
-              title="Things"
-              url="https://my-json-server.typicode.com/xy-planning-network/trees/things"
-            >
+            <DetailList :config="detailListConfig">
               <template #default="{ item }">
                 <div class="block cursor-pointer hover:bg-gray-50">
                   <div class="px-4 py-4 sm:px-6">

--- a/dev/content/Lists.vue
+++ b/dev/content/Lists.vue
@@ -12,7 +12,6 @@ import type {
   TableActions,
   DynamicTableOptions,
 } from "@/composables/table"
-import { DetailListConfig } from "@/composables/list"
 import NeedleTag from "./examples/NeedleTags.vue"
 import { conifers } from "../../db.json"
 import { Conifer } from "./types/tree"
@@ -33,17 +32,13 @@ const cardsProps = [
 const detailListCopy = `<DetailList :config="detailListConfig"></DetailList>`
 const detailListProps = [
   { name: "url", required: true, type: "string" },
-  { name: "alwaysHideNav", required: false, type: "boolean" },
-  { name: "dateSearch", required: false, type: "boolean | DateRangeProps " },
+  { name: "borderless", required: false, type: "boolean" },
   { name: "defaultSort", required: false, type: "string" },
   { name: "defaultSortDir", required: false, type: "SortDir" },
+  { name: "disableDate", required: false, type: "boolean" },
+  { name: "disableNavigation", required: false, type: "boolean" },
   { name: "perPage", required: false, type: "number" },
 ]
-const detailListConfig: DetailListConfig = {
-  url: "https://my-json-server.typicode.com/xy-planning-network/trees/things",
-  dateSearch: true,
-}
-
 const staticTableCopy = `<DataTable :table-columns="tableColumns" />`
 
 const coniferList = ref(conifers.data.items)
@@ -169,7 +164,9 @@ const tableProps = [
             <ClickToCopy :value="detailListCopy" />
           </label>
           <div class="mt-1">
-            <DetailList :config="detailListConfig">
+            <DetailList
+              url="https://my-json-server.typicode.com/xy-planning-network/trees/things"
+            >
               <template #default="{ item }">
                 <div class="block cursor-pointer hover:bg-gray-50">
                   <div class="px-4 py-4 sm:px-6">

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -22,11 +22,20 @@ import type {
   TableRowsData,
 } from "./table"
 
+import type {
+  DetailListConfig,
+  DetailListAPI,
+  SortDir,
+} from "./list"
+
 export type {
   UseBaseAPIOptions,
   UseBaseAPI,
+  DetailListConfig,
+  DetailListAPI,
   DynamicTableOptions,
   DynamicTableAPI,
+  SortDir,
   TableActionItem,
   TableColumn,
   TableActions,

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -23,7 +23,6 @@ import type {
 } from "./table"
 
 import type {
-  DetailListConfig,
   DetailListAPI,
   SortDir,
 } from "./list"
@@ -31,7 +30,6 @@ import type {
 export type {
   UseBaseAPIOptions,
   UseBaseAPI,
-  DetailListConfig,
   DetailListAPI,
   DynamicTableOptions,
   DynamicTableAPI,

--- a/src/composables/list.ts
+++ b/src/composables/list.ts
@@ -2,21 +2,34 @@ import { DateRangeProps } from "./date"
 
 export interface DetailListConfig {
   /**
-   * date turns on the date-range filter input
-   */
-  dateSearch?: boolean | DateRangeProps
-
-  defaultSort?: string
-  defaultSortDir?: SortDir
-
-  /**
    * alwaysHideNav disables navigation components from displaying whatsoever.
    * This makes the List as a "single-page" limiting the number of results via perPage.
    */
   alwaysHideNav?: boolean
 
+  /**
+   * date turns on the date-range filter input
+   */
+  dateSearch?: boolean | DateRangeProps
+
+  /**
+   * defaultSort overrides the default field to sort items on.
+   */
+  defaultSort?: string
+
+  /**
+   * defaultSortDir overrides the default order to sort items with.
+   */
+  defaultSortDir?: SortDir
+
+  /**
+   * perPage overrides the default number of items per page to retrieve.
+   */
   perPage?: number
 
+  /**
+   * url is the endpoint to retrieve list data from
+   */
   url: string
 }
 

--- a/src/composables/list.ts
+++ b/src/composables/list.ts
@@ -1,38 +1,3 @@
-import { DateRangeProps } from "./date"
-
-export interface DetailListConfig {
-  /**
-   * alwaysHideNav disables navigation components from displaying whatsoever.
-   * This makes the List as a "single-page" limiting the number of results via perPage.
-   */
-  alwaysHideNav?: boolean
-
-  /**
-   * date turns on the date-range filter input
-   */
-  dateSearch?: boolean | DateRangeProps
-
-  /**
-   * defaultSort overrides the default field to sort items on.
-   */
-  defaultSort?: string
-
-  /**
-   * defaultSortDir overrides the default order to sort items with.
-   */
-  defaultSortDir?: SortDir
-
-  /**
-   * perPage overrides the default number of items per page to retrieve.
-   */
-  perPage?: number
-
-  /**
-   * url is the endpoint to retrieve list data from
-   */
-  url: string
-}
-
 export interface DetailListAPI {
   /**
    * Force refresh the table data with the current api params state

--- a/src/composables/list.ts
+++ b/src/composables/list.ts
@@ -1,6 +1,6 @@
 export interface DetailListAPI {
   /**
-   * Force refresh the table data with the current api params state
+   * Force refresh the list data with the current api params state
    * @returns void
    */
   refresh: () => void

--- a/src/composables/list.ts
+++ b/src/composables/list.ts
@@ -1,0 +1,36 @@
+import { DateRangeProps } from "./date"
+
+export interface DetailListConfig {
+  /**
+   * date turns on the date-range filter input
+   */
+  dateSearch?: boolean | DateRangeProps
+
+  defaultSort?: string
+  defaultSortDir?: SortDir
+
+  /**
+   * alwaysHideNav disables navigation components from displaying whatsoever.
+   * This makes the List as a "single-page" limiting the number of results via perPage.
+   */
+  alwaysHideNav?: boolean
+
+  perPage?: number
+
+  url: string
+}
+
+export interface DetailListAPI {
+  /**
+   * Force refresh the table data with the current api params state
+   * @returns void
+   */
+  refresh: () => void
+  /**
+   * Reset the table data back to page 1 and load
+   * @returns void
+   */
+  reset: () => void
+}
+
+export type SortDir = "asc" | "desc"

--- a/src/composables/list.ts
+++ b/src/composables/list.ts
@@ -5,7 +5,7 @@ export interface DetailListAPI {
    */
   refresh: () => void
   /**
-   * Reset the table data back to page 1 and load
+   * Reset the list data back to page 1 and load
    * @returns void
    */
   reset: () => void

--- a/src/lib-components/layout/DateFilter.vue
+++ b/src/lib-components/layout/DateFilter.vue
@@ -1,27 +1,27 @@
 <script setup lang="ts">
-import { DateRange } from "@/composables/date"
 import { ref } from "vue"
+import { DateRange } from "@/composables/date"
+import { SortDir } from "@/composables/list"
 import DateRangePicker from "../forms/DateRangePicker.vue"
 import Select from "@/lib-components/forms/Select.vue"
 
 const props = defineProps<{
   dateRange: DateRange
-  sortDir: string
-  title: string
+  sortDir: SortDir
 }>()
 const dateRange = ref<DateRange>(props.dateRange)
-const sortDir = ref<string>(props.sortDir)
-const sortOptions = [
-  { label: "Newest-Oldest", value: "DESC" },
-  { label: "Oldest-Newest", value: "ASC" },
+const sortDir = ref<SortDir>(props.sortDir)
+const sortOptions: { label: string; value: SortDir }[] = [
+  { label: "Newest-Oldest", value: "desc" },
+  { label: "Oldest-Newest", value: "asc" },
 ]
 
 const emits = defineEmits<{
-  (e: "sort-dir-changed", val: string): void
+  (e: "sort-dir-changed", val: SortDir): void
   (e: "date-range-changed", val: DateRange): void
 }>()
 
-const sortDirChanged = (sortDir: string) => {
+const sortDirChanged = (sortDir: SortDir) => {
   emits("sort-dir-changed", sortDir)
 }
 
@@ -30,25 +30,14 @@ const dateRangeChanged = (dateRange: DateRange) => {
 }
 </script>
 <template>
-  <div
-    class="md:flex md:items-center md:justify-between bg-white mx-auto py-4 border-t border-gray-100"
-  >
-    <div class="flex-1 min-w-0">
-      <h1 class="text-lg leading-6 font-semibold text-gray-900">
-        {{ title }}
-      </h1>
-    </div>
-    <div class="mt-4 flex md:mt-0 md:ml-4">
-      <Select
-        v-model="sortDir"
-        :options="sortOptions"
-        @update:model-value="sortDirChanged"
-      ></Select>
-      <DateRangePicker
-        v-model="dateRange"
-        class="ml-3"
-        @update:model-value="dateRangeChanged"
-      />
-    </div>
-  </div>
+  <Select
+    v-model="sortDir"
+    :options="sortOptions"
+    @update:model-value="sortDirChanged"
+  ></Select>
+  <DateRangePicker
+    v-model="dateRange"
+    class="ml-3"
+    @update:model-value="dateRangeChanged"
+  />
 </template>

--- a/src/lib-components/lists/DetailList.vue
+++ b/src/lib-components/lists/DetailList.vue
@@ -119,7 +119,7 @@ const reset = (): void => {
 
 const publicMethods: DetailListAPI = {
   refresh: loadAndRender,
-  reset: reloadTable,
+  reset: reset,
 }
 
 watch([sortDir, dateRange], () => {

--- a/src/lib-components/lists/DetailList.vue
+++ b/src/lib-components/lists/DetailList.vue
@@ -112,7 +112,7 @@ const showPaginator = computed(() => {
   return !props.disableNavigation && hasContent
 })
 
-const reloadTable = (): void => {
+const reset = (): void => {
   pagination.value.page = 1
   loadAndRender()
 }


### PR DESCRIPTION
## Problem statement
`<DetailList />` is tightly coupled to its use cases in `second-child`. A lot is baked in by default and can't be configured, unlike how `<DataTable />` and `<DynamicTable />` are more flexible and allow for more use cases.

Recently, we identified `<DetailList />` as a candidate for replacing some custom markup, simplifying the page it appears on. But the default filtering, styling, and pagination made it a bad fit.

## What this does
This PR brings `<DetailList />` opens up configurability following `<DynamicTable />`'s pattern. Notably, it copies the `DynamicTableAPI`, allowing for the parent to call list resetting methods.

Next, this PR turns the date searching feature into an optional one. When turned off, the `<DetailList />` does not display with a shadowed border. The rationale there is the parent can supply this styling when desired. When the only markup in `<DetailList />` is the items themselves, the border shadowing is difficult to work with.

This PR also allows for overriding a few default params passed to the request that retrieves the list items. Sorting and the amount of results to retrieve per page can be overwritten.

Lastly, this PR adds a feature to turn off pagination navigation altogether. In conjunction with the new `perPage` field, this enables `<DetailList />` to fit into tighter spaces, such as on `college-try`'s dashboard `<NotifcationCard />`.

## TODO
- [ ] ~~Move over an `<EmptyState />` type of component for display instead of the `<slot name="empty" />` in `<DetailList />`?~~
- [x] Finalize open TODOs
- [x] Finalize `<DateFilter />` given the removal of `title`
- [x] Finalize decision on use of option interfaces in `<DynamicTable />`
- [x] Update `/dev`
- [ ] ~~Review, clean up for `grid`-style alternative layout use case, like in `college-try`'s `/community/profiles`~~
- [x] Review, clean up for use cases in `second-child`

---
## Previous Discussion
Putting my cards on the table with regards to how I'm thinking about this:

In our backpack, we want a set of components to display a list in a particular layout. We want to support filtering the result set, sorting the result set, navigation through pages of results, and user actions able to be taken on a particular item. Many times, we want the components to fetch the data themselves and offload user interaction on the above functionality to the component. Less often, we supply the data to the component.

In that vein, a table is a kind of list. It's a layout style for a list. It seems `<DetailList />` is a columnar layout. There's mention of need for a grid layout (like for Community Search profiles). Ideally, one can swap between these 3 styles without substantial changes in configuration, potentially only dropping configuration that isn't supported in one layout. This way, ideating can move quickly, but more importantly, this approach simplifies the mental model required to interact with them.

To get there, I believe we need a shared configuration interface between `<DataTable />`, `<DynamicTable />` and `<DetailList />`. The `List*Options` interfaces are the intended way of getting there. Each component composes together the set of options that are applicable to its currently supported functionality. In many cases, their fields are optional and the component brings its own defaults.

`<DetailList />` isn't quite in alignment with `<DynamicTable />`, yet. I'd love to see the former remove the need for `<slot>`s altogether. We'd get there by adopting the `TableColumns` pattern, it seems. Then, we'd also need an idea of `TableActions`, since `second-child`'s templates have actions. These tasks seem like good candidates for the next pass, to me.