### PR TITLE
initial progress circle components

### DIFF
--- a/dev/pages/Indicators.vue
+++ b/dev/pages/Indicators.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { ref } from "vue"
+import User from "@/composables/user"
+
+defineProps<{
+  user: User
+}>()
+
+const progressCircleProps = [
+  { name: "step", required: true, type: "number" },
+  {
+    name: "steps",
+    required: true,
+    type: "Array<{name: string, description?: string}>",
+  },
+]
+
+const progressCirclesCopy = `<ProgressCircles :current="currentStep" :steps="steps" />`
+const progressCirclesLabeledCopy = `<ProgressCirclesLabeled :current="currentStep" :steps="steps" />`
+
+const currentStep = ref(2)
+const steps = [
+  { name: "Sign Up", description: "Complete the registration process." },
+  {
+    name: "Verify Email",
+    description: "Check your inbox for a verification link.",
+  },
+  {
+    name: "Set Up Profile",
+    description: "Tell us more about yourself to personalize your experience.",
+  },
+  {
+    name: "Choose a Plan",
+    description: "Select the best plan that fits your needs.",
+  },
+  {
+    name: "Review and Submit",
+    description: "Ensure all information is correct before submission.",
+  },
+]
+</script>
+<template>
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="max-w-3xl mx-auto">
+      <ComponentLayout class="mt-8" title="Progress Circles">
+        <template #description
+          >Progress Circles help indicate the current step of a multi-step UI.
+          This small version is useful for mobile views or inside tight spaces.
+          The horizontal layout is default aligned i.e. (left) and does not
+          assume how it will be used in layouts to maintain flexibile layout
+          options around other componentes. The "current" step is indicated with
+          the index of a step in the steps props. You can use -1 to indicate no
+          steps are current or complete and any number >= steps.length will
+          cause all steps to appear complete. Currently, ProgressCircles assumes
+          a linear progress of steps is required and it does not act as a
+          navigation. It simply displays progress. While this component does not
+          display copy, it does require copy in steps prop for
+          accessibility</template
+        >
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="progressCirclesCopy" />
+          </label>
+          <div class="mt-4">
+            <div class="space-y-6">
+              <div>
+                <h5 class="mb-2">Not Started</h5>
+                <ProgressCircles :current="-1" :steps="steps" />
+              </div>
+              <div>
+                <h5 class="mb-2">Index 2 (Step 3 is current)</h5>
+                <ProgressCircles :current="currentStep" :steps="steps" />
+              </div>
+              <div>
+                <h5 class="mb-2">Completed</h5>
+                <ProgressCircles :current="5" :steps="steps" />
+              </div>
+            </div>
+            <PropsTable :props="progressCircleProps" />
+          </div>
+        </div>
+      </ComponentLayout>
+
+      <ComponentLayout class="mt-8" title="Progress Circles Labeled">
+        <template #description
+          >Progress Circles with Lables help indicate the current step of a
+          multi-step UI and support displaying a label and description for each
+          step. This larger version is useful for larger viewports. The
+          "current" step is indicated with the index of a step in the steps
+          props. You can use -1 to indicate no steps are current or complete and
+          any number >= steps.length will cause all steps to appear complete.
+          Currently, ProgressCirclesLabeled assumes a linear progress of steps
+          is required and it does not act as a navigation. It simply displays
+          progress.</template
+        >
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="progressCirclesLabeledCopy" />
+          </label>
+
+          <div class="mt-4">
+            <div class="grid sm:grid-cols-2 gap-6">
+              <div class="space-y-3">
+                <h5>Not Started - With Descriptions</h5>
+                <ProgressCirclesLabeled :current="-1" :steps="steps" />
+              </div>
+
+              <div class="space-y-3">
+                <h5>Index 2 - No Descriptions</h5>
+                <ProgressCirclesLabeled
+                  :current="2"
+                  :steps="
+                    steps.map((s) => {
+                      return { name: s.name }
+                    })
+                  "
+                />
+              </div>
+            </div>
+          </div>
+          <PropsTable :props="progressCircleProps" />
+        </div>
+      </ComponentLayout>
+    </div>
+  </div>
+</template>

