### PR TITLE
support show property on table columns

### DIFF
--- a/dev/pages/Lists.vue
+++ b/dev/pages/Lists.vue
@@ -57,6 +57,10 @@ const tableColumns: TableColumns<Conifer> = [
       return h(NeedleTag, { tree: tree, onClickLeaf: announceTree })
     },
   },
+  {
+    title: "Hidden Column",
+    render: () => "-",
+  },
 ]
 
 const announceTree = (t: Conifer) => {

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -85,6 +85,11 @@ export interface TableColumn<T = TableRowData> {
     | keyof T
     | ((rowData: T, rowIndex: number) => string | number | boolean | VNodeChild)
   /**
+   * A show condition for determining whether the column should be shown in the table.
+   * Use this condition for supporting dynamic column visibility.
+   */
+  show?: boolean
+  /**
    * A sorting identifier
    * Only used on DynamicTable
    */
@@ -94,4 +99,5 @@ export interface TableColumn<T = TableRowData> {
 export type TableCellAlignment = "left" | "center" | "right"
 export type TableRowData = Record<string, any>
 export type TableColumns<T = TableRowData> = TableColumn<T>[]
+
 export type TableRowsData = TableRowData[]

--- a/src/composables/useTable.ts
+++ b/src/composables/useTable.ts
@@ -38,24 +38,26 @@ export const useTable = (
   })
 
   const columns = computed(() => {
-    return tableColumn.value.map((col) => {
-      let alignmentClass = ""
-      switch (col?.alignment || "left") {
-        case "left":
-          alignmentClass = "text-left"
-          break
-        case "right":
-          alignmentClass = "text-right"
-          break
-        case "center":
-          alignmentClass = "text-center"
-          break
-      }
-      return {
-        ...col,
-        alignment: alignmentClass,
-      }
-    })
+    return tableColumn.value
+      .filter((col) => col.show ?? true)
+      .map((col) => {
+        let alignmentClass = ""
+        switch (col?.alignment || "left") {
+          case "left":
+            alignmentClass = "text-left"
+            break
+          case "right":
+            alignmentClass = "text-right"
+            break
+          case "center":
+            alignmentClass = "text-center"
+            break
+        }
+        return {
+          ...col,
+          alignment: alignmentClass,
+        }
+      })
   })
 
   const rows = computed(() => {


### PR DESCRIPTION
# What this does

- adds an optional `show` property on `TableColumn` to aid conditional column rendering in table components

### Notes

I haven't come up with an elegant way to support extending the `TableColumn` type while declaring an object literal and supporting inference on the custom properties, so let's just support the common logic of filtering out columns based on a show property like we do in a lot of other components.

In other words, you won't need to do this:
```typescript
interface ExitInterviewTableColumn<T> extends TableColumn<T> {
  show: boolean
}

const tableColumns = computed(() => {
  const columns: ExitInterviewTableColumn<ExitInterview>[] = [
    {
      title: "submitted on",
      render: (ei) => formatDate(ei.createdAt, DateFormat.Datetime),
      sort: "created_at",
      show: true,
    },
    {
      title: "approved by",
      render: (ei) => ei.staff.email || "-",
      show: isActiveTab("approved"),
    },
  ]

  return columns.filter((ei) => ei.show)
})
```

Just do this:
```typescript
const tableColumns = computed((): TableColumns<ExitInterview> => {
return [
    {
      title: "submitted on",
      render: (ei) => formatDate(ei.createdAt, DateFormat.Datetime),
      sort: "created_at",
     // show is optional, but defaults to "true"
    },
    {
      title: "approved by",
      render: (ei) => ei.staff.email || "-",
      show: isActiveTab("approved"),
    },
  ]
})
```