### PR TITLE
update value handling in select component, apply trim to text and tex…

### DIFF
--- a/dev/content/Forms.vue
+++ b/dev/content/Forms.vue
@@ -183,7 +183,10 @@ const toggleProps = [
             class="xy-link"
             target="_blank"
             >input variations</a
-          >.
+          >. When the type attibute is set to 'number' the value returned will
+          be a number making v-model.number modifiers unnecessary. Likewise, the
+          `trim()` method is applies to all string values making the
+          v-model.trim modifier unnecessary.
         </template>
 
         <div>
@@ -258,7 +261,9 @@ const toggleProps = [
 
       <ComponentLayout class="mt-8" title="Textarea">
         <template #description>
-          A common and consistent textarea input.
+          A common and consistent textarea input. Return values are
+          automatically trimed with the `trim()` method and the v-model.trim
+          modifier is unnecessary.
         </template>
 
         <div>
@@ -538,18 +543,11 @@ const toggleProps = [
         <template #description>
           Similar to checkboxes, these are wrapped in a vue component given
           their nested structure so that we are consistent across all projects.
-          <br /><br />Note that the
-          <a
-            class="xy-link"
-            href="https://v3.vuejs.org/guide/forms.html#value-bindings"
-            >Value Bindings</a
-          >
-          section of the Vue docs states that binding values for selects are
-          usually static strings. Use the <b>v-model.number </b>
-          <a class="xy-link" href="https://v3.vuejs.org/guide/forms.html#number"
-            >modifier</a
-          >
-          if you need the binding to be typecast as a number.
+          <br /><br />When the options set use number types as their values, the
+          return value of the input will also be a number making v-model.number
+          usage unnecessary. <br /><br />As a best practice avoid mixing string
+          and number type values in the options and note that mixed types that
+          resolve to the same string value, ex: '3' and 3 are not supported.
         </template>
 
         <div>

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -61,6 +61,10 @@ const onInput = (e: Event) => {
     val = looseToNumber(val)
   }
 
+  if (typeof val === "string") {
+    val = val.trim()
+  }
+
   modelState.value = val
 
   inputValidation(e)

--- a/src/lib-components/forms/Select.vue
+++ b/src/lib-components/forms/Select.vue
@@ -26,8 +26,17 @@ const {
 } = useInputField(props)
 
 const onChange = (e: Event) => {
-  modelState.value = (e.target as HTMLInputElement).value
-  validate(e)
+  // NOTE(spk): The selectedIndex references the list of options in tree order
+  // https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-selectedindex
+  const selectedIndex = (e.target as HTMLSelectElement).selectedIndex
+
+  // NOTE(spk): we disable the 0 index option in the list, so there's
+  // no expectation it will trigger a change event.  Likewise, dynamic updates to
+  // a modelValue prop in a parent do not trigger the change event.
+  if (selectedIndex > 0) {
+    modelState.value = props.options[selectedIndex - 1].value
+    validate(e)
+  }
 }
 </script>
 

--- a/src/lib-components/forms/TextArea.vue
+++ b/src/lib-components/forms/TextArea.vue
@@ -22,7 +22,7 @@ const {
 } = useInputField(props)
 
 const onInput = (e: Event) => {
-  modelState.value = (e.target as HTMLInputElement).value
+  modelState.value = (e.target as HTMLInputElement).value.trim()
   inputValidation(e)
 }
 </script>


### PR DESCRIPTION
# What this does

- refactors the onChange event in the `Select` component to use the value property on the prop options instead of using the value on the input (allows for number support in options)
- applies the trim method to Textarea and BaseInput to drop the need of v-model.trim modifiers

## Notes

After looking closely at the `HTMLSelectElement` spec, it appears there is a way to determine which option was selected via an index value that can be mapped back to the options set on the component props.  This allows us to read the exact value set on the option allowing for both string and number support, technically even mixed uses.  The only situation not supported is mixed types where the string value is the same, ex: '3' and 3.  This potentially could be handled as well if we handle setting the `selected` attribute ourselves, but it seems unlikely to be necessary and may even be better classified as something we shouldn't do at all.  If a valid cases for it arises, I've got some ideas though.

Looking through Portal and Archive the use of the `trim` modifier is pretty heavy.  We've had that baked into. `FormDisplay` since the start, so it seems like a very useful default handling for those input types.