--- a/dev/pages/index.ts
+++ b/dev/pages/index.ts
@@ -7,10 +7,12 @@ import {
   TableIcon,
   UserGroupIcon,
   HomeIcon,
+  StatusOnlineIcon,
 } from "@heroicons/vue/outline"
 
 import Elements from "./Elements.vue"
 import Forms from "./Forms.vue"
+import Indicators from "./Indicators.vue"
 import Lists from "./Lists.vue"
 import Navigation from "./Navigation.vue"
 import Overlays from "./Overlays.vue"
@@ -57,6 +59,13 @@ export const pages = [
     icon: CollectionIcon,
     url: `${import.meta.env.BASE_URL}?page=Overlays`,
     component: Overlays,
+  },
+  {
+    name: "Indicators",
+    description: "What is happening?  What step am I on?",
+    icon: StatusOnlineIcon,
+    url: `${import.meta.env.BASE_URL}?page=Indicators`,
+    component: Indicators,
   },
   {
     name: "Elements",

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -25,6 +25,8 @@ import { default as DynamicTable } from "./lists/DynamicTable.vue"
 import { default as Tabs } from "./navigation/Tabs.vue"
 import { default as Toggle } from "./forms/Toggle.vue"
 import { default as XYSpinner } from "./indicators/XYSpinner.vue"
+import { default as ProgressCircles } from "./indicators/ProgressCircles.vue"
+import { default as ProgressCirclesLabeled } from "./indicators/ProgressCirclesLabeled.vue"
 
 // Form components
 import { default as BaseInput } from "./forms/BaseInput.vue"
@@ -81,6 +83,8 @@ export {
   TextArea,
   YesOrNoRadio,
   XYSpinner,
+  ProgressCircles,
+  ProgressCirclesLabeled,
 }
 
 /**
@@ -123,4 +127,6 @@ export interface TreesComponents {
   TextArea: typeof TextArea
   YesOrNoRadio: typeof YesOrNoRadio
   XYSpinner: typeof XYSpinner
+  ProgressCircles: typeof ProgressCircles
+  ProgressCirclesLabeled: typeof ProgressCirclesLabeled
 }

--- a/src/lib-components/indicators/ProgressCircles.vue
+++ b/src/lib-components/indicators/ProgressCircles.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { CheckIcon } from "@heroicons/vue/solid"
+import { computed } from "vue"
+
+type StepStatus = "complete" | "current" | "incomplete"
+
+interface Step {
+  name: string
+  description?: string
+}
+
+const props = defineProps<{
+  /**
+   * current sets the "current" step using an index of the steps prop
+   * to show all steps in an "incomplete" state set step to -1
+   * to show all steps in an "complete" state set step to a value >= steps.length
+   */
+  current: number
+  steps: Step[]
+}>()
+
+const layoutSteps = computed(() => {
+  return props.steps.map((step, stepIndex) => {
+    let status: StepStatus
+
+    if (props.current > stepIndex) {
+      status = "complete"
+    } else if (props.current === stepIndex) {
+      status = "current"
+    } else {
+      status = "incomplete"
+    }
+
+    return {
+      name: step.name,
+      description: step?.description || "",
+      status: status,
+    }
+  })
+})
+</script>
+
+<template>
+  <nav aria-label="Progress">
+    <ol role="list" class="flex items-center">
+      <li
+        v-for="(step, index) in layoutSteps"
+        :key="step.name"
+        :class="[index !== layoutSteps.length - 1 ? 'pr-8' : '', 'relative']"
+      >
+        <!--NOTE: horizontal connecting bar-->
+        <div class="absolute inset-0 flex items-center" aria-hidden="true">
+          <div
+            :class="[
+              'h-0.5 w-full',
+              step.status === 'complete' ? 'bg-xy-blue' : 'bg-gray-200',
+            ]"
+          />
+        </div>
+        <div
+          :class="{
+            'relative flex h-5 w-5 items-center justify-center rounded-full': true,
+            'bg-xy-blue': step.status === 'complete',
+            'border-2 border-indigo-600 bg-white': step.status === 'current',
+            'border-2 border-gray-300 bg-white': step.status === 'incomplete',
+          }"
+          :aria-current="step.status === 'current' ? true : undefined"
+        >
+          <CheckIcon
+            v-if="step.status === 'complete'"
+            class="h-3 w-3 text-white"
+            aria-hidden="true"
+          />
+          <span
+            v-else-if="step.status === 'current'"
+            class="h-3 w-3 rounded-full bg-xy-blue"
+            aria-hidden="true"
+          />
+          <span class="sr-only">{{ step.name }}</span>
+          <span v-if="step.description" class="sr-only">{{
+            step.description
+          }}</span>
+        </div>
+      </li>
+    </ol>
+  </nav>
+</template>

