### PR TITLE
add url pattern validation and additional buttons

### DIFF
--- a/dev/docs/ButtonDocs.md
+++ b/dev/docs/ButtonDocs.md
@@ -118,6 +118,8 @@ Utility buttons are useful for indicating purpose. `danger` for situations when 
 
 ### Neutral
 
+Neutral comes in two flavors meant to support light vs dark colored backgrounds. Use the `inverse` style when the background is dark.
+
 <DocsDemo>
     <div class="btn-layout">
         <button class="xy-btn-neutral-sm">Button Text</button>
@@ -128,6 +130,16 @@ Utility buttons are useful for indicating purpose. `danger` for situations when 
         <button class="xy-btn-neutral-sm" disabled>Button Text</button>
         <button class="xy-btn-neutral" disabled>Button Text</button>
         <button class="xy-btn-neutral-lg" disabled>Button Text</button>
+    </div>
+    <div class="btn-layout bg-neutral-700 rounded-xl p-4 mt-8">
+        <button class="xy-btn-neutral-inverse-sm">Button Text</button>
+        <button class="xy-btn-neutral-inverse">Button Text</button>
+        <button class="xy-btn-neutral-inverse-lg">Button Text</button>
+    </div>
+    <div class="btn-layout bg-neutral-700 rounded-xl p-4 mt-8">
+        <button class="xy-btn-neutral-inverse-sm" disabled>Button Text</button>
+        <button class="xy-btn-neutral-inverse" disabled>Button Text</button>
+        <button class="xy-btn-neutral-inverse-lg" disabled>Button Text</button>
     </div>
 </DocsDemo>
 
@@ -140,6 +152,16 @@ Utility buttons are useful for indicating purpose. `danger` for situations when 
 <button class="xy-btn-neutral-sm" disabled>Button Text</button>
 <button class="xy-btn-neutral" disabled>Button Text</button>
 <button class="xy-btn-neutral-lg" disabled>Button Text</button>
+
+<!-- inverse -->
+<button class="xy-btn-neutral-inverse-sm">Button Text</button>
+<button class="xy-btn-neutral-inverse">Button Text</button>
+<button class="xy-btn-neutral-inverse-lg">Button Text</button>
+
+<!--inverse disabled-->
+<button class="xy-btn-neutral-inverse-sm" disabled>Button Text</button>
+<button class="xy-btn-neutral-inverse" disabled>Button Text</button>
+<button class="xy-btn-neutral-inverse-lg" disabled>Button Text</button>
 ```
 
 ## Specialty Buttons
@@ -192,20 +214,28 @@ These specialty buttons should be used sparingly and are generally reserved for 
 <button class="xy-btn-accent-inverse-lg" disabled>Button Text</button>
 ```
 
-## Deprecated
-
-The following buttons are deprecated and their usage should be replaced.
-
-### White
-
-Most of the existing use cases can be replaced with either `xy-btn-secondary` or `xy-btn-neutral`.
+### Brand Alternative
 
 <DocsDemo>
     <div class="btn-layout">
-        <button class="xy-btn-white">Button Text</button>
+        <button class="xy-btn-alt-sm">Button Text</button>
+        <button class="xy-btn-alt">Button Text</button>
+        <button class="xy-btn-alt-lg">Button Text</button>
+    </div>
+    <div class="btn-layout">
+        <button class="xy-btn-alt-sm" disabled>Button Text</button>
+        <button class="xy-btn-alt" disabled>Button Text</button>
+        <button class="xy-btn-alt-lg" disabled>Button Text</button>
     </div>
 </DocsDemo>
 
 ```html
-<button class="xy-btn-white">Button Text</button>
+<button class="xy-btn-alt-sm">Button Text</button>
+<button class="xy-btn-alt">Button Text</button>
+<button class="xy-btn-alt-lg">Button Text</button>
+
+<!-- disabled -->
+<button class="xy-btn-alt-sm" disabled>Button Text</button>
+<button class="xy-btn-alt" disabled>Button Text</button>
+<button class="xy-btn-alt-lg" disabled>Button Text</button>
 ```

