### PR TITLE
SidebarLayout nav slot, form input tweaks, progress circles fix

### DIFF
--- a/dev/app.vue
+++ b/dev/app.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { homePage, pages } from "./pages"
-import TreeIcon from "./assets/trees-square-icon.svg"
 import { user } from "./domain/user"
+import { ref } from "vue"
 
 /**
  * determine the app layout on load
@@ -55,6 +55,27 @@ const userNavigation = (() => {
     },
   ]
 })()
+
+/**
+ * App Sidebar Nav Slot Demo
+ */
+const showProgress = ref(false)
+const currentStep = ref(2)
+const steps = [
+  { name: "Sign Up" },
+  {
+    name: "Verify Email",
+  },
+  {
+    name: "Set Up Profile",
+  },
+  {
+    name: "Choose a Plan",
+  },
+  {
+    name: "Review and Submit",
+  },
+]
 </script>
 
 <template>
@@ -75,21 +96,30 @@ const userNavigation = (() => {
         </div>
       </div>
 
-      <template v-if="appLayout === 'SidebarLayout'" #sidebar-bottom>
-        <div class="bg-gray-50 rounded-md p-4 space-y-3">
-          <div class="flex space-x-2 items-center">
-            <div class="h-14 w-14">
-              <img :src="TreeIcon" />
-            </div>
-            <h5 class="h5 leading-tight flex-1">
-              Thought Experiment Of The Day
-            </h5>
-          </div>
-          <p class="text-sm font-medium italic">
-            If a tree falls in a forest and no one is around to hear it, does it
-            make a sound?
-          </p>
+      <template
+        v-if="appLayout === 'SidebarLayout' && showProgress"
+        #sidebar-nav
+      >
+        <div class="flex justify-center px-2 py-6">
+          <ProgressCirclesLabeled :current="currentStep" :steps="steps" />
         </div>
+      </template>
+
+      <template v-if="appLayout === 'SidebarLayout'" #sidebar-bottom>
+        <button
+          v-if="!showProgress"
+          class="xy-btn w-full"
+          @click="showProgress = true"
+        >
+          Show Progress
+        </button>
+        <button
+          v-if="showProgress"
+          class="xy-btn w-full"
+          @click="showProgress = false"
+        >
+          Show Navigation
+        </button>
       </template>
     </component>
   </div>

--- a/src/lib-components/forms/FieldsetLegend.vue
+++ b/src/lib-components/forms/FieldsetLegend.vue
@@ -34,7 +34,7 @@ const labelDisplay = computed((): string => {
   <component
     :is="tag"
     v-if="label"
-    class="block text-base leading-snug font-medium text-gray-800"
+    class="block text-sm leading-6 font-semibold text-gray-800"
     v-bind="$attrs"
   >
     {{ labelDisplay }}

--- a/src/lib-components/forms/InputHelp.vue
+++ b/src/lib-components/forms/InputHelp.vue
@@ -14,7 +14,7 @@ withDefaults(
   <component
     :is="tag"
     v-if="text"
-    class="text-sm leading-snug font-normal text-gray-600"
+    class="text-sm leading-6 font-normal text-gray-600"
     v-bind="$attrs"
   >
     {{ text }}

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -85,7 +85,7 @@ const setValidationError = () => {
 
 <template>
   <fieldset
-    class="relative space-y-4"
+    class="relative space-y-6"
     :aria-labelledby="aria.labelledby"
     :aria-describedby="aria.describedby"
     :aria-errormessage="aria.errormessage"
@@ -96,10 +96,15 @@ const setValidationError = () => {
         :label="label"
         :required="minCount > 0"
       />
-      <InputHelp v-if="help" :id="aria.describedby" tag="p" :text="help" />
+      <InputHelp
+        v-if="help"
+        :id="aria.describedby"
+        class="mt-1"
+        tag="p"
+        :text="help"
+      />
+      <InputError :id="aria.errormessage" class="mt-1" :text="errorState" />
     </div>
-
-    <InputError :id="aria.errormessage" :text="errorState" />
 
     <!--Hidden input for custom validation-->
     <input
@@ -114,9 +119,9 @@ const setValidationError = () => {
 
     <div class="flex">
       <div
-        class="grid gap-y-6"
+        class="grid gap-y-5"
         :class="{
-          'sm:grid sm:gap-x-5 sm:space-y-0': columns !== undefined,
+          'sm:grid sm:gap-x-10': columns !== undefined,
           'sm:grid-cols-2': columns === 2,
           'sm:grid-cols-3': columns === 3,
         }"

--- a/src/lib-components/forms/Radio.vue
+++ b/src/lib-components/forms/Radio.vue
@@ -36,7 +36,7 @@ const onChange = (e: Event, val: string | number) => {
 
 <template>
   <fieldset
-    class="space-y-4"
+    class="space-y-6"
     :aria-labelledby="aria.labelledby"
     :aria-describedby="aria.describedby"
     :aria-errormessage="aria.errormessage"
@@ -47,16 +47,21 @@ const onChange = (e: Event, val: string | number) => {
         :label="label"
         :required="isRequired"
       />
-      <InputHelp v-if="help" :id="aria.describedby" tag="p" :text="help" />
+      <InputHelp
+        v-if="help"
+        :id="aria.describedby"
+        class="mt-1"
+        tag="p"
+        :text="help"
+      />
+      <InputError :id="aria.errormessage" class="mt-1" :text="errorState" />
     </div>
-
-    <InputError :id="aria.errormessage" :text="errorState" />
 
     <div class="flex">
       <div
-        class="grid gap-y-6"
+        class="grid gap-y-5"
         :class="{
-          'sm:grid sm:gap-x-5 sm:space-y-0': columns !== undefined,
+          'sm:grid sm:gap-x-10': columns !== undefined,
           'sm:grid-cols-2': columns === 2,
           'sm:grid-cols-3': columns === 3,
         }"

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -66,14 +66,14 @@ const onUpdate = (val: unknown) => {
       <FieldsetLegend tag="div" :label="label" :required="isRequired" />
     </RadioGroupLabel>
 
-    <RadioGroupDescription v-if="help">
+    <RadioGroupDescription v-if="help" class="mt-1">
       <InputHelp :text="help" />
     </RadioGroupDescription>
 
-    <InputError :id="aria.errormessage" :text="errorState" />
+    <InputError :id="aria.errormessage" class="mt-1" :text="errorState" />
 
     <div
-      class="mt-4 grid grid-cols-1 gap-y-5 gap-x-4 relative"
+      class="mt-6 grid grid-cols-1 gap-y-5 gap-x-4 relative"
       :class="{
         'sm:grid-cols-2': columns === 2,
         'sm:grid-cols-3': columns === 3,
@@ -87,9 +87,9 @@ const onUpdate = (val: unknown) => {
           checked,
           disabled,
         }: {
-          active: boolean,
-          checked: boolean,
-          disabled: boolean,
+          active: boolean
+          checked: boolean
+          disabled: boolean
         }"
         as="template"
         :disabled="isDisabled || option.disabled"

--- a/src/lib-components/forms/YesOrNoRadio.vue
+++ b/src/lib-components/forms/YesOrNoRadio.vue
@@ -32,7 +32,7 @@ const onChange = (e: Event, val: boolean) => {
 
 <template>
   <fieldset
-    class="space-y-4"
+    class="space-y-6"
     :aria-labelledby="aria.labelledby"
     :aria-describedby="aria.describedby"
     :aria-errormessage="aria.errormessage"
@@ -45,10 +45,15 @@ const onChange = (e: Event, val: boolean) => {
         :required="isRequired"
         tag="legend"
       />
-      <InputHelp v-if="help" :id="aria.describedby" tag="p" :text="help" />
+      <InputHelp
+        v-if="help"
+        :id="aria.describedby"
+        class="mt-1"
+        tag="p"
+        :text="help"
+      />
+      <InputError :id="aria.errormessage" class="mt-1" :text="errorState" />
     </div>
-
-    <InputError :id="aria.errormessage" :text="errorState" />
 
     <div>
       <label

--- a/src/lib-components/indicators/ProgressCirclesLabeled.vue
+++ b/src/lib-components/indicators/ProgressCirclesLabeled.vue
@@ -46,7 +46,7 @@ const layoutSteps = computed(() => {
       <li
         v-for="(step, index) in layoutSteps"
         :key="index"
-        :class="[index !== layoutSteps.length - 1 ? 'pb-10' : '', 'relative']"
+        :class="[index !== layoutSteps.length - 1 ? 'pb-6' : '', 'relative']"
       >
         <!--NOTE: vertical connecting bar-->
         <div

--- a/src/lib-components/layout/SidebarLayout.vue
+++ b/src/lib-components/layout/SidebarLayout.vue
@@ -90,32 +90,36 @@ const isActive = (url: string): boolean => {
               <img class="w-auto h-12" :src="iconUrl" alt="Logo" />
             </div>
             <div class="mt-5 flex flex-col flex-1 h-0 overflow-y-auto">
-              <nav class="flex-1 px-2 space-y-1">
-                <a
-                  v-for="item in navigation"
-                  :key="item.name"
-                  :href="item.url"
-                  :class="[
-                    isActive(item.url)
-                      ? 'bg-gray-100 text-gray-900'
-                      : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900',
-                    'group flex items-center px-2 py-2 text-base font-semibold rounded-md',
-                  ]"
-                  :target="item.openInTab ? '_blank' : '_self'"
-                >
-                  <component
-                    :is="item.icon"
-                    :class="[
-                      isActive(item.url)
-                        ? 'text-gray-600'
-                        : 'text-gray-500 group-hover:text-gray-600',
-                      'mr-4 h-6 w-6',
-                    ]"
-                    aria-hidden="true"
-                  />
-                  {{ item.name }}
-                </a>
-              </nav>
+              <div class="flex-1 px-2">
+                <slot name="sidebar-nav">
+                  <nav class="space-y-1">
+                    <a
+                      v-for="item in navigation"
+                      :key="item.name"
+                      :href="item.url"
+                      :class="[
+                        isActive(item.url)
+                          ? 'bg-gray-100 text-gray-900'
+                          : 'text-gray-700 hover:bg-gray-50 hover:text-gray-900',
+                        'group flex items-center px-2 py-2 text-base font-semibold rounded-md',
+                      ]"
+                      :target="item.openInTab ? '_blank' : '_self'"
+                    >
+                      <component
+                        :is="item.icon"
+                        :class="[
+                          isActive(item.url)
+                            ? 'text-gray-600'
+                            : 'text-gray-500 group-hover:text-gray-600',
+                          'mr-4 h-6 w-6',
+                        ]"
+                        aria-hidden="true"
+                      />
+                      {{ item.name }}
+                    </a>
+                  </nav>
+                </slot>
+              </div>
               <div v-if="$slots['sidebar-bottom']" class="mt-auto">
                 <div class="mt-6 px-2">
                   <slot name="sidebar-bottom" />
@@ -141,32 +145,36 @@ const isActive = (url: string): boolean => {
             <img class="w-auto h-12" :src="iconUrl" alt="Logo" />
           </div>
           <div class="mt-5 grow flex flex-col">
-            <nav class="flex-1 px-2 bg-white space-y-1">
-              <a
-                v-for="item in navigation"
-                :key="item.name"
-                :href="item.url"
-                :class="[
-                  isActive(item.url)
-                    ? 'bg-gray-100 text-gray-900'
-                    : 'text-gray-800 hover:bg-gray-100 hover:text-gray-900',
-                  'group flex items-center px-2 py-2 text-sm font-semibold rounded-md',
-                ]"
-                :target="item.openInTab ? '_blank' : '_self'"
-              >
-                <component
-                  :is="item.icon"
-                  :class="[
-                    isActive(item.url)
-                      ? 'text-gray-600'
-                      : 'text-gray-400 group-hover:text-gray-600',
-                    'mr-3 h-6 w-6',
-                  ]"
-                  aria-hidden="true"
-                />
-                {{ item.name }}
-              </a>
-            </nav>
+            <div class="flex-1 px-2 bg-white">
+              <slot name="sidebar-nav">
+                <nav class="space-y-1">
+                  <a
+                    v-for="item in navigation"
+                    :key="item.name"
+                    :href="item.url"
+                    :class="[
+                      isActive(item.url)
+                        ? 'bg-gray-100 text-gray-900'
+                        : 'text-gray-800 hover:bg-gray-100 hover:text-gray-900',
+                      'group flex items-center px-2 py-2 text-sm font-semibold rounded-md',
+                    ]"
+                    :target="item.openInTab ? '_blank' : '_self'"
+                  >
+                    <component
+                      :is="item.icon"
+                      :class="[
+                        isActive(item.url)
+                          ? 'text-gray-600'
+                          : 'text-gray-400 group-hover:text-gray-600',
+                        'mr-3 h-6 w-6',
+                      ]"
+                      aria-hidden="true"
+                    />
+                    {{ item.name }}
+                  </a>
+                </nav>
+              </slot>
+            </div>
 
             <div v-if="$slots['sidebar-bottom']" class="mt-atuo">
               <div class="mt-6 px-2">


### PR DESCRIPTION
# What this does

- Adds a slot for replacing the sidebar navigation in the `SidebarLayout` with a custom component
- tweaks some input styles to help with layout cramping
- fixes a found issue with progress circles where their height was larger than expected (helps keep it visible in a sidebar layout)

## Note

There are a lot of ways to go about replacing the navigation in the `SidebarLayout`, including having progress steps fulfill the navigation interface, but at the moment they don't function as a nav, so I took the most straightforward route to allowing the swap to occur.