### PR TITLE
update styles and components to be more consistent with brand guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,22 +78,14 @@ module.exports = {
 
 ### Fonts
 
-**Include Inter Var in html template**
-
-```html
-<head>
-  <link href="https://rsms.me/inter/inter.css" rel="stylesheet" />
-</head>
-```
-
-**Optionally include Work Sans in html template**
+**Include Font Families in html template**
 
 ```html
 <head>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Work+Sans:ital,wght@0,300..800;1,300..800&display=swap"
     rel="stylesheet"
   />
 </head>

--- a/components.d.ts
+++ b/components.d.ts
@@ -8,6 +8,7 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     BaseAPIDocs: typeof import('./dev/docs/BaseAPIDocs.md')['default']
+    ButtonDocs: typeof import('./dev/docs/ButtonDocs.md')['default']
     FlashDocs: typeof import('./dev/docs/FlashDocs.md')['default']
     StackingContextDocs: typeof import('./dev/docs/StackingContextDocs.md')['default']
     UseBaseAPIDocs: typeof import('./dev/docs/UseBaseAPIDocs.md')['default']

--- a/components.d.ts
+++ b/components.d.ts
@@ -10,6 +10,7 @@ declare module 'vue' {
     BaseAPIDocs: typeof import('./dev/docs/BaseAPIDocs.md')['default']
     ButtonDocs: typeof import('./dev/docs/ButtonDocs.md')['default']
     FlashDocs: typeof import('./dev/docs/FlashDocs.md')['default']
+    Rounded: typeof import('./dev/docs/Rounded.md')['default']
     StackingContextDocs: typeof import('./dev/docs/StackingContextDocs.md')['default']
     UseBaseAPIDocs: typeof import('./dev/docs/UseBaseAPIDocs.md')['default']
     UseTabHistoryDocs: typeof import('./dev/docs/UseTabHistoryDocs.md')['default']

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -19,6 +19,7 @@ module.exports = {
     },
     extend: {
       animation: treesTheme.animation,
+      borderRadius: treesTheme.borderRadius,
       colors: treesTheme.colors,
       fontFamily: treesTheme.fontFamily,
       fontWeight: treesTheme.fontWeight,

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
       animation: treesTheme.animation,
       colors: treesTheme.colors,
       fontFamily: treesTheme.fontFamily,
+      fontWeight: treesTheme.fontWeight,
       typography: (theme) => {
         return {
           DEFAULT: {

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -26,15 +26,17 @@ module.exports = {
         return {
           DEFAULT: {
             css: {
-              color: theme("colors.gray.900"),
+              color: theme("colors.neutral.800"),
               a: {
-                color: theme("colors.xy-blue.DEFAULT"),
+                textDecoration: "none",
+                borderBottom: `2px solid ${theme("colors.xy-blue.DEFAULT")}`,
                 "&:hover": {
-                  color: theme("colors.blue.700"),
+                  color: theme("colors.xy-blue.DEFAULT"),
+                  borderBottomColor: theme("colors.transparent"),
                 },
               },
               "h2, h3, h4": {
-                color: theme("colors.gray.900"),
+                color: theme("colors.neutral.800"),
               },
             },
           },

--- a/config/theme/colors.ts
+++ b/config/theme/colors.ts
@@ -1,3 +1,5 @@
+import twColors from "tailwindcss/colors"
+
 export const brandColors = {
   blue: {
     50: "#C9E4F6",
@@ -24,7 +26,9 @@ export const brandColors = {
     900: "#307D41",
   },
   neutral: {
-    // holding on usage for potential palette update
+    // NOTE(spk): This is the official xy-neutral color pallete, but we're holding on usage.
+    // The color gradients are problematic with existing designs.
+    // The color weights 100-300 need a shift to the right by introducing a new 100 weight.
     50: "#FAF9F8",
     100: "#E7E6E5",
     200: "#C9C8C7",
@@ -39,6 +43,9 @@ export const brandColors = {
 }
 
 export default {
+  // NOTE(spk): The gray color pallete is currently in heavy rotation
+  // replace with tailwind/neutral while we phase it out.
+  gray: twColors.neutral,
   "xy-blue": {
     DEFAULT: brandColors["blue"][600],
     ...brandColors["blue"],
@@ -50,6 +57,8 @@ export default {
     DEFAULT: brandColors["green"][200],
     ...brandColors["green"],
   },
+  // NOTE(spk): while xy-neutral is updated we'll work with tailwind/neutral in its place.
+  "xy-neutral": twColors.neutral,
   "xy-black": {
     DEFAULT: brandColors["neutral"][800],
   },

--- a/config/theme/fontFamily.ts
+++ b/config/theme/fontFamily.ts
@@ -1,5 +1,0 @@
-import defaultTheme from "tailwindcss/defaultTheme"
-export default {
-  display: ["Work Sans", ...defaultTheme.fontFamily.sans],
-  sans: ["Inter var", ...defaultTheme.fontFamily.sans],
-}

--- a/config/theme/index.ts
+++ b/config/theme/index.ts
@@ -1,9 +1,10 @@
 import animation from "./animation"
 import colors from "./colors"
-import fontFamily from "./fontFamily"
+import { fontFamily, fontWeight } from "./typography"
 
 export default {
   animation,
   colors,
   fontFamily,
+  fontWeight,
 }

--- a/config/theme/index.ts
+++ b/config/theme/index.ts
@@ -1,9 +1,11 @@
 import animation from "./animation"
 import colors from "./colors"
+import { borderRadius } from "./layout"
 import { fontFamily, fontWeight } from "./typography"
 
 export default {
   animation,
+  borderRadius,
   colors,
   fontFamily,
   fontWeight,

--- a/config/theme/layout.ts
+++ b/config/theme/layout.ts
@@ -1,0 +1,11 @@
+/**
+ * borderRadius
+ * experimental .rounded class utilities for consitency with the brand design language
+ *
+ * These rounded utilities should be used mostly for layout container styles like cards,
+ * continue to use tailwind rounded utilities for other components like buttons and inputs.
+ */
+export const borderRadius = {
+  xy: "1.125rem", // rounded-xy 18px - use with padding < 1.5rem/24px
+  "xy-lg": "1.5rem", // rounded-xy-lg 32px - use with padding > 1.5rem/24px
+}

--- a/config/theme/typography.ts
+++ b/config/theme/typography.ts
@@ -1,0 +1,25 @@
+import defaultTheme from "tailwindcss/defaultTheme"
+
+export const fontFamily = {
+  display: ["Work Sans", ...defaultTheme.fontFamily.sans],
+  sans: [
+    // NOTE(spk): https://tailwindcss.com/docs/font-family#providing-default-font-settings
+    `"Open Sans", ${defaultTheme.fontFamily.sans.join(", ")}`,
+    {
+      // NOTE(spk): suggested by Google Fonts embed
+      fontVariationSettings: '"wdth" 100',
+    },
+  ],
+}
+
+// NOTE(spk): The Work Sans font family technically supports weights 100-900,
+// here Open Sans is limited to 300-800.  The current brand guidelines only make use of
+// the 300-800 weight range for both type faces.
+export const fontWeight = {
+  light: "300",
+  normal: "400",
+  medium: "500",
+  semibold: "600",
+  bold: "700",
+  extrabold: "800",
+}

--- a/dev/app.ts
+++ b/dev/app.ts
@@ -3,7 +3,6 @@ import "prismjs"
 import "prismjs/components/prism-typescript"
 import "prismjs/components/prism-markup"
 import "prismjs/components/prism-markup-templating"
-import "prismjs/themes/prism-tomorrow.min.css"
 import Trees, {
   setBaseAPIDefaults,
   useAppFlashes,

--- a/dev/app.ts
+++ b/dev/app.ts
@@ -11,6 +11,7 @@ import Trees, {
 } from "@/entry"
 import ClickToCopy from "./components/ClickToCopy.vue"
 import ComponentLayout from "./components/ComponentLayout.vue"
+import DocsDemo from "./components/DocsDemo.vue"
 import PropsTable from "./components/PropsTable.vue"
 import Serve from "./app.vue"
 import "./main.css"
@@ -21,6 +22,7 @@ declare module "vue" {
   interface GlobalComponents extends TreesComponents {
     ClickToCopy: typeof ClickToCopy
     ComponentLayout: typeof ComponentLayout
+    DocsDemo: typeof DocsDemo
     PropsTable: typeof PropsTable
   }
 }
@@ -32,5 +34,6 @@ const app = createApp(Serve)
 app.use(Trees)
 app.component("ClickToCopy", ClickToCopy)
 app.component("ComponentLayout", ComponentLayout)
+app.component("DocsDemo", DocsDemo)
 app.component("PropsTable", PropsTable)
 app.mount("#app")

--- a/dev/components/ComponentLayout.vue
+++ b/dev/components/ComponentLayout.vue
@@ -12,7 +12,7 @@ withDefaults(
 )
 </script>
 <template>
-  <div class="bg-white shadow rounded-lg divide-y divide-gray-200">
+  <div class="bg-white shadow rounded-xy divide-y divide-gray-200">
     <div class="px-4 py-5 border-b border-gray-200 sm:px-6">
       <div
         class="-ml-4 -mt-4 flex justify-between items-center flex-wrap sm:flex-nowrap"

--- a/dev/components/DocsDemo.vue
+++ b/dev/components/DocsDemo.vue
@@ -1,0 +1,23 @@
+<script lang="ts" setup></script>
+
+<template>
+  <div class="mt-4">
+    <div
+      class="not-prose bg-neutral-50/50 border border-neutral-100 shadow-sm overflow-hidden relative rounded-xl"
+    >
+      <div
+        style="background-position: 10px 10px"
+        class="absolute inset-0 bg-grid-slate-100 [mask-image:linear-gradient(0deg,#fff,rgba(255,255,255,0.6))] dark:bg-grid-slate-700/25 dark:[mask-image:linear-gradient(0deg,rgba(255,255,255,0.1),rgba(255,255,255,0.5))]"
+      />
+      <div class="relative rounded-xl overflow-auto p-8">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style>
+.bg-grid-slate-100 {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='%23f1f5f9'%3e%3cpath d='M0 .5H31.5V32'/%3e%3c/svg%3e");
+}
+</style>

--- a/dev/docs/ButtonDocs.md
+++ b/dev/docs/ButtonDocs.md
@@ -1,0 +1,211 @@
+<style>
+    .btn-layout {
+        @apply my-2 flex flex-col items-center justify-start space-y-4 sm:flex-row sm:items-end sm:space-y-0 sm:space-x-3;
+    }
+</style>
+
+## Button Sizing
+
+Buttons are available in three size. In most use cases you should reach for the base size. Leverage the small size when you're working in a compact space like a tight list or compact card. The large size should see minimal usage and is generally reserved for marketing like situations.
+
+## Common Buttons
+
+For the majority of your application interface you'll reach for buttons `xy-btn` and `xy-btn-secondary`. They're the bread and butter of buttons and it's best not to over think them. Think of the `xy-btn` as the primary call to action on any given page or interface - its the UI happy path you'd hope the user will take. Use `xy-btn-secondary` as the alterntive UI path and keep in mind that sometimes the happy path in a UI is for the user to do nothing but read the copy you've provided.
+
+### Primary
+
+<DocsDemo>
+    <div class="btn-layout">
+        <button class="xy-btn-sm">Button Text</button>
+        <button class="xy-btn">Button Text</button>
+        <button class="xy-btn-lg">Button Text</button>
+    </div>
+    <div class="btn-layout">
+        <button class="xy-btn-sm" disabled>Button Text</button>
+        <button class="xy-btn" disabled>Button Text</button>
+        <button class="xy-btn-lg" disabled>Button Text</button>
+    </div>
+</DocsDemo>
+
+```html
+<button class="xy-btn-sm">Button Text</button>
+<button class="xy-btn">Button Text</button>
+<button class="xy-btn-lg">Button Text</button>
+
+<!-- disabled -->
+<button class="xy-btn-sm" disabled>Button Text</button>
+<button class="xy-btn" disabled>Button Text</button>
+<button class="xy-btn-lg" disabled>Button Text</button>
+```
+
+### Secondary
+
+<DocsDemo>
+    <div class="btn-layout">
+        <button class="xy-btn-secondary-sm">Button Text</button>
+        <button class="xy-btn-secondary">Button Text</button>
+        <button class="xy-btn-secondary-lg">Button Text</button>
+    </div>
+    <div class="btn-layout">
+        <button class="xy-btn-secondary-sm" disabled>Button Text</button>
+        <button class="xy-btn-secondary" disabled>Button Text</button>
+        <button class="xy-btn-secondary-lg" disabled>Button Text</button>
+    </div>
+</DocsDemo>
+
+```html
+<button class="xy-btn-secondary-sm">Button Text</button>
+<button class="xy-btn-secondary">Button Text</button>
+<button class="xy-btn-secondary-lg">Button Text</button>
+
+<!-- disabled -->
+<button class="xy-btn-secondary-sm" disabled>Button Text</button>
+<button class="xy-btn-secondary" disabled>Button Text</button>
+<button class="xy-btn-secondary-lg" disabled>Button Text</button>
+```
+
+## Utility Buttons
+
+Utility buttons are useful for indicating purpose. `danger` for situations when a destructive action is taking place and `neutral` for when situations like canceling an action.
+
+### Danger
+
+<DocsDemo>
+    <div class="btn-layout">
+        <button class="xy-btn-danger-sm">Button Text</button>
+        <button class="xy-btn-danger">Button Text</button>
+        <button class="xy-btn-danger-lg">Button Text</button>
+    </div>
+    <div class="btn-layout">
+        <button class="xy-btn-danger-sm" disabled>Button Text</button>
+        <button class="xy-btn-danger" disabled>Button Text</button>
+        <button class="xy-btn-danger-lg" disabled>Button Text</button>
+    </div>
+    <div class="btn-layout">
+        <button class="xy-btn-secondary-danger-sm">Button Text</button>
+        <button class="xy-btn-secondary-danger">Button Text</button>
+        <button class="xy-btn-secondary-danger-lg">Button Text</button>
+    </div>
+    <div class="btn-layout">
+        <button class="xy-btn-secondary-danger-sm" disabled>Button Text</button>
+        <button class="xy-btn-secondary-danger" disabled>Button Text</button>
+        <button class="xy-btn-secondary-danger-lg" disabled>Button Text</button>
+    </div>
+</DocsDemo>
+
+```html
+<button class="xy-btn-danger-sm">Button Text</button>
+<button class="xy-btn-danger">Button Text</button>
+<button class="xy-btn-danger-lg">Button Text</button>
+
+<!-- disabled -->
+<button class="xy-btn-danger-sm" disabled>Button Text</button>
+<button class="xy-btn-danger" disabled>Button Text</button>
+<button class="xy-btn-danger-lg" disabled>Button Text</button>
+
+<!-- secondary -->
+<button class="xy-btn-secondary-danger-sm">Button Text</button>
+<button class="xy-btn-secondary-danger">Button Text</button>
+<button class="xy-btn-secondary-danger-lg">Button Text</button>
+
+<!-- secondary disabled-->
+<button class="xy-btn-secondary-danger-sm" disabled>Button Text</button>
+<button class="xy-btn-secondary-danger" disabled>Button Text</button>
+<button class="xy-btn-secondary-danger-lg" disabled>
+  Button disabled Text
+</button>
+```
+
+### Neutral
+
+<DocsDemo>
+    <div class="btn-layout">
+        <button class="xy-btn-neutral-sm">Button Text</button>
+        <button class="xy-btn-neutral">Button Text</button>
+        <button class="xy-btn-neutral-lg">Button Text</button>
+    </div>
+    <div class="btn-layout">
+        <button class="xy-btn-neutral-sm" disabled>Button Text</button>
+        <button class="xy-btn-neutral" disabled>Button Text</button>
+        <button class="xy-btn-neutral-lg" disabled>Button Text</button>
+    </div>
+</DocsDemo>
+
+```html
+<button class="xy-btn-neutral-sm">Button Text</button>
+<button class="xy-btn-neutral">Button Text</button>
+<button class="xy-btn-neutral-lg">Button Text</button>
+
+<!-- disabled -->
+<button class="xy-btn-neutral-sm" disabled>Button Text</button>
+<button class="xy-btn-neutral" disabled>Button Text</button>
+<button class="xy-btn-neutral-lg" disabled>Button Text</button>
+```
+
+## Specialty Buttons
+
+These specialty buttons should be used sparingly and are generally reserved for marketing situations.
+
+### Accent
+
+<DocsDemo>
+    <div class="btn-layout">
+        <button class="xy-btn-accent-sm">Button Text</button>
+        <button class="xy-btn-accent">Button Text</button>
+        <button class="xy-btn-accent-lg">Button Text</button>
+    </div>
+    <div class="btn-layout">
+        <button class="xy-btn-accent-sm" disabled>Button Text</button>
+        <button class="xy-btn-accent" disabled>Button Text</button>
+        <button class="xy-btn-accent-lg" disabled>Button Text</button>
+    </div>
+    <div class="btn-layout bg-neutral-700 rounded-xl p-4 mt-8">
+        <button class="xy-btn-accent-inverse-sm">Button Text</button>
+        <button class="xy-btn-accent-inverse">Button Text</button>
+        <button class="xy-btn-accent-inverse-lg">Button Text</button>
+    </div>
+    <div class="btn-layout bg-neutral-700 rounded-xl p-4 mt-8">
+        <button class="xy-btn-accent-inverse-sm" disabled>Button Text</button>
+        <button class="xy-btn-accent-inverse" disabled>Button Text</button>
+        <button class="xy-btn-accent-inverse-lg" disabled>Button Text</button>
+    </div>
+</DocsDemo>
+
+```html
+<button class="xy-btn-accent-sm">Button Text</button>
+<button class="xy-btn-accent">Button Text</button>
+<button class="xy-btn-accent-lg">Button Text</button>
+
+<!-- disabled -->
+<button class="xy-btn-accent-sm" disabled>Button Text</button>
+<button class="xy-btn-accent" disabled>Button Text</button>
+<button class="xy-btn-accent-lg" disabled>Button Text</button>
+
+<!-- inverse -->
+<button class="xy-btn-accent-inverse-sm">Button Text</button>
+<button class="xy-btn-accent-inverse">Button Text</button>
+<button class="xy-btn-accent-inverse-lg">Button Text</button>
+
+<!--inverse disabled-->
+<button class="xy-btn-accent-inverse-sm" disabled>Button Text</button>
+<button class="xy-btn-accent-inverse" disabled>Button Text</button>
+<button class="xy-btn-accent-inverse-lg" disabled>Button Text</button>
+```
+
+## Deprecated
+
+The following buttons are deprecated and their usage should be replaced.
+
+### White
+
+Most of the existing use cases can be replaced with either `xy-btn-secondary` or `xy-btn-neutral`.
+
+<DocsDemo>
+    <div class="btn-layout">
+        <button class="xy-btn-white">Button Text</button>
+    </div>
+</DocsDemo>
+
+```html
+<button class="xy-btn-white">Button Text</button>
+```

--- a/dev/docs/Rounded.md
+++ b/dev/docs/Rounded.md
@@ -1,0 +1,33 @@
+<style>
+    .test-card-compact {
+        @apply bg-white shadow-md p-4 min-h-[5rem] w-full;
+    }
+
+    .test-card {
+        @apply bg-white shadow-md p-8 min-h-[5rem] w-full;
+    }
+</style>
+
+<DocsDemo>
+    <div class="test-card prose rounded-xy-lg">
+        <h3>Card</h3>
+        <p>The content of this larger card.</p>
+    </div>
+</DocsDemo>
+
+```html
+// rounded-xy 18px - use when the containers internal padding < 1.5rem (24px)
+.rounded-xy
+```
+
+<DocsDemo>
+    <div class="test-card-compact prose rounded-xy">
+        <h4>Compact Card</h4>
+        <p>The content of this compact card.</p>
+    </div>
+</DocsDemo>
+
+```html
+// rounded-xy 32px - use when the containers internal padding > 1.5rem (24px)
+.rounded-xy-lg
+```

--- a/dev/main.css
+++ b/dev/main.css
@@ -1,1 +1,10 @@
+@import "prismjs/themes/prism-tomorrow.min.css";
 @import "../src/index.css";
+
+/* NOTE(spk): override the styles added by import "prismjs/themes/prism-tomorrow.min.css" */
+@layer base {
+  code[class*="language-"],
+  pre[class*="language-"] {
+    @apply text-sm leading-relaxed;
+  }
+}

--- a/dev/pages/Elements.vue
+++ b/dev/pages/Elements.vue
@@ -9,10 +9,6 @@ const badgePrimary = ref<HTMLElement>()
 const badgeInfo = ref<HTMLElement>()
 const badgeSuccess = ref<HTMLElement>()
 const badgeAlert = ref<HTMLElement>()
-const btnPrimary = ref<HTMLElement>()
-const btnSecondary = ref<HTMLElement>()
-const btnRed = ref<HTMLElement>()
-const btnWhite = ref<HTMLElement>()
 const links = ref<HTMLElement>()
 const extraFlairCopy = `<h1 class="xy-h1-extra-flair">Header1 Bold</h1>`
 
@@ -203,47 +199,7 @@ const alertProps = [
           Buttons are the best. Clickable. What's not to love.
         </template>
 
-        <div>
-          <label class="block text-sm font-medium text-gray-700">
-            <ClickToCopy :value="btnPrimary?.outerHTML" />
-          </label>
-          <div class="mt-1">
-            <button ref="btnPrimary" type="button" class="xy-btn">
-              Primary
-            </button>
-          </div>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium text-gray-700">
-            <ClickToCopy :value="btnSecondary?.outerHTML" />
-          </label>
-          <div class="mt-1">
-            <button ref="btnSecondary" type="button" class="xy-btn-secondary">
-              Secondary
-            </button>
-          </div>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium text-gray-700">
-            <ClickToCopy :value="btnRed?.outerHTML" />
-          </label>
-          <div class="mt-1">
-            <button ref="btnRed" type="button" class="xy-btn-red">Red</button>
-          </div>
-        </div>
-
-        <div>
-          <label class="block text-sm font-medium text-gray-700">
-            <ClickToCopy :value="btnWhite?.outerHTML" />
-          </label>
-          <div class="mt-1">
-            <button ref="btnWhite" type="button" class="xy-btn-white">
-              White
-            </button>
-          </div>
-        </div>
+        <ButtonDocs />
       </ComponentLayout>
 
       <ComponentLayout class="mt-8" :css-component="true" title="Links">

--- a/dev/pages/Elements.vue
+++ b/dev/pages/Elements.vue
@@ -16,11 +16,26 @@ const links = ref<HTMLElement>()
 const extraFlairCopy = `<h1 class="xy-h1-extra-flair">Header1 Bold</h1>`
 
 const typefaces = {
-  "font-inter": "Inter",
+  "font-sans": "Open Sans",
   "font-display": "Work Sans",
 }
 
+// NOTE(spk): explicitly written out so that tailwind doesn't prune the values
+const fontSizes = [
+  "text-xs",
+  "text-sm",
+  "text-base",
+  "text-lg",
+  "text-xl",
+  "text-2xl",
+  "text-3xl",
+  "text-4xl",
+  "text-5xl",
+  "text-6xl",
+]
+
 const weights = [
+  "font-light",
   "font-normal",
   "font-medium",
   "font-semibold",
@@ -377,36 +392,46 @@ const alertProps = [
 
       <ComponentLayout :css-component="true" title="Fonts">
         <template #description
-          >There are two fonts available. Inter (font-sans) is the default
+          >There are two fonts available. Open Sans (font-sans) is the default
           interface font and should be used for most things. Work Sans
-          (font-display) is useful for headings and more marketing focused
-          content.</template
+          (font-display) is useful for small interface features like buttons and
+          stand-out title and headings. Think of it as the brand typeface, but
+          use it sparingly as Open Sans is a better general use typeface for
+          interfaces.</template
         >
 
         <div class="space-y-10">
-          <div class="space-y-10">
-            <div v-for="weight in weights" :key="weight">
-              <h5 class="text-sm font-semibold text-gray-900">{{ weight }}</h5>
-              <div class="grid grid-cols-2 gap-x-6">
-                <template
-                  v-for="(name, typeface) in typefaces"
-                  :key="`${typeface}-${weight}`"
-                >
-                  <div>
-                    <h5 class="text-sm font-semibold text-gray-900">
-                      {{ name }}
-                    </h5>
-                    <div
-                      v-for="header in 6"
-                      :key="`${typeface}-${header}-${weight}`"
-                      class="mt-1 bg-gray-100"
-                    >
-                      <component :is="`h${header}`" :class="[weight, typeface]"
-                        >Header H{{ header }}</component
-                      >
-                    </div>
+          <div
+            v-for="(name, typeface) in typefaces"
+            :key="typeface"
+            class="space-y-10"
+          >
+            <div>
+              <h5 class="text-lg font-semibold text-gray-900 mb-2">
+                {{ name }} Font Sizes
+              </h5>
+
+              <div class="space-y-5">
+                <div v-for="size in fontSizes" :key="`${typeface}-${size}`">
+                  <div class="text-sm text-gray-700">{{ size }}</div>
+                  <div :class="[size, typeface, 'font-normal bg-gray-100']">
+                    The quick brown fox jumps over the lazy dog.
                   </div>
-                </template>
+                </div>
+              </div>
+            </div>
+
+            <div>
+              <h5 class="text-lg font-semibold text-gray-900 mb-2">
+                {{ name }} Font Weights
+              </h5>
+              <div class="space-y-5">
+                <div v-for="weight in weights" :key="`${typeface}-${weight}`">
+                  <div class="text-sm text-gray-700">{{ weight }}</div>
+                  <div :class="[weight, typeface, 'text-xl bg-gray-100']">
+                    The quick brown fox jumps over the lazy dog.
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/dev/pages/Elements.vue
+++ b/dev/pages/Elements.vue
@@ -55,6 +55,11 @@ const alertProps = [
         >
           <ColorRow name="" :colors="colors['xy-blue']" code="xy-blue" />
           <ColorRow name="" :colors="colors['xy-green']" code="xy-green" />
+          <ColorRow
+            name=""
+            :colors="colors['xy-neutral']"
+            code="xy-neutral/gray"
+          />
         </div>
       </ComponentLayout>
 

--- a/dev/pages/Elements.vue
+++ b/dev/pages/Elements.vue
@@ -7,6 +7,7 @@ import { InputOption } from "@/composables/forms"
 
 const badgePrimary = ref<HTMLElement>()
 const badgeInfo = ref<HTMLElement>()
+const badgeSuccess = ref<HTMLElement>()
 const badgeAlert = ref<HTMLElement>()
 const btnPrimary = ref<HTMLElement>()
 const btnSecondary = ref<HTMLElement>()
@@ -175,6 +176,15 @@ const alertProps = [
           </label>
           <div class="mt-1">
             <span ref="badgeInfo" class="xy-badge-blue">Info</span>
+          </div>
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">
+            <ClickToCopy :value="badgeSuccess?.outerHTML" />
+          </label>
+          <div class="mt-1">
+            <span ref="badgeSuccess" class="xy-badge-green">Most Popular</span>
           </div>
         </div>
 

--- a/dev/pages/Elements.vue
+++ b/dev/pages/Elements.vue
@@ -403,6 +403,14 @@ const alertProps = [
           </div>
         </div>
       </ComponentLayout>
+
+      <ComponentLayout :css-component="true" title="Rounded">
+        <template #description>
+          An experimental border-radius utility for matching rounded corners
+          with the brand design language.
+        </template>
+        <Rounded />
+      </ComponentLayout>
     </div>
   </div>
 </template>

--- a/dev/pages/Home.vue
+++ b/dev/pages/Home.vue
@@ -29,7 +29,7 @@ const features = computed(() => {
           <div v-for="feature in features" :key="feature.name" class="pt-6">
             <a
               :href="feature.url"
-              class="flow-root bg-gray-50 shadow rounded-lg px-6 pb-8 cursor-pointer hover:bg-gray-100"
+              class="flow-root bg-white shadow rounded-lg px-6 pb-8 cursor-pointer"
             >
               <div class="-mt-6">
                 <div>

--- a/dev/pages/Overlays.vue
+++ b/dev/pages/Overlays.vue
@@ -138,28 +138,28 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
         <div class="flex flex-col space-y-3">
           <button
             type="button"
-            class="xy-btn-white"
+            class="xy-btn"
             @click="useAppFlasher.genericError()"
           >
             Generic Error with default email
           </button>
           <button
             type="button"
-            class="xy-btn-white"
+            class="xy-btn"
             @click="useAppFlasher.genericError('help@trees.com')"
           >
             Show Generic with custom email
           </button>
           <button
             type="button"
-            class="xy-btn-white"
+            class="xy-btn"
             @click="useAppFlasher.success('Hooray!')"
           >
             Flash Success
           </button>
           <button
             type="button"
-            class="xy-btn-white"
+            class="xy-btn"
             @click="useAppFlasher.info('Sticky!', true)"
           >
             Flash Persistent

--- a/index.html
+++ b/index.html
@@ -6,9 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://rsms.me/inter/inter.css" rel="stylesheet" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Work+Sans:ital,wght@0,300..800;1,300..800&display=swap"
       rel="stylesheet"
     />
     <title>Trees Docs</title>

--- a/src/index.css
+++ b/src/index.css
@@ -58,21 +58,106 @@
     @apply inline-flex justify-center items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800;
   }
 
-  /* Button classes */
+  /*
+    Button classes
+
+    NOTE(spk): prefer rounded-3xl to rounded-full to support line wrapping in buttons.
+    NOTE(spk): prefer a consistent focus ring color for tracking - best practice.
+    NOTE(spk): using opacity in disabled states fails contrast accessibility standards (revisit).
+  */
+  .xy-btn-sm {
+    @apply inline-flex justify-center items-center px-2.5 py-1.5 border border-transparent text-xs font-display font-semibold rounded-3xl shadow-sm text-white bg-xy-blue-600 hover:bg-xy-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-xy-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
   .xy-btn {
-    @apply inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-semibold rounded-md shadow-md text-white bg-xy-blue-600 hover:bg-xy-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-display font-semibold rounded-3xl shadow-sm text-white bg-xy-blue-600 hover:bg-xy-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-xy-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  .xy-btn-lg {
+    @apply inline-flex justify-center items-center px-5 py-2.5 border border-transparent text-base font-display font-semibold rounded-3xl shadow-sm text-white bg-xy-blue-600 hover:bg-xy-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-xy-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  /* NOTE(spk): including .xy-btn-red alias for backwards compatibility */
+  .xy-btn-danger-sm,
+  .xy-btn-red-sm {
+    @apply inline-flex justify-center items-center px-2.5 py-1.5 border border-transparent text-xs font-display font-semibold rounded-3xl shadow-sm text-white bg-red-700 hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-500;
+  }
+
+  .xy-btn-danger,
+  .xy-btn-red {
+    @apply inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-display font-semibold rounded-3xl shadow-sm text-white bg-red-700 hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-500;
+  }
+
+  .xy-btn-danger-lg,
+  .xy-btn-red-lg {
+    @apply inline-flex justify-center items-center px-5 py-2.5 border border-transparent text-base font-display font-semibold rounded-3xl shadow-sm text-white bg-red-700 hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-500;
+  }
+
+  .xy-btn-neutral-sm {
+    @apply inline-flex justify-center items-center px-2.5 py-1.5 border border-transparent text-xs font-display font-semibold rounded-3xl shadow-none text-neutral-800 bg-neutral-100 hover:bg-neutral-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-neutral-50 disabled:text-neutral-500 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  .xy-btn-neutral {
+    @apply inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-display font-semibold rounded-3xl shadow-none text-neutral-800 bg-neutral-100 hover:bg-neutral-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-neutral-50 disabled:text-neutral-500 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  .xy-btn-neutral-lg {
+    @apply inline-flex justify-center items-center px-5 py-2.5 border border-transparent text-base font-display font-semibold rounded-3xl shadow-none text-neutral-800 bg-neutral-100 hover:bg-neutral-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-neutral-50 disabled:text-neutral-500 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  /* NOTE(spk): always consider the relative box-sizing between buttons with solid backgrounds and full borders vs secondary styles as they will commonly be laid out next to each other */
+  /* NOTE(spk): there's no way to round a ring or outline in a focus state without rounding the entire button.  Avoid this as it causes odd shapes on the bottom border and using content hacks aren't worth the trouble */
+  .xy-btn-secondary-sm {
+    @apply inline-flex justify-center items-center py-1.5 border-b-2 border-b-xy-blue-600 text-xs font-display font-semibold shadow-none text-neutral-800 hover:text-xy-blue-600 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-xy-blue-600 disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
   }
 
   .xy-btn-secondary {
-    @apply inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-semibold rounded-md shadow-md text-blue-700 bg-blue-100 hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply inline-flex justify-center items-center py-2 border-b-2 border-b-xy-blue-600 text-sm font-display font-semibold shadow-none text-neutral-800 hover:text-xy-blue-600 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-xy-blue-600 disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
   }
 
-  .xy-btn-red {
-    @apply inline-flex justify-center items-center px-4 py-2 border border-transparent text-xs md:text-sm font-semibold rounded-md shadow-md text-red-700 bg-red-100 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-300 disabled:opacity-50 disabled:cursor-not-allowed;
+  .xy-btn-secondary-lg {
+    @apply inline-flex justify-center items-center py-2.5 border-b-2 border-b-xy-blue-600 text-base font-display font-semibold shadow-none text-neutral-800 hover:text-xy-blue-600 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-xy-blue-600 disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
   }
 
+  .xy-btn-accent-sm {
+    @apply inline-flex justify-center items-center py-1.5 border-b-2 border-b-xy-green text-xs font-display font-semibold shadow-none text-neutral-800 hover:text-xy-green-900 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-xy-green disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
+  }
+
+  .xy-btn-accent {
+    @apply inline-flex justify-center items-center py-2 border-b-2 border-b-xy-green text-sm font-display font-semibold shadow-none text-neutral-800 hover:text-xy-green-900 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-xy-green disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
+  }
+
+  .xy-btn-accent-lg {
+    @apply inline-flex justify-center items-center py-2.5 border-b-2 border-b-xy-green text-base font-display font-semibold shadow-none text-neutral-800 hover:text-xy-green-900 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-xy-green disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
+  }
+
+  .xy-btn-accent-inverse-sm {
+    @apply inline-flex justify-center items-center py-1.5 border-b-2 border-b-xy-green text-xs font-display font-semibold shadow-none text-white hover:text-xy-green hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-white disabled:border-b-xy-green disabled:opacity-75 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
+  }
+
+  .xy-btn-accent-inverse {
+    @apply inline-flex justify-center items-center py-2 border-b-2 border-b-xy-green text-sm font-display font-semibold shadow-none text-white hover:text-xy-green hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-white disabled:border-b-xy-green disabled:opacity-75 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
+  }
+
+  .xy-btn-accent-inverse-lg {
+    @apply inline-flex justify-center items-center py-2.5 border-b-2 border-b-xy-green text-base font-display font-semibold shadow-none text-white hover:text-xy-green hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-white disabled:border-b-xy-green disabled:opacity-75 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
+  }
+
+  .xy-btn-secondary-danger-sm {
+    @apply inline-flex justify-center items-center py-1.5 border-b-2 border-b-red-700 text-xs font-display font-semibold shadow-none text-neutral-800 hover:text-red-700 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-red-700 disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
+  }
+
+  .xy-btn-secondary-danger {
+    @apply inline-flex justify-center items-center py-2 border-b-2 border-b-red-700 text-sm font-display font-semibold shadow-none text-neutral-800 hover:text-red-700 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-red-700 disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
+  }
+
+  .xy-btn-secondary-danger-lg {
+    @apply inline-flex justify-center items-center py-2.5 border-b-2 border-b-red-700 text-base font-display font-semibold shadow-none text-neutral-800 hover:text-red-700 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-red-700 disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
+  }
+
+  /* Deprecated */
   .xy-btn-white {
-    @apply inline-flex justify-center items-center px-4 py-2 border border-xy-blue shadow-md text-sm font-semibold rounded-md text-xy-blue bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply inline-flex justify-center items-center px-4 py-2 border border-xy-blue shadow-sm text-sm font-semibold rounded-3xl text-xy-blue bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
   /* Header classes */
@@ -118,7 +203,7 @@
 
   /* Link classes */
   .xy-link {
-    @apply font-semibold underline text-xy-blue-600 hover:text-xy-blue-500;
+    @apply font-medium border-b-2 border-b-xy-blue hover:border-b-transparent hover:text-xy-blue;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,14 @@
 @tailwind utilities;
 
 @layer base {
+  html {
+    @apply antialiased;
+    font-optical-sizing: auto;
+  }
+
   /* general body copy */
   body {
-    @apply text-base leading-normal text-gray-900;
+    @apply text-base leading-normal text-gray-800; /* NOTE(spk): expecting this to eventually hold the xy-black value */
   }
 
   /* Headers */

--- a/src/index.css
+++ b/src/index.css
@@ -42,15 +42,20 @@
 @layer components {
   /* Badge classes - TODO: handle anchor tag class cases and generic wrapper cases */
   .xy-badge {
-    @apply inline-flex justify-center items-center px-2 py-0.5 rounded text-xs font-semibold bg-gray-100 text-gray-800;
+    @apply inline-flex justify-center items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-gray-100 text-gray-800;
   }
 
   .xy-badge-blue {
-    @apply inline-flex justify-center items-center px-2 py-0.5 rounded text-xs font-semibold bg-blue-100 text-blue-800;
+    @apply inline-flex justify-center items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-blue-100 text-blue-800;
+  }
+
+  .xy-badge-green {
+    /* NOTE(spk): currently does not meet contrast ratio requirements */
+    @apply inline-flex justify-center items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-xy-green-50/40 text-xy-green-900;
   }
 
   .xy-badge-yellow {
-    @apply inline-flex justify-center items-center px-2 py-0.5 rounded text-xs font-semibold bg-yellow-100 text-yellow-800;
+    @apply inline-flex justify-center items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800;
   }
 
   /* Button classes */

--- a/src/lib-components/indicators/InlineAlert.vue
+++ b/src/lib-components/indicators/InlineAlert.vue
@@ -116,7 +116,7 @@ const icon = computed(() => {
 </script>
 
 <template>
-  <div v-if="visible" class="rounded-lg p-4" :class="display.bgColor">
+  <div v-if="visible" class="rounded-xy p-4" :class="display.bgColor">
     <div class="flex">
       <div class="flex-shrink-0">
         <component
@@ -152,7 +152,7 @@ const icon = computed(() => {
           >
             <div v-if="btnText">
               <a
-                class="inline-flex rounded-md px-2 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2"
+                class="inline-flex rounded-3xl px-2.5 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2"
                 :class="display.btnAction"
                 :href="btnLink"
                 :role="btnLink ? 'link' : 'button'"
@@ -163,7 +163,7 @@ const icon = computed(() => {
             </div>
             <div v-if="secondaryBtnText">
               <a
-                class="inline-flex rounded-md px-2 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2"
+                class="inline-flex rounded-3xl px-2.5 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2"
                 :class="display.btnAction"
                 :href="secondaryBtnLink"
                 :role="secondaryBtnLink ? 'link' : 'button'"

--- a/src/lib-components/indicators/ProgressCircles.vue
+++ b/src/lib-components/indicators/ProgressCircles.vue
@@ -53,7 +53,7 @@ const layoutSteps = computed(() => {
           <div
             :class="[
               'h-0.5 w-full',
-              step.status === 'complete' ? 'bg-xy-blue' : 'bg-gray-200',
+              step.status === 'complete' ? 'bg-xy-blue' : 'bg-gray-300',
             ]"
           />
         </div>

--- a/src/lib-components/indicators/ProgressCirclesLabeled.vue
+++ b/src/lib-components/indicators/ProgressCirclesLabeled.vue
@@ -88,12 +88,12 @@ const layoutSteps = computed(() => {
                 'text-sm font-bold': true,
                 'text-gray-800': step.status === 'complete',
                 'text-xy-blue': step.status === 'current',
-                'text-gray-500': step.status === 'incomplete',
+                'text-gray-600': step.status === 'incomplete',
                 'mt-2': !step.description,
               }"
               >{{ step.name }}</span
             >
-            <span v-if="step.description" class="text-sm text-gray-500">{{
+            <span v-if="step.description" class="text-sm text-gray-600">{{
               step.description
             }}</span>
           </span>

--- a/src/lib-components/layout/SidebarLayout.vue
+++ b/src/lib-components/layout/SidebarLayout.vue
@@ -35,7 +35,7 @@ const isActive = (url: string): boolean => {
 }
 </script>
 <template>
-  <div class="h-screen flex overflow-hidden bg-gray-100">
+  <div class="h-screen flex overflow-hidden bg-gray-50">
     <TransitionRoot as="template" :show="sidebarOpen">
       <Dialog
         as="div"

--- a/src/lib-components/layout/SidebarLayout.vue
+++ b/src/lib-components/layout/SidebarLayout.vue
@@ -99,7 +99,7 @@ const isActive = (url: string): boolean => {
                     isActive(item.url)
                       ? 'bg-gray-100 text-gray-900'
                       : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900',
-                    'group flex items-center px-2 py-2 text-base font-medium rounded-md',
+                    'group flex items-center px-2 py-2 text-base font-semibold rounded-md',
                   ]"
                   :target="item.openInTab ? '_blank' : '_self'"
                 >
@@ -149,8 +149,8 @@ const isActive = (url: string): boolean => {
                 :class="[
                   isActive(item.url)
                     ? 'bg-gray-100 text-gray-900'
-                    : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900',
-                  'group flex items-center px-2 py-2 text-sm font-medium rounded-md',
+                    : 'text-gray-800 hover:bg-gray-100 hover:text-gray-900',
+                  'group flex items-center px-2 py-2 text-sm font-semibold rounded-md',
                 ]"
                 :target="item.openInTab ? '_blank' : '_self'"
               >
@@ -159,7 +159,7 @@ const isActive = (url: string): boolean => {
                   :class="[
                     isActive(item.url)
                       ? 'text-gray-600'
-                      : 'text-gray-500 group-hover:text-gray-600',
+                      : 'text-gray-400 group-hover:text-gray-600',
                     'mr-3 h-6 w-6',
                   ]"
                   aria-hidden="true"

--- a/src/lib-components/layout/StackedLayout.vue
+++ b/src/lib-components/layout/StackedLayout.vue
@@ -31,7 +31,7 @@ const isActive = (url: string): boolean => {
 }
 </script>
 <template>
-  <div class="min-h-screen bg-gray-100">
+  <div class="min-h-screen bg-gray-50">
     <Disclosure v-slot="{ open }" as="nav" class="bg-white shadow-sm">
       <div class="mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">

--- a/src/lib-components/lists/Cards.vue
+++ b/src/lib-components/lists/Cards.vue
@@ -14,7 +14,7 @@ defineProps<{
     <div
       v-for="(card, idx) in cards"
       :key="idx"
-      class="bg-white overflow-hidden shadow rounded-lg"
+      class="bg-white overflow-hidden shadow rounded-xy"
     >
       <div class="px-4 py-5 sm:p-6 text-center">
         <dl>

--- a/src/lib-components/navigation/Steps.vue
+++ b/src/lib-components/navigation/Steps.vue
@@ -65,7 +65,7 @@ const previous = (): void => {
       <span v-if="!hidePrevious" class="inline-flex rounded-md shadow-sm">
         <button
           type="button"
-          class="xy-btn-white"
+          class="xy-btn-secondary"
           @click="previous"
           v-text="previousText"
         ></button>

--- a/src/lib-components/overlays/ContentModal.vue
+++ b/src/lib-components/overlays/ContentModal.vue
@@ -67,7 +67,7 @@ const updateModelValue = (value: boolean) => {
           leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         >
           <div
-            class="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6"
+            class="inline-block align-bottom bg-white rounded-xy px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-md sm:w-full sm:p-8 sm:rounded-xy-lg"
           >
             <div>
               <slot name="icon"></slot>

--- a/src/lib-components/overlays/Modal.vue
+++ b/src/lib-components/overlays/Modal.vue
@@ -81,10 +81,10 @@ const updateModelValue = (value: boolean) => {
           leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         >
           <div
-            class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle w-full"
+            class="inline-block align-bottom bg-white rounded-xy text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:rounded-xy-lg w-full"
             :class="wide ? 'sm:max-w-6xl' : 'sm:max-w-2xl'"
           >
-            <div class="block absolute top-0 right-0 pt-4 pr-4">
+            <div class="block absolute top-0 right-0 pt-4 pr-4 sm:pt-6 sm:pr-8">
               <button
                 type="button"
                 class="bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
@@ -94,7 +94,7 @@ const updateModelValue = (value: boolean) => {
                 <XIcon class="h-6 w-6" aria-hidden="true" />
               </button>
             </div>
-            <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <div class="bg-white px-4 pt-5 pb-4 sm:p-8 sm:pb-6">
               <div class="mt-3 sm:mt-0 sm:text-left">
                 <DialogTitle
                   as="h3"
@@ -108,7 +108,7 @@ const updateModelValue = (value: boolean) => {
             </div>
             <div
               v-if="submitText"
-              class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse"
+              class="bg-gray-50 px-4 py-3 sm:py-4 sm:px-8 sm:flex sm:flex-row-reverse"
             >
               <button
                 type="button"

--- a/src/lib-components/overlays/Modal.vue
+++ b/src/lib-components/overlays/Modal.vue
@@ -121,7 +121,7 @@ const updateModelValue = (value: boolean) => {
               <button
                 ref="cancelButtonRef"
                 type="button"
-                class="xy-btn-white mt-3 w-full sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+                class="xy-btn-neutral mt-3 w-full sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
                 @click="updateModelValue(false)"
               >
                 Cancel

--- a/src/lib-components/overlays/Popover/PopoverContent.vue
+++ b/src/lib-components/overlays/Popover/PopoverContent.vue
@@ -1,7 +1,7 @@
 <template>
   <!--styling wrapper - top level element will merge attrs for class overrides -->
   <div
-    class="w-full max-w-xs bg-white rounded-md p-2 border border-gray-100 shadow-md"
+    class="w-full max-w-xs bg-white rounded-xy p-2 border border-gray-100 shadow-md"
   >
     <slot></slot>
   </div>

--- a/src/lib-components/overlays/Tooltip.vue
+++ b/src/lib-components/overlays/Tooltip.vue
@@ -36,7 +36,7 @@ const hoverPopover = (e: MouseEvent, open: boolean): void => {
 
 <template>
   <Popover :position="position" :as="as">
-    <template #button="{ open, close }: { open: boolean, close: () => void }">
+    <template #button="{ open, close }: { open: boolean; close: () => void }">
       <div
         class="leading-none relative w-4 h-4"
         @mouseover="hoverPopover($event, open)"
@@ -51,7 +51,7 @@ const hoverPopover = (e: MouseEvent, open: boolean): void => {
     </template>
     <template #default="{ close }: { close: () => void }">
       <div
-        class="sm:min-w-max bg-white rounded-md px-3 py-2 border border-gray-100 drop-shadow-md text-xs text-gray-900 leading-snug font-medium"
+        class="sm:min-w-max bg-white rounded-xy px-3.5 py-2.5 border border-gray-100 drop-shadow-md text-xs text-gray-900 leading-snug font-medium"
         @mouseover.prevent="popoverHover = true"
         @mouseleave.prevent="closePopover(close)"
       >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,5 +2,5 @@
 const baseConfig = require("./config/tailwind.config")
 module.exports = {
   ...baseConfig,
-  content: [...baseConfig.content, "./dev/**/*.vue"],
+  content: [...baseConfig.content, "./dev/**/*.vue", "./dev/docs/**/*.md"],
 }


### PR DESCRIPTION
# What this does

Makes a handful of changes that move our components styles closer to the brand's guidelines and marketing materials.

- maps the tailwind gray palette to tailwind neutral (I'm still holding on adopting the palette created by Audrey as the 100-300 weights could use a rightward shift one weight)
- sets `Open Sans` as the primary `sans` style font and uses `Work Sans` in a small set of components (buttons)
- adds the `antialiased` style globally to line up with marketing sites and the perceived styles of figma
- updates badge styles and adds a green badge
- updates and adds new button styles and sizes
- adds custom tailwind rounded utility classes and applies the new radius to a handful of layout components (ex: `ContentModal, Modal, InlineAlert`)
- tweaks docs further and makes code sample font smaller

### Notes

The docs styles are rough.  This is on my radar, and I'm eager to tackle it, but I just ran out of time.  My goal would be to tidy up `prose` utilities to help with these docs and the admin docs feature in the apps as well as having a more general use prose utility for dropping large bits of stakeholder requested copy on to pages.

Here are a handful of screenshots to give you a sense of what's changing visually, I'll include some migration steps in the final release branch for v0.10.0 once this is all merged.

<img width="851" alt="Screenshot 2024-08-27 at 6 18 53 PM" src="https://github.com/user-attachments/assets/81e0317c-08e7-4de2-8e15-e0084520ec9a">
<img width="812" alt="Screenshot 2024-08-27 at 6 18 24 PM" src="https://github.com/user-attachments/assets/a46cb988-fd5a-44d2-9fb5-246c4780e91f">
<img width="827" alt="Screenshot 2024-08-27 at 6 18 37 PM" src="https://github.com/user-attachments/assets/d7d582c5-65e9-4fc1-9429-23cbaa268c55">