--- a/dev/pages/Forms.vue
+++ b/dev/pages/Forms.vue
@@ -759,10 +759,25 @@ const toggleProps = [
       <form id="test-form" @submit.prevent>
         <div class="space-y-8">
           <BaseInput type="text" label="Name" required />
+
           <BaseInput
             type="email"
             label="Email"
             help="Try using a gmail address!"
+            required
+          />
+
+          <BaseInput
+            type="tel"
+            label="Phone"
+            help="10 digits please, bonus points for dashes."
+            required
+          />
+
+          <BaseInput
+            type="url"
+            label="Website URL"
+            help="Don't mangle that protocol."
             required
           />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "unplugin-vue-components": "^0.27.4",
         "unplugin-vue-markdown": "^0.25.2",
         "vite": "^5.4.10",
-        "vue-tsc": "^2.1.8"
+        "vue-tsc": "^2.1.10"
       },
       "engines": {
         "node": ">=20"
@@ -1490,9 +1490,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.8.tgz",
-      "integrity": "sha512-DtPUKrIRqqzY1joGfVHxHWZoxXZbCQLmVtW+QTifuPInfcs1R/3UAdlJXDp+lpSpP9lI5m+jMYYlwDXXu3KSTg==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.10.tgz",
+      "integrity": "sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1634,9 +1634,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.2.0.tgz",
-      "integrity": "sha512-StlonZhBBrsPPwrDjiPAiVTf/rolxffLxVPT60Qv/t88BZ81BvUVzHgGqEFvJ1ii8HXtm1+zU2Icr59tfWEcag==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.2.2.tgz",
+      "integrity": "sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -4657,14 +4657,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.1.8.tgz",
-      "integrity": "sha512-6+vjb7JLxKIzeD/1ktoUBZGAr+148FQoEFl8Lv5EpDJLO2PrUalhp7atMEuzEkLnoooM5bg3pJqjZI+oobxIaQ==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.1.10.tgz",
+      "integrity": "sha512-RBNSfaaRHcN5uqVqJSZh++Gy/YUzryuv9u1aFWhsammDJXNtUiJMNoJ747lZcQ68wUQFx6E73y4FY3D8E7FGMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "~2.4.8",
-        "@vue/language-core": "2.1.8",
+        "@vue/language-core": "2.1.10",
         "semver": "^7.5.4"
       },
       "bin": {
@@ -5637,9 +5637,9 @@
       }
     },
     "@vue/language-core": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.8.tgz",
-      "integrity": "sha512-DtPUKrIRqqzY1joGfVHxHWZoxXZbCQLmVtW+QTifuPInfcs1R/3UAdlJXDp+lpSpP9lI5m+jMYYlwDXXu3KSTg==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.10.tgz",
+      "integrity": "sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==",
       "dev": true,
       "requires": {
         "@volar/language-core": "~2.4.8",
@@ -5744,9 +5744,9 @@
       }
     },
     "alien-signals": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.2.0.tgz",
-      "integrity": "sha512-StlonZhBBrsPPwrDjiPAiVTf/rolxffLxVPT60Qv/t88BZ81BvUVzHgGqEFvJ1ii8HXtm1+zU2Icr59tfWEcag==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.2.2.tgz",
+      "integrity": "sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==",
       "dev": true
     },
     "ansi-regex": {
@@ -7821,13 +7821,13 @@
       }
     },
     "vue-tsc": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.1.8.tgz",
