### PR TITLE
[DEV-2926] patch fixes and improvements 0.10.3

### DIFF
--- a/dev/pages/Forms.vue
+++ b/dev/pages/Forms.vue
@@ -728,7 +728,21 @@ const toggleProps = [
           <YesOrNoRadio label="Please confim this field" required />
 
           <MultiCheckboxes
-            label="More selections is better"
+            label="Minimum selection of 1"
+            :columns="2"
+            :options="options"
+            :min="1"
+          />
+
+          <MultiCheckboxes
+            label="Maximum selection of 2"
+            :columns="2"
+            :options="options"
+            :max="2"
+          />
+
+          <MultiCheckboxes
+            label="Somewhere in between"
             help="Pick at least 1, but no more than 2!"
             :columns="2"
             :options="options"

--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -58,16 +58,22 @@ const maxCount = computed(() => {
 })
 
 const countError = computed(() => {
-  if (selectionCount.value < minCount.value) {
-    return `Please select ${minCount.value} of these option${
-      minCount.value > 1 ? "s" : ""
-    }.`
+  // min not reached, no max is set
+  if (selectionCount.value < minCount.value && !props.max) {
+    return `Please select at least ${minCount.value} of these options.`
   }
 
-  if (selectionCount.value > maxCount.value) {
-    return `Please select only ${maxCount.value} of these option${
-      maxCount.value > 1 ? "s" : ""
-    }.`
+  // max is reached, no min set
+  if (selectionCount.value > maxCount.value && !props.min) {
+    return `Please limit your selection to ${maxCount.value} of these options.`
+  }
+
+  // min and max are both set and out of range
+  if (
+    selectionCount.value < minCount.value ||
+    selectionCount.value > maxCount.value
+  ) {
+    return `Please select between ${minCount.value} and ${maxCount.value} of these options.`
   }
 
   return ""

--- a/src/lib-components/indicators/ProgressCirclesLabeled.vue
+++ b/src/lib-components/indicators/ProgressCirclesLabeled.vue
@@ -52,7 +52,7 @@ const layoutSteps = computed(() => {
         <div
           v-if="index !== layoutSteps.length - 1"
           :class="[
-            'absolute left-4 top-4 -ml-px mt-0.5 h-full w-0.5',
+            'absolute left-3 top-3 -ml-px mt-0.5 h-full w-0.5',
             step.status === 'complete' ? 'bg-xy-blue' : 'bg-gray-300',
           ]"
           aria-hidden="true"
@@ -64,7 +64,7 @@ const layoutSteps = computed(() => {
           <span class="flex h-9 items-center">
             <span
               :class="{
-                'relative z-10 flex h-8 w-8 items-center justify-center rounded-full': true,
+                'relative z-10 flex h-6 w-6 items-center justify-center rounded-full': true,
                 'bg-xy-blue ': step.status === 'complete',
                 'border-2 border-xy-blue bg-white': step.status === 'current',
                 'border-2 border-gray-300 bg-white':
@@ -73,7 +73,7 @@ const layoutSteps = computed(() => {
             >
               <CheckIcon
                 v-if="step.status === 'complete'"
-                class="h-5 w-5 text-white"
+                class="h-4 w-4 text-white"
                 aria-hidden="true"
               />
               <span

--- a/src/lib-components/layout/SidebarLayout.vue
+++ b/src/lib-components/layout/SidebarLayout.vue
@@ -196,7 +196,9 @@ const isActive = (url: string): boolean => {
         </button>
         <div class="flex-1 px-4 flex justify-between">
           <div class="flex-1 flex">
-            <h1 class="flex items-center text-2xl text-white">
+            <h1
+              class="flex items-center text-base leading-snug sm:text-2xl text-white"
+            >
               <slot name="header"></slot>
             </h1>
           </div>

--- a/vite.docs.config.ts
+++ b/vite.docs.config.ts
@@ -6,9 +6,9 @@ import prism from "markdown-it-prism"
 import vue from "@vitejs/plugin-vue"
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => {
+export default defineConfig(() => {
   return {
-    base: command === "serve" ? "/trees/" : "/",
+    base: "/trees/",
     build: {
       outDir: resolve(__dirname, "trees"),
     },


### PR DESCRIPTION
# What this does

Makes a few improvements and fixes that have popped up recently.

- fixes progress circle sizing compared to initial design details
- fixes oversized sidebar layout header text on mobile devices - which can sometimes overflow the header
- improves Multiselect error messages when min/max are set, [see comment in #1444](https://github.com/xy-planning-network/college-try/pull/1444/files#r1745935157)
- fixes broken base path when docs build is run (causing github hosted pages to fail)

fixes DEV-2926