--- a/src/lib-components/indicators/ProgressCirclesLabeled.vue
+++ b/src/lib-components/indicators/ProgressCirclesLabeled.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { CheckIcon } from "@heroicons/vue/solid"
+import { computed } from "vue"
+
+type StepStatus = "complete" | "current" | "incomplete"
+
+interface Step {
+  name: string
+  description?: string
+}
+
+const props = defineProps<{
+  /**
+   * current sets the "current" step using an index of the steps prop
+   * to show all steps in an "incomplete" state set step to -1
+   * to show all steps in an "complete" state set step to a value >= steps.length
+   */
+  current: number
+  steps: Step[]
+}>()
+
+const layoutSteps = computed(() => {
+  return props.steps.map((step, stepIndex) => {
+    let status: StepStatus
+
+    if (props.current > stepIndex) {
+      status = "complete"
+    } else if (props.current === stepIndex) {
+      status = "current"
+    } else {
+      status = "incomplete"
+    }
+
+    return {
+      name: step.name,
+      description: step?.description || "",
+      status: status,
+    }
+  })
+})
+</script>
+
+<template>
+  <div aria-label="Progress">
+    <ol role="list" class="overflow-hidden">
+      <li
+        v-for="(step, index) in layoutSteps"
+        :key="index"
+        :class="[index !== layoutSteps.length - 1 ? 'pb-10' : '', 'relative']"
+      >
+        <!--NOTE: vertical connecting bar-->
+        <div
+          v-if="index !== layoutSteps.length - 1"
+          :class="[
+            'absolute left-4 top-4 -ml-px mt-0.5 h-full w-0.5',
+            step.status === 'complete' ? 'bg-xy-blue' : 'bg-gray-300',
+          ]"
+          aria-hidden="true"
+        />
+        <div
+          class="group relative flex items-start"
+          :aria-current="step.status === 'current' ? true : undefined"
+        >
+          <span class="flex h-9 items-center">
+            <span
+              :class="{
+                'relative z-10 flex h-8 w-8 items-center justify-center rounded-full': true,
+                'bg-xy-blue ': step.status === 'complete',
+                'border-2 border-xy-blue bg-white': step.status === 'current',
+                'border-2 border-gray-300 bg-white':
+                  step.status === 'incomplete',
+              }"
+            >
+              <CheckIcon
+                v-if="step.status === 'complete'"
+                class="h-5 w-5 text-white"
+                aria-hidden="true"
+              />
+              <span
+                v-else-if="step.status === 'current'"
+                class="h-2.5 w-2.5 rounded-full bg-xy-blue"
+              />
+            </span>
+          </span>
+          <span class="ml-4 flex min-w-0 flex-col">
+            <span
+              :class="{
+                'text-sm font-bold': true,
+                'text-gray-800': step.status === 'complete',
+                'text-xy-blue': step.status === 'current',
+                'text-gray-500': step.status === 'incomplete',
+                'mt-2': !step.description,
+              }"
+              >{{ step.name }}</span
+            >
+            <span v-if="step.description" class="text-sm text-gray-500">{{
+              step.description
+            }}</span>
+          </span>
+        </div>
+      </li>
+    </ol>
+  </div>
+</template>


### PR DESCRIPTION
# What this does

- adds two progress circle components for the incoming New App and Account Setup work
- adds a new docs page called "Indicators"

## Notes

There's currently no expectation that these progress indicators will function like nav items and tabs, so they're pretty dumb.  The current step is indicated by the "index" of the step in "steps", i.e. step 1 is current with an index of 0.  If this doesn't feel intuitive, let me know, and we can get it changed before the first use cases.