-      "integrity": "sha512-6+vjb7JLxKIzeD/1ktoUBZGAr+148FQoEFl8Lv5EpDJLO2PrUalhp7atMEuzEkLnoooM5bg3pJqjZI+oobxIaQ==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.1.10.tgz",
+      "integrity": "sha512-RBNSfaaRHcN5uqVqJSZh++Gy/YUzryuv9u1aFWhsammDJXNtUiJMNoJ747lZcQ68wUQFx6E73y4FY3D8E7FGMA==",
       "dev": true,
       "requires": {
         "@volar/typescript": "~2.4.8",
-        "@vue/language-core": "2.1.8",
+        "@vue/language-core": "2.1.10",
         "semver": "^7.5.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "unplugin-vue-components": "^0.27.4",
     "unplugin-vue-markdown": "^0.25.2",
     "vite": "^5.4.10",
-    "vue-tsc": "^2.1.8"
+    "vue-tsc": "^2.1.10"
   },
   "dependencies": {
     "@floating-ui/vue": "^1.0.1",

--- a/src/composables/forms.ts
+++ b/src/composables/forms.ts
@@ -253,6 +253,20 @@ export const emailPattern = String.raw`^\w+([\-+.']\w+)*@\w+([\-.]\w+)*\.\w+([\-
 export const phonePattern = String.raw`[0-9]{10}|[0-9]{3}-[0-9]{3}-[0-9]{4}`
 
 /**
+ * url validation regex pattern
+ * used with input type="url" in the pattern attribute for html5
+ *
+ * The pattern is conservative and focuses on ensuring the protocol is valid
+ * and the remainder of the url does not include empty spaces.  If additional protocols
+ * need to be supported, they can be added to the first group (?:https|http|ftp).
+ *
+ * Reference: https://regex101.com/r/P5dlas/3
+ *
+ * NOTE(spk): not all JavaScript regular expression characters are not supported in input patterns.
+ */
+export const urlPattern = String.raw`^(?:https|http):\/\/[^ ]+$`
+
+/**
  * This is used for the .number modifier in v-model
  */
 export const looseToNumber = (val: any): any => {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -19,6 +19,7 @@ import {
   emailPattern,
   looseToNumber,
   phonePattern,
+  urlPattern,
   textInputTypes,
   useInputField,
 } from "@/composables/forms"
@@ -67,6 +68,7 @@ export {
   emailPattern,
   looseToNumber,
   phonePattern,
+  urlPattern,
   textInputTypes,
   useInputField,
 }

--- a/src/index.css
+++ b/src/index.css
@@ -77,6 +77,18 @@
     @apply inline-flex justify-center items-center px-5 py-2.5 border border-transparent text-base font-display font-semibold rounded-3xl shadow-sm text-white bg-xy-blue-600 hover:bg-xy-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-xy-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
   }
 
+  .xy-btn-alt-sm {
+    @apply inline-flex justify-center items-center px-2.5 py-1.5 border border-transparent text-xs font-display font-semibold rounded-3xl shadow-sm text-xy-black bg-xy-green-200 hover:bg-xy-green-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-green-100 disabled:bg-xy-green-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  .xy-btn-alt {
+    @apply inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-display font-semibold rounded-3xl shadow-sm text-xy-black bg-xy-green-200 hover:bg-xy-green-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-green-100 disabled:bg-xy-green-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  .xy-btn-alt-lg {
+    @apply inline-flex justify-center items-center px-5 py-2.5 border border-transparent text-base font-display font-semibold rounded-3xl shadow-sm text-xy-black bg-xy-green-200 hover:bg-xy-green-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-green-100 disabled:bg-xy-green-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
   /* NOTE(spk): including .xy-btn-red alias for backwards compatibility */
   .xy-btn-danger-sm,
   .xy-btn-red-sm {
@@ -103,6 +115,18 @@
 
   .xy-btn-neutral-lg {
     @apply inline-flex justify-center items-center px-5 py-2.5 border border-transparent text-base font-display font-semibold rounded-3xl shadow-none text-neutral-800 bg-transparent hover:bg-neutral-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-transparent disabled:text-neutral-600 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  .xy-btn-neutral-inverse-sm {
+    @apply inline-flex justify-center items-center px-2.5 py-1.5 border border-transparent text-xs font-display font-semibold rounded-3xl shadow-none text-neutral-800 bg-white hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-white/90 disabled:text-neutral-700 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  .xy-btn-neutral-inverse {
+    @apply inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-display font-semibold rounded-3xl shadow-none text-neutral-800 bg-white hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-white/90 disabled:disabled:text-neutral-700 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
+  }
+
+  .xy-btn-neutral-inverse-lg {
+    @apply inline-flex justify-center items-center px-5 py-2.5 border border-transparent text-base font-display font-semibold rounded-3xl shadow-none text-neutral-800 bg-white hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:bg-white/90 disabled:disabled:text-neutral-700 disabled:cursor-not-allowed transition-colors ease-linear duration-300;
   }
 
   /* NOTE(spk): always consider the relative box-sizing between buttons with solid backgrounds and full borders vs secondary styles as they will commonly be laid out next to each other */
@@ -153,11 +177,6 @@
 
   .xy-btn-secondary-danger-lg {
     @apply inline-flex justify-center items-center py-2.5 border-b-2 border-b-red-700 text-base font-display font-semibold shadow-none text-neutral-800 hover:text-red-700 hover:border-b-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:text-neutral-800 disabled:border-b-red-700 disabled:opacity-70 disabled:cursor-not-allowed transition-colors ease-linear duration-150;
-  }
-
-  /* Deprecated */
-  .xy-btn-white {
-    @apply inline-flex justify-center items-center px-4 py-2 border border-xy-blue shadow-sm text-sm font-semibold rounded-3xl text-xy-blue bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-xy-blue-500 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
   /* Header classes */

--- a/src/lib-components/forms/BaseInput.vue
+++ b/src/lib-components/forms/BaseInput.vue
@@ -9,6 +9,7 @@ import {
   emailPattern,
   looseToNumber,
   phonePattern,
+  urlPattern,
 } from "@/composables/forms"
 import type { TextLikeInput } from "@/composables/forms"
 import { computed, useTemplateRef } from "vue"
@@ -60,6 +61,10 @@ const typeAttributes = computed(() => {
     case "tel":
       return {
         pattern: phonePattern,
+      }
+    case "url":
+      return {
+        pattern: urlPattern,
       }
     default:
       return {}


### PR DESCRIPTION
# What this does

- adds button styles for dark/marketing like UI support [[DEV-3086]](https://www.notion.so/xylabs/8f16954aa3494675837f0cceb6a21c95?v=9d015d84f6fa48fe837c8ad0f6ab5be8&p=137d6eba0f7b8059a8b8d06d9a600c48&pm=s)
- adds basic url pattern validation to `<BaseInput type="url" />` [[DEV-2930]](https://www.notion.so/xylabs/8f16954aa3494675837f0cceb6a21c95?v=9d015d84f6fa48fe837c8ad0f6ab5be8&p=e210354a22f04dd39bbb7f96d5311a54&pm=s)
- bumps vue-tsc@latest

<img width="1041" alt="Screenshot 2024-11-15 at 10 52 29 AM" src="https://github.com/user-attachments/assets/a4b53ff1-7eb7-43cc-a5e6-1758c66fce7e">
<img width="1049" alt="Screenshot 2024-11-15 at 10 52 35 AM" src="https://github.com/user-attachments/assets/29fdd2cb-fec7-46b0-918b-7acd9e096845">
