### PR TITLE
number inputs

### DIFF
--- a/dev/pages/Forms.vue
+++ b/dev/pages/Forms.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { ref } from "vue"
-import { InputOption, TextInputType, textInputTypes } from "@/composables/forms"
+import {
+  InputOption,
+  NumericInputType,
+  TextInputType,
+  numericInputTypes,
+  textInputTypes,
+} from "@/composables/forms"
 
 const options: InputOption[] = [
   {
@@ -43,10 +49,18 @@ const inputTypes: InputOption[] = textInputTypes.map((type) => {
   }
 })
 
+const numericInputOpts: InputOption[] = numericInputTypes.map((type) => {
+  return {
+    label: type,
+    value: type,
+  }
+})
+
 /**
  * v-models
  */
 const inputTypeSelected = ref<TextInputType>("text")
+const numericTypeSelected = ref<NumericInputType>("number")
 const inputVals = ref<Record<string, any>>({})
 const toggleValue = ref(undefined)
 const dateRangeInput = ref({ minDate: 1725148800, maxDate: 1727740799 })
@@ -59,6 +73,7 @@ const dateRangePickerCopy = `<DateRangePicker v-model="dateRange" />`
 const dateTimeCopy = `<DateTime v-model="dateTime" label="Select a date and time" help="Use your local timezone!" />`
 const inputCopy = `<BaseInput type="text" label="What's your lide moto?" help="No wrong ansswers here." placeholder="It's good to be alive" />`
 const multiCheckboxCopy = `<MultiCheckboxes v-model="selected" label="Make Some Selections" help="Select all that apply." :options="options" />`
+const numberCopy = `<NumberInput label="Give me a number" help="I'll format it for you." />`
 const radioCopy = `<Radio :options="options" v-model="selected" />`
 const selectCopy = `<Select :options="options" placeholder="Select an option that you fancy" />`
 const yesOrNoRadioCopy = `<YesOrNoRadio v-model="selected" />`
@@ -126,6 +141,12 @@ const dateTimeInputProps = [
   ...inputCommonProps,
 ]
 
+const numericInputProps = [
+  { name: "type", required: false, type: numericInputTypes.join(" | ") },
+  { name: "modelValue", required: false, type: "number | null" },
+  ...inputCommonProps,
+]
+
 const textLikeInputProps = [
   { name: "type", required: true, type: textInputTypes.join(" | ") },
   { name: "modelValue", required: false, type: "string | number | null" },
@@ -182,10 +203,11 @@ const toggleProps = [
           class="xy-link"
           target="_blank"
           >input variations</a
-        >. When the type attibute is set to 'number' the value returned will be
-        a number making v-model.number modifiers unnecessary. Likewise, the
-        `trim()` method is applies to all string values making the v-model.trim
-        modifier unnecessary.
+        >. When the type attribute is set to 'number' the value returned will be
+        a number making v-model.number modifiers unnecessary - (type 'number' is
+        Deprecated, use 'NumberInput' instead). Likewise, the `trim()` method is
+        applies to all string values making the v-model.trim modifier
+        unnecessary.
       </template>
 
       <div>
@@ -259,6 +281,56 @@ const toggleProps = [
           </div>
 
           <PropsTable :props="textLikeInputProps" />
+        </div>
+      </div>
+    </ComponentLayout>
+
+    <ComponentLayout title="Number Input">
+      <template #description
+        >The HTML input type="number" doesn't format numbers and can be
+        difficult to read. Grab this number input to provide a well formatted
+        input or capture monetary inputs as U.S. cents with the money
+        type.</template
+      >
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700">
+          <ClickToCopy :value="numberCopy" />
+        </label>
+        <div class="mt-1">
+          <Select
+            v-model="numericTypeSelected"
+            :options="numericInputOpts"
+            label="Try out the numeric types"
+            placeholder="Select a numeric type"
+            class="mb-8"
+          />
+          <NumberInput
+            v-model="inputVals[`numericInput-${numericTypeSelected}`]"
+            :help="`Some help text for a ${numericTypeSelected}`"
+            :type="numericTypeSelected"
+            :label="`Here's an example of an <input type='${numericTypeSelected}'>`"
+            :placeholder="`A placeholder for a ${numericTypeSelected}`"
+            :precision="1"
+            @update:model-value="
+              $log(
+                `v-model update event for NumberInput type='${numericTypeSelected}': ${$event}`
+              )
+            "
+          />
+
+          <div class="mt-4">
+            <p>
+              <b>Value:</b>
+              {{ inputVals[`numericInput-${numericTypeSelected}`] }}
+            </p>
+            <p>
+              <b>Type:</b>
+              {{ typeof inputVals[`numericInput-${numericTypeSelected}`] }}
+            </p>
+          </div>
+
+          <PropsTable :props="numericInputProps" />
         </div>
       </div>
     </ComponentLayout>
@@ -779,6 +851,13 @@ const toggleProps = [
             label="Website URL"
             help="Don't mangle that protocol."
             required
+          />
+
+          <NumberInput
+            label="Number"
+            name="my-number-input"
+            required
+            :precision="1"
           />
 
           <Select :options="options" required label="Select an option" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@floating-ui/vue": "^1.0.1",
         "@headlessui/vue": "^1.4.2",
         "@heroicons/vue": "^1.0.5",
+        "@maskito/core": "^3.5.0",
+        "@maskito/kit": "^3.5.0",
+        "@maskito/vue": "^3.5.0",
         "axios": "^1.5.0",
         "flatpickr": "^4.6.9"
       },
@@ -752,6 +755,31 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@maskito/core": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@maskito/core/-/core-3.5.0.tgz",
+      "integrity": "sha512-zgmBjXeXc7BSBaw8jQw25dnwkFmKDvdj5rHzhEIxYhgGtnpli236F0YWPIOYzIwADjbefwDq1o7qpJfMsdDO4Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@maskito/kit": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@maskito/kit/-/kit-3.5.0.tgz",
+      "integrity": "sha512-QnpZsPTINgK4ScA4pMMJagoj+ufIXc/VGOP61AsQa/H/lmXII4pEZTLzpmMNUYmCEIEyjHR2DIbfEed04sktvQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@maskito/core": "^3.5.0"
+      }
+    },
+    "node_modules/@maskito/vue": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@maskito/vue/-/vue-3.5.0.tgz",
+      "integrity": "sha512-tWBOtNTNVgs5RTpeqt1jooiDEBPrD7IUwhqkfedDeBo6JKS+OK1/Kpda7GC8/L6F7GUTGSKjI5idkTJP5yUj5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@maskito/core": "^3.5.0",
+        "vue": ">=3.0.0"
       }
     },
     "node_modules/@mdit-vue/plugin-component": {
@@ -5281,6 +5309,23 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@maskito/core": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@maskito/core/-/core-3.5.0.tgz",
+      "integrity": "sha512-zgmBjXeXc7BSBaw8jQw25dnwkFmKDvdj5rHzhEIxYhgGtnpli236F0YWPIOYzIwADjbefwDq1o7qpJfMsdDO4Q=="
+    },
+    "@maskito/kit": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@maskito/kit/-/kit-3.5.0.tgz",
+      "integrity": "sha512-QnpZsPTINgK4ScA4pMMJagoj+ufIXc/VGOP61AsQa/H/lmXII4pEZTLzpmMNUYmCEIEyjHR2DIbfEed04sktvQ==",
+      "requires": {}
+    },
+    "@maskito/vue": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@maskito/vue/-/vue-3.5.0.tgz",
+      "integrity": "sha512-tWBOtNTNVgs5RTpeqt1jooiDEBPrD7IUwhqkfedDeBo6JKS+OK1/Kpda7GC8/L6F7GUTGSKjI5idkTJP5yUj5Q==",
+      "requires": {}
     },
     "@mdit-vue/plugin-component": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "@floating-ui/vue": "^1.0.1",
     "@headlessui/vue": "^1.4.2",
     "@heroicons/vue": "^1.0.5",
+    "@maskito/core": "^3.5.0",
+    "@maskito/kit": "^3.5.0",
+    "@maskito/vue": "^3.5.0",
     "axios": "^1.5.0",
     "flatpickr": "^4.6.9"
   },

--- a/src/composables/forms.ts
+++ b/src/composables/forms.ts
@@ -1,10 +1,5 @@
 import { computed, ref, useAttrs, useId } from "vue"
 import { debounce } from "@/helpers/Debounce"
-import {
-  maskitoNumberOptionsGenerator,
-  type MaskitoNumberParams,
-} from "@maskito/kit"
-import type { MaskitoOptions } from "@maskito/core"
 
 export interface Input {
   modelValue?: any

--- a/src/composables/forms.ts
+++ b/src/composables/forms.ts
@@ -1,5 +1,10 @@
 import { computed, ref, useAttrs, useId } from "vue"
 import { debounce } from "@/helpers/Debounce"
+import {
+  maskitoNumberOptionsGenerator,
+  type MaskitoNumberParams,
+} from "@maskito/kit"
+import type { MaskitoOptions } from "@maskito/core"
 
 export interface Input {
   modelValue?: any
@@ -24,7 +29,7 @@ export interface BooleanInput extends Input {
  * DateRangeInput allows a max range to be applied to the datepicker
  * such that selecting the first date will then apply a max/min of +/- maxRange.
  * This does not play nicely with maxDate and startDate.
- * 
+ *
  * ex: when submitting a startDate of Jan 1 and maxRange of 10, the date picker will allow
  * dates prior to Jan 1 given the handling of maxRange being adjusted on the fly.
  */
@@ -45,6 +50,14 @@ export interface DateTimeInput extends Input {
 export interface TextLikeInput extends Input {
   modelValue?: string | number | null
   type: TextInputType
+}
+
+export interface NumericInput extends Input {
+  max?: number
+  min?: number
+  modelValue?: number | null
+  precision?: number
+  type?: NumericInputType
 }
 
 export interface TextareaInput extends Input {
@@ -94,7 +107,7 @@ export const textInputTypes = [
   "date",
   "email",
   "month",
-  "number",
+  "number", // DEPRECATED
   "password",
   "search",
   "tel",
@@ -105,6 +118,10 @@ export const textInputTypes = [
 ] as const
 
 export type TextInputType = (typeof textInputTypes)[number]
+
+export const numericInputTypes = ["money", "number"] as const
+
+export type NumericInputType = (typeof numericInputTypes)[number]
 
 /**
  * useInputField provides a number of computed values, refs, and methods to support

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -18,6 +18,7 @@ import type {
 import {
   emailPattern,
   looseToNumber,
+  numericInputTypes,
   phonePattern,
   urlPattern,
   textInputTypes,
@@ -69,6 +70,7 @@ export {
   looseToNumber,
   phonePattern,
   urlPattern,
+  numericInputTypes,
   textInputTypes,
   useInputField,
 }

--- a/src/lib-components/forms/NumberInput.vue
+++ b/src/lib-components/forms/NumberInput.vue
@@ -14,6 +14,7 @@ import { maskitoTransform } from "@maskito/core"
 import {
   MaskitoNumberParams,
   maskitoNumberOptionsGenerator,
+  maskitoParseNumber,
 } from "@maskito/kit"
 
 defineOptions({
@@ -80,7 +81,7 @@ const masked = computed({
       return
     }
 
-    let number = parseFloat(v.toString().replace(/[^\d.-]/g, ""))
+    let number = maskitoParseNumber(v)
     if (isNaN(number)) {
       modelState.value = null
       return

--- a/src/lib-components/forms/NumberInput.vue
+++ b/src/lib-components/forms/NumberInput.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import InputLabel from "./InputLabel.vue"
+import InputHelp from "./InputHelp.vue"
+import InputError from "./InputError.vue"
+import {
+  useInputField,
+  defaultInputProps,
+  defaultModelOpts,
+} from "@/composables/forms"
+import type { NumericInput } from "@/composables/forms"
+import { computed, useAttrs, useTemplateRef } from "vue"
+import { maskito as vMaskito } from "@maskito/vue"
+import { maskitoTransform } from "@maskito/core"
+import {
+  MaskitoNumberParams,
+  maskitoNumberOptionsGenerator,
+} from "@maskito/kit"
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = withDefaults(defineProps<NumericInput>(), {
+  ...defaultInputProps,
+  max: Number.MAX_SAFE_INTEGER,
+  min: Number.MIN_SAFE_INTEGER,
+  precision: 0,
+  type: "number",
+})
+
+const opts = computed(() => {
+  const params: MaskitoNumberParams = {
+    decimalSeparator: ".",
+    thousandSeparator: ",",
+    min: props.min,
+    max: props.max,
+    precision: props.precision,
+    minusSign: "-",
+  }
+
+  switch (props.type) {
+    case "money":
+      params.decimalZeroPadding = true
+      params.precision = 2
+      params.prefix = "$"
+      break
+
+    default:
+      break
+  }
+
+  return maskitoNumberOptionsGenerator(params)
+})
+
+const modelState = defineModel<NumericInput["modelValue"]>(defaultModelOpts)
+
+/**
+ * masked is a writable computed variable that ensures the modelState
+ * is only set to a valid numeric value as the masked state is a string which
+ * may contain prefix and postfix characters as well as leading or trailing "-", and "." characters.
+ *
+ * It additionally handles the computation of converting a "money" input to an amount in U.S. cents.
+ */
+const masked = computed({
+  get: () => {
+    if (modelState.value === null || modelState.value === undefined) {
+      return ""
+    }
+
+    let num = modelState.value
+    if (props.type === "money") {
+      num = num / 100
+    }
+
+    return maskitoTransform(num.toString(), opts.value)
+  },
+  set: (v) => {
+    if (v === "") {
+      modelState.value = null
+      return
+    }
+
+    let number = parseFloat(v.toString().replace(/[^\d.-]/g, ""))
+    if (isNaN(number)) {
+      modelState.value = null
+      return
+    }
+
+    if (props.type === "money") {
+      number = number * 100
+    }
+
+    modelState.value = number
+  },
+})
+
+const inputRef = useTemplateRef("input")
+
+const {
+  errorState,
+  inputID,
+  isRequired,
+  nameAttr,
+  onInvalid,
+  inputValidation,
+} = useInputField(props)
+
+// NOTE(spk): reserve the name attribute for the hidden number input.
+const inputAttrs = computed(() => {
+  const attributes = useAttrs()
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { name, ...attrs } = attributes
+  return attrs
+})
+
+defineExpose({ input: inputRef })
+</script>
+
+<template>
+  <div>
+    <InputLabel
+      :id="`${inputID}-label`"
+      class="mb-2"
+      :for="inputID"
+      :label="label"
+      :required="isRequired"
+    />
+    <input
+      :id="inputID"
+      ref="input"
+      v-model="masked"
+      v-maskito="opts"
+      :aria-labelledby="label ? `${inputID}-label` : undefined"
+      :aria-describedby="help ? `${inputID}-help` : undefined"
+      :aria-errormessage="errorState ? `${inputID}-error` : undefined"
+      :class="[
+        'block w-full rounded-md border-0 py-2 shadow-sm ring-1 ring-inset focus:ring-2 sm:text-sm sm:leading-6',
+        'disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-700 disabled:ring-gray-200',
+        errorState
+          ? 'text-red-900 ring-red-700 placeholder:text-red-300 focus:ring-red-700'
+          : 'text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-xy-blue-500',
+      ]"
+      :placeholder="placeholder"
+      type="text"
+      inputmode="decimal"
+      v-bind="{ ...inputAttrs }"
+      @input="inputValidation"
+    />
+
+    <InputHelp :id="`${inputID}-help`" class="mt-1" :text="help" />
+    <InputError :id="`${inputID}-error`" class="mt-0.5" :text="errorState" />
+    <input
+      :value="modelState"
+      class="sr-only"
+      aria-hidden="true"
+      :name="nameAttr"
+      :min="min"
+      :max="max"
+      :required="isRequired"
+      tabindex="-1"
+      type="number"
+      @invalid="onInvalid"
+    />
+  </div>
+</template>

--- a/src/lib-components/forms/NumberInput.vue
+++ b/src/lib-components/forms/NumberInput.vue
@@ -86,8 +86,14 @@ const masked = computed({
       return
     }
 
+    // NOTE(spk): There's no Integer type in JavaScript all numbers are stored as floating point values
+    // to avoid approximations from decimal values avoid calling parseFloat and use parseInt on only the dollar
+    // portion when converting from string to number.
     if (props.type === "money") {
-      number = number * 100
+      let parts = number.toString().split(".")
+      let dollars = parseInt(parts[0], 10)
+      let cents = parts.length > 1 ? parseInt(parts[1].padEnd(2, "0"), 10) : 0
+      number = dollars * 100 + cents
     }
 
     modelState.value = number

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -38,6 +38,7 @@ import { default as InputHelp } from "./forms/InputHelp.vue"
 import { default as InputLabel } from "./forms/InputLabel.vue"
 import { default as FieldsetLegend } from "./forms/FieldsetLegend.vue"
 import { default as MultiCheckboxes } from "./forms/MultiCheckboxes.vue"
+import { default as NumberInput } from "./forms/NumberInput.vue"
 import { default as Radio } from "./forms/Radio.vue"
 import { default as RadioCards } from "./forms/RadioCards.vue"
 import { default as Select } from "./forms/Select.vue"
@@ -77,6 +78,7 @@ export {
   InputLabel,
   FieldsetLegend,
   MultiCheckboxes,
+  NumberInput,
   Radio,
   RadioCards,
   Select,
@@ -121,6 +123,7 @@ export interface TreesComponents {
   InputLabel: typeof InputLabel
   FieldsetLegend: typeof FieldsetLegend
   MultiCheckboxes: typeof MultiCheckboxes
+  NumberInput: typeof NumberInput
   Radio: typeof Radio
   RadioCards: typeof RadioCards
   Select: typeof Select


### PR DESCRIPTION
# What this does

- introduces a `NumberInput` component that masks all number inputs according to US-en number formatting with support for a `money` type to handle the conversion between a monetary string input to US cents as a number

### Notes

- Number handling in `BaseInput` has been good, but trying to support masking and number/money conversions for the backend is enough bloat that I'd prefer to separate them.  Longer term, it moves `BaseInput` away from supporting `number` types at all to limit type juggling on v-model values in a parent.
- Supporting a combination of prefix, precision > 0, and negative values creates some user input edge cases that can be tricky to handle.  ex: Typing a `.` character and not having it set in the input field is due to the interaction of trying to store a number type from an incomplete string input.  That's where the `masked` computed variable comes in.  It's more complicated than I'd like, but appears to work as intended.  An alternative approach is to lazily set the `modelState` on blur, but this had its own subtle headaches.
- We're no longer using the `step` attribute anywhere that is either necessary or that precision can't handle.   There's no clear way to support `step` with masking.  I suspect we don't really have a need for it long term - punting on worrying about it for now.
- The money mask configuration is intentionally opinionated at the moment based on its current use case.  If there's a need for something like a `dollars` input that is still storing data as `Money` let's deal with that if it shows up.
- `FieldSchema` will call `NumberInput` over `BaseInput` (only handful of instances between portal and archive) with a small tweak while I evaluate swapping out `BaseInput type="number"`

### Discussion

I'd like to call it out of scope for now so we can get money handled for team members, and I'm not looking to add disruption to Benchmarking, but rather than having prefix/postfix characters in the masked input I'd like to see us move toward a UI that bakes this prefix/postfix into the input where it is static and non-interactive.  It helps limit special handling on the input values on our side and avoids some odd user interactions when capturing inputs.

<img width="1050" alt="Screenshot 2025-03-31 at 4 48 48 PM" src="https://github.com/user-attachments/assets/4d87a820-9d6d-4d1c-8136-9bbc67e21e9d" />
