### PR TITLE
Fix: addresses `sr-only` component impacting layout

### DIFF
--- a/src/lib-components/forms/MultiCheckboxes.vue
+++ b/src/lib-components/forms/MultiCheckboxes.vue
@@ -112,17 +112,6 @@ const setValidationError = () => {
       <InputError :id="aria.errormessage" class="mt-1" :text="errorState" />
     </div>
 
-    <!--Hidden input for custom validation-->
-    <input
-      v-if="countError"
-      ref="errorInput"
-      required
-      class="sr-only top-1 left-1"
-      aria-hidden
-      type="checkbox"
-      @invalid="setValidationError"
-    />
-
     <div class="flex">
       <div
         class="grid gap-y-5"
@@ -175,5 +164,15 @@ const setValidationError = () => {
         </div>
       </div>
     </div>
+    <!--Hidden input for custom validation-->
+    <input
+      v-if="countError"
+      ref="errorInput"
+      required
+      class="sr-only top-1 left-1"
+      aria-hidden
+      type="checkbox"
+      @invalid="setValidationError"
+    />
   </fieldset>
 </template>


### PR DESCRIPTION
## Problem statement
A `sr-only` or "hidden" component factors is not ignored by classes like `space-x/y-*`, etc. Here's an example where the `<input>` does not exist:
<img width="421" alt="Screenshot 2024-10-04 at 9 32 11 AM" src="https://github.com/user-attachments/assets/45bfc2e3-15d5-4069-8224-46e5b721afa9">
Here's where it does:
<img width="437" alt="Screenshot 2024-10-04 at 9 27 23 AM" src="https://github.com/user-attachments/assets/bd9328d4-c2d2-4309-bd27-f17fd38d6684">


## What this does
This PR fixes the one case of this bug in `forms/MultiCheckboxes`. It solves it by moving the `<input />` to the end of the the `<fieldset />` that has a `space-y-6`. Here's what that looks like:
<img width="438" alt="Screenshot 2024-10-04 at 9 28 36 AM" src="https://github.com/user-attachments/assets/a3c99ff8-47e4-4121-83d1-6cd2c1b56ade">

There appear to be no other components using `sr-only` where this layout bug can pop up.

If I had to explain why this is a bug - and why this PR fixes it - unfortunately, I come up a bit short.

This indicates it makes sense we're running into it: https://github.com/tailwindlabs/tailwindcss/issues/3857

But, that `<fieldset />` has a `relative` class and the `<input />` has position classes. So, my mental model suggests the `<input />`is outside the flow of its sibling nodes. The only explanation I can come up with is the "cascading" part of CSS - might be `space-x/y-*` is applied before `top-*` and `left-*`.
