### PR TITLE
[DEV-3404] init bulk actions support on dynamic table

### DIFF
--- a/dev/pages/Lists.vue
+++ b/dev/pages/Lists.vue
@@ -124,9 +124,9 @@ const dynamicTableActions: TableActions<Conifer> = {
 const dynamicTableBulkActions: TableBulkActions<Conifer> = {
   actions: [
     {
-      label: "Nuke em",
-      onClick: (ids, table) => {
-        const doit = confirm(`Nuke em? [${ids.join(",")}]`)
+      label: "Remove",
+      onClick: (ids, _, table) => {
+        const doit = confirm(`Remove these items? [${ids.join(",")}]`)
 
         if (doit) {
           table.refresh()
@@ -137,8 +137,8 @@ const dynamicTableBulkActions: TableBulkActions<Conifer> = {
       show: true,
     },
     {
-      label: "Alert em",
-      onClick: (ids, table) => {
+      label: "Update",
+      onClick: (ids, _, table) => {
         useAppSpinner.show()
 
         const promises: Promise<void>[] = []
@@ -186,12 +186,14 @@ const dynamicTableOptions: DynamicTableOptions = {
 
 const tableCopy = `<DynamicTable :table-columns="tableColumns" :table-options="tableOptions" />`
 const tableProps = [
-  { name: "clickable", required: false, type: "boolean" },
-  { name: "loader", required: false, type: "boolean" },
   { name: "tableActions", required: false, type: "TableActions<T>" },
-  { name: "tableActionsType", required: false, type: "dropdown | buttons" },
   { name: "tableColumns", required: true, type: "TableColumns<T>" },
   { name: "tableOptions", required: true, type: "DynamicTableOptions" },
+]
+
+const dynamictableProps = [
+  ...tableProps,
+  { name: "tableBulkActions", required: false, type: "TableBulkActions<T>" },
 ]
 </script>
 <template>
@@ -323,13 +325,16 @@ const tableProps = [
             :table-options="dynamicTableOptions"
             :table-actions="dynamicTableActions"
           />
-          <PropsTable :props="tableProps" />
+          <PropsTable :props="dynamictableProps" />
         </div>
       </div>
     </ComponentLayout>
 
     <ComponentLayout title="Table with Bulk Actions">
-      <template #description> TODO </template>
+      <template #description
+        >Individual row ActionsDropdown's can also be combined with bulk actions
+        applied against multiple row selections.</template
+      >
 
       <div>
         <label class="block text-sm font-medium text-gray-700">
@@ -342,7 +347,7 @@ const tableProps = [
             :table-actions="dynamicTableActions"
             :table-bulk-actions="dynamicTableBulkActions"
           />
-          <PropsTable :props="tableProps" />
+          <PropsTable :props="dynamictableProps" />
         </div>
       </div>
     </ComponentLayout>

--- a/dev/pages/Lists.vue
+++ b/dev/pages/Lists.vue
@@ -125,7 +125,7 @@ const dynamicTableBulkActions: TableBulkActions<Conifer> = {
   actions: [
     {
       label: "Nuke em",
-      onClick: (ids, _, table) => {
+      onClick: (ids, table) => {
         const doit = confirm(`Nuke em? [${ids.join(",")}]`)
 
         if (doit) {
@@ -138,15 +138,15 @@ const dynamicTableBulkActions: TableBulkActions<Conifer> = {
     },
     {
       label: "Alert em",
-      onClick: (_, data, table) => {
+      onClick: (ids, table) => {
         useAppSpinner.show()
 
         const promises: Promise<void>[] = []
-        data.forEach((tree, index) => {
+        ids.forEach((id, index) => {
           promises.push(
             new Promise((resolve) => {
               setTimeout(() => {
-                useAppFlasher.info(`Selected a ${tree.name}!`)
+                useAppFlasher.info(`Updating ${id}!`)
                 resolve()
               }, index * 1000)
             })

--- a/dev/pages/Lists.vue
+++ b/dev/pages/Lists.vue
@@ -138,15 +138,15 @@ const dynamicTableBulkActions: TableBulkActions<Conifer> = {
     },
     {
       label: "Update",
-      onClick: (ids, _, table) => {
+      onClick: (_, data, table) => {
         useAppSpinner.show()
 
         const promises: Promise<void>[] = []
-        ids.forEach((id, index) => {
+        data.forEach((data, index) => {
           promises.push(
             new Promise((resolve) => {
               setTimeout(() => {
-                useAppFlasher.info(`Updating ${id}!`)
+                useAppFlasher.info(`Updating ${data.name}!`)
                 resolve()
               }, index * 1000)
             })
@@ -174,7 +174,6 @@ const dynamicTableBulkActions: TableBulkActions<Conifer> = {
   isSelectable: (d) => {
     return d.leaf.type !== "Scale-leaf"
   },
-  persistent: false,
 }
 
 const dynamicTableOptions: DynamicTableOptions = {

--- a/dev/pages/Lists.vue
+++ b/dev/pages/Lists.vue
@@ -174,7 +174,7 @@ const dynamicTableBulkActions: TableBulkActions<Conifer> = {
   isSelectable: (d) => {
     return d.leaf.type !== "Scale-leaf"
   },
-  persistent: true,
+  persistent: false,
 }
 
 const dynamicTableOptions: DynamicTableOptions = {

--- a/dev/pages/Lists.vue
+++ b/dev/pages/Lists.vue
@@ -132,7 +132,7 @@ const dynamicTableBulkActions: TableBulkActions<Conifer> = {
           table.refresh()
         }
 
-        table.deselectAll()
+        table.clearSelection()
       },
       show: true,
     },
@@ -155,7 +155,7 @@ const dynamicTableBulkActions: TableBulkActions<Conifer> = {
 
         Promise.all(promises).then(() => {
           useAppSpinner.hide()
-          table.deselectAll()
+          table.clearSelection()
           table.refresh()
         })
       },
@@ -174,6 +174,7 @@ const dynamicTableBulkActions: TableBulkActions<Conifer> = {
   isSelectable: (d) => {
     return d.leaf.type !== "Scale-leaf"
   },
+  persistent: true,
 }
 
 const dynamicTableOptions: DynamicTableOptions = {

--- a/dev/pages/Navigation.vue
+++ b/dev/pages/Navigation.vue
@@ -30,7 +30,7 @@ const pagination = ref({
   page: 1,
   perPage: 10,
   totalItems: 100,
-  totalPages: 10,
+  totalPages: 100,
 })
 
 const paginatorCopy = `<Paginator v-model="pagination" />`
@@ -99,6 +99,31 @@ const tabsProps = [
             Current Page: {{ pagination.page }}
           </p>
           <Paginator
+            v-model="pagination"
+            @update:model-value="
+              $log(`Pagination update event, on page: (${$event.page})`)
+            "
+          />
+          <PropsTable :props="paginatorProps" />
+        </div>
+      </div>
+    </ComponentLayout>
+
+    <ComponentLayout title="Table Paginator">
+      <template #description>
+        This is used to create page numbers based on our server side paging
+        implementation underneath a list of data.
+      </template>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700">
+          <ClickToCopy :value="paginatorCopy" />
+        </label>
+        <div class="mt-1">
+          <p class="text-center font-bold mt-2 mb-8">
+            Current Page: {{ pagination.page }}
+          </p>
+          <TablePaginator
             v-model="pagination"
             @update:model-value="
               $log(`Pagination update event, on page: (${$event.page})`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4676,9 +4676,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7983,9 +7983,9 @@
       "dev": true
     },
     "vite": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.25.0",

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -136,4 +136,5 @@ export interface TableColumn<T = TableRowData> {
 export type TableCellAlignment = "left" | "center" | "right"
 export type TableRowData = Record<string, any>
 export type TableColumns<T = TableRowData> = TableColumn<T>[]
+
 export type TableRowsData = TableRowData[]

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -13,7 +13,7 @@ export interface DynamicTableOptions {
 }
 
 export interface DynamicTableAPI {
-  deselectAll: () => void
+  clearSelection: () => void
   /**
    * Force refresh the table data with the current api params state
    * @returns void
@@ -79,6 +79,8 @@ export interface TableBulkActions<T extends TableRowData = TableRowData> {
    * an array of TableActionItem definitions
    */
   actions: TableBulkActionItem<T>[]
+  persistent?: boolean // whether to persist the selections across pagination, searching, sorting, and filtering
+  // max?: number // TODO(spk): restrain users from creating server bombing selections?
   isSelectable?: (data: T) => boolean
 }
 

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -1,4 +1,4 @@
-import { VNodeChild } from "vue"
+import { VNodeChild, type ComputedRef } from "vue"
 import { ActionItem } from "@/composables/nav"
 import { DateRangeProps } from "./date"
 
@@ -12,7 +12,12 @@ export interface DynamicTableOptions {
   url: string
 }
 
-export interface DynamicTableAPI {
+export interface DynamicTableAPI<T = TableRowData> {
+  /**
+   * Clear the currently selected rows when bulk selections are enabled
+   * This method is called when refresh and reset methods are called.
+   * @returns void
+   */
   clearSelection: () => void
   /**
    * Force refresh the table data with the current api params state
@@ -24,6 +29,10 @@ export interface DynamicTableAPI {
    * @returns void
    */
   reset: () => void
+  /**
+   * The selected data records when bulk actions are enabled on the table
+   */
+  selectedData: ComputedRef<T[]>
 }
 
 export interface TableActionItem<T = TableRowData> extends ActionItem {
@@ -53,7 +62,7 @@ export interface TableActionItem<T = TableRowData> extends ActionItem {
   show?: boolean | ((rowData: T, rowIndex: number) => boolean)
 }
 
-export interface TableBulkActionItem extends ActionItem {
+export interface TableBulkActionItem<T = TableRowData> extends ActionItem {
   /**
    * Whether or not the bulk action item is enabled.  Disabled actions are
    * visible in the UI, but do not trigger click events.
@@ -62,11 +71,15 @@ export interface TableBulkActionItem extends ActionItem {
   /**
    * The callback method triggered by the action item buttons click event.
    * @param selected the array of selected rows by the primary key `id`
-   * @param _ NOTE(spk): Holding for T[]
+   * @param selectedData the array of selected rows as the underlying data type T
    * @param tableAPI DynamicTableAPI
    * @returns void
    */
-  onClick: (selected: number[], _: undefined, tableAPI: DynamicTableAPI) => void
+  onClick: (
+    selected: number[],
+    selectedData: T[],
+    tableAPI: DynamicTableAPI
+  ) => void
   /**
    * Whether or not to visible show the action item in the UI.  When all action items
    * on a table a hidden with show: false, bulk selections are disabled for the table.
@@ -89,11 +102,7 @@ export interface TableBulkActions<T = TableRowData> {
   /**
    * an array of TableActionItem definitions
    */
-  actions: TableBulkActionItem[]
-  /**
-   * whether to persist the selections across pagination, searching, sorting, and filtering
-   */
-  persistent?: boolean
+  actions: TableBulkActionItem<T>[]
   /**
    * a function that determines if the row can be selected for bulk actions
    */

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -55,11 +55,7 @@ export interface TableActionItem<T = TableRowData> extends ActionItem {
 
 export interface TableBulkActionItem<T = TableRowData> extends ActionItem {
   disabled?: boolean
-  onClick: (
-    selected: number[],
-    selectedRows: T[],
-    tableAPI: DynamicTableAPI
-  ) => void
+  onClick: (selected: number[], tableAPI: DynamicTableAPI) => void
   show?: boolean
 }
 
@@ -74,7 +70,7 @@ export interface TableActions<T = TableRowData> {
   type: "dropdown" | "buttons"
 }
 
-export interface TableBulkActions<T extends TableRowData = TableRowData> {
+export interface TableBulkActions<T = TableRowData> {
   /**
    * an array of TableActionItem definitions
    */
@@ -118,16 +114,6 @@ export interface TableColumn<T = TableRowData> {
 }
 
 export type TableCellAlignment = "left" | "center" | "right"
-export type TableRowData<
-  // NOTE(spk): enforced that TableRowData has an "id" key
-  T extends {
-    [key: string]: any
-    id: number
-  } = {
-    [key: string]: any
-    id: number
-  },
-> = T
+export type TableRowData = Record<string, any>
 export type TableColumns<T = TableRowData> = TableColumn<T>[]
-
 export type TableRowsData = TableRowData[]

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -62,10 +62,11 @@ export interface TableBulkActionItem extends ActionItem {
   /**
    * The callback method triggered by the action item buttons click event.
    * @param selected the array of selected rows by the primary key `id`
+   * @param _ NOTE(spk): Holding for T[]
    * @param tableAPI DynamicTableAPI
    * @returns void
    */
-  onClick: (selected: number[], tableAPI: DynamicTableAPI) => void
+  onClick: (selected: number[], _: undefined, tableAPI: DynamicTableAPI) => void
   /**
    * Whether or not to visible show the action item in the UI.  When all action items
    * on a table a hidden with show: false, bulk selections are disabled for the table.

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -53,9 +53,23 @@ export interface TableActionItem<T = TableRowData> extends ActionItem {
   show?: boolean | ((rowData: T, rowIndex: number) => boolean)
 }
 
-export interface TableBulkActionItem<T = TableRowData> extends ActionItem {
+export interface TableBulkActionItem extends ActionItem {
+  /**
+   * Whether or not the bulk action item is enabled.  Disabled actions are
+   * visible in the UI, but do not trigger click events.
+   */
   disabled?: boolean
+  /**
+   * The callback method triggered by the action item buttons click event.
+   * @param selected the array of selected rows by the primary key `id`
+   * @param tableAPI DynamicTableAPI
+   * @returns void
+   */
   onClick: (selected: number[], tableAPI: DynamicTableAPI) => void
+  /**
+   * Whether or not to visible show the action item in the UI.  When all action items
+   * on a table a hidden with show: false, bulk selections are disabled for the table.
+   */
   show?: boolean
 }
 
@@ -74,9 +88,14 @@ export interface TableBulkActions<T = TableRowData> {
   /**
    * an array of TableActionItem definitions
    */
-  actions: TableBulkActionItem<T>[]
-  persistent?: boolean // whether to persist the selections across pagination, searching, sorting, and filtering
-  // max?: number // TODO(spk): restrain users from creating server bombing selections?
+  actions: TableBulkActionItem[]
+  /**
+   * whether to persist the selections across pagination, searching, sorting, and filtering
+   */
+  persistent?: boolean
+  /**
+   * a function that determines if the row can be selected for bulk actions
+   */
   isSelectable?: (data: T) => boolean
 }
 

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -13,6 +13,7 @@ export interface DynamicTableOptions {
 }
 
 export interface DynamicTableAPI {
+  deselectAll: () => void
   /**
    * Force refresh the table data with the current api params state
    * @returns void
@@ -52,6 +53,16 @@ export interface TableActionItem<T = TableRowData> extends ActionItem {
   show?: boolean | ((rowData: T, rowIndex: number) => boolean)
 }
 
+export interface TableBulkActionItem<T = TableRowData> extends ActionItem {
+  disabled?: boolean
+  onClick: (
+    selected: number[],
+    selectedRows: T[],
+    tableAPI: DynamicTableAPI
+  ) => void
+  show?: boolean
+}
+
 export interface TableActions<T = TableRowData> {
   /**
    * an array of TableActionItem definitions
@@ -61,6 +72,14 @@ export interface TableActions<T = TableRowData> {
    * type determines what component will render the actions
    */
   type: "dropdown" | "buttons"
+}
+
+export interface TableBulkActions<T extends TableRowData = TableRowData> {
+  /**
+   * an array of TableActionItem definitions
+   */
+  actions: TableBulkActionItem<T>[]
+  isSelectable?: (data: T) => boolean
 }
 
 export interface TableColumn<T = TableRowData> {
@@ -97,7 +116,16 @@ export interface TableColumn<T = TableRowData> {
 }
 
 export type TableCellAlignment = "left" | "center" | "right"
-export type TableRowData = Record<string, any>
+export type TableRowData<
+  // NOTE(spk): enforced that TableRowData has an "id" key
+  T extends {
+    [key: string]: any
+    id: number
+  } = {
+    [key: string]: any
+    id: number
+  },
+> = T
 export type TableColumns<T = TableRowData> = TableColumn<T>[]
 
 export type TableRowsData = TableRowData[]

--- a/src/composables/table.ts
+++ b/src/composables/table.ts
@@ -6,6 +6,8 @@ export interface DynamicTableOptions {
   dateSearch?: boolean | DateRangeProps
   defaultSort?: string
   defaultSortDirection?: string
+  pageOptions?: { label: string; value: number }[]
+  perPage?: number
   refreshTrigger: number
   reloadTrigger?: number
   search?: boolean

--- a/src/composables/useTable.ts
+++ b/src/composables/useTable.ts
@@ -11,7 +11,7 @@ const isEmptyCellValue = (v: unknown): boolean => {
 }
 
 const tableAPIStub: DynamicTableAPI = {
-  deselectAll() {
+  clearSelection() {
     console.warn(
       "deselectAll() was called on a static table, did you mean to use DynamicTable?"
     )

--- a/src/composables/useTable.ts
+++ b/src/composables/useTable.ts
@@ -13,7 +13,7 @@ const isEmptyCellValue = (v: unknown): boolean => {
 const tableAPIStub: DynamicTableAPI = {
   clearSelection() {
     console.warn(
-      "deselectAll() was called on a static table, did you mean to use DynamicTable?"
+      "clearSelection() was called on a static table, did you mean to use DynamicTable?"
     )
   },
   refresh() {

--- a/src/composables/useTable.ts
+++ b/src/composables/useTable.ts
@@ -26,6 +26,7 @@ const tableAPIStub: DynamicTableAPI = {
       "reset() was called on a static table, did you mean to use DynamicTable?"
     )
   },
+  selectedData: computed(() => []),
 }
 
 export const useTable = (

--- a/src/composables/useTable.ts
+++ b/src/composables/useTable.ts
@@ -11,6 +11,11 @@ const isEmptyCellValue = (v: unknown): boolean => {
 }
 
 const tableAPIStub: DynamicTableAPI = {
+  deselectAll() {
+    console.warn(
+      "deselectAll() was called on a static table, did you mean to use DynamicTable?"
+    )
+  },
   refresh() {
     console.warn(
       "refresh() was called on a static table, did you mean to use DynamicTable?"
@@ -80,9 +85,9 @@ export const useTable = (
         rowData: rowData,
         cells: columns.value.map((col) => {
           const val =
-            typeof col.render === "string"
-              ? rowData[col.render]
-              : col.render(rowData, rowIdx)
+            typeof col.render === "function"
+              ? col.render.apply(undefined, [rowData, rowIdx])
+              : rowData[col.render]
 
           const classNames = col?.classNames || ""
 

--- a/src/lib-components/index.ts
+++ b/src/lib-components/index.ts
@@ -22,6 +22,7 @@ import { default as Spinner } from "./overlays/Spinner.vue"
 import { default as DataTable } from "./lists/DataTable.vue"
 import { default as Steps } from "./navigation/Steps.vue"
 import { default as DynamicTable } from "./lists/DynamicTable.vue"
+import { default as TablePaginator } from "./navigation/TablePaginator.vue"
 import { default as Tabs } from "./navigation/Tabs.vue"
 import { default as Toggle } from "./forms/Toggle.vue"
 import { default as XYSpinner } from "./indicators/XYSpinner.vue"
@@ -67,6 +68,7 @@ export {
   Steps,
   DynamicTable,
   Tabs,
+  TablePaginator,
   Toggle,
   Tooltip,
   BaseInput,
@@ -112,6 +114,7 @@ export interface TreesComponents {
   DynamicTable: typeof DynamicTable
   Steps: typeof Steps
   Tabs: typeof Tabs
+  TablePaginator: typeof TablePaginator
   Toggle: typeof Toggle
   Tooltip: typeof Tooltip
   BaseInput: typeof BaseInput

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -103,7 +103,7 @@ const dateRange = ref({
 
 const pagination = ref({
   page: 1,
-  perPage: 10,
+  perPage: props.tableOptions?.perPage || 10,
   totalItems: 0,
   totalPages: 0,
 })
@@ -497,6 +497,7 @@ loadAndRender()
     <div v-if="hasContent" class="mt-4">
       <TablePaginator
         v-model="pagination"
+        :page-options="tableOptions?.pageOptions"
         @update:model-value="loadAndRender()"
       />
     </div>

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -169,7 +169,11 @@ const bulkActions = computed(() => {
         ...action,
         disabled: selected.value.length === 0 || action.disabled,
         onClick: () =>
-          action.onClick.apply(undefined, [selected.value, publicMethods]),
+          action.onClick.apply(undefined, [
+            selected.value,
+            undefined,
+            publicMethods,
+          ]),
       }
     })
 })

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, toRef, watch } from "vue"
-import { ActionsDropdown } from "@/lib-components"
+import { ActionsDropdown, TablePaginator } from "@/lib-components"
 import DateRangePicker from "../forms/DateRangePicker.vue"
-import Paginator from "../navigation/Paginator.vue"
 import BaseAPI from "../../api/base"
 import type {
   DynamicTableAPI,
@@ -508,10 +507,11 @@ loadAndRender()
       </table>
     </div>
 
-    <Paginator
-      v-if="hasContent"
-      v-model="pagination"
-      @update:model-value="loadAndRender()"
-    />
+    <div v-if="hasContent" class="mt-4">
+      <TablePaginator
+        v-model="pagination"
+        @update:model-value="loadAndRender()"
+      />
+    </div>
   </div>
 </template>

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -8,7 +8,9 @@ import type {
   DynamicTableAPI,
   DynamicTableOptions,
   TableActions,
+  TableBulkActions,
   TableColumns,
+  TableRowData,
 } from "@/composables/table"
 import { useAppFlasher } from "@/composables/useFlashes"
 import { TrailsRespPaged } from "@/api/client"
@@ -19,11 +21,13 @@ import TableActionButtons from "./TableActionButtons.vue"
 const props = withDefaults(
   defineProps<{
     tableActions?: TableActions<any>
+    tableBulkActions?: TableBulkActions<any>
     tableColumns: TableColumns<any>
     tableOptions: DynamicTableOptions
   }>(),
   {
     tableActions: () => ({ type: "dropdown", actions: [] }),
+    tableBulkActions: () => ({ actions: [] }),
   }
 )
 
@@ -54,7 +58,7 @@ const loadAndRender = (): void => {
         totalItems: success.data.totalItems,
         totalPages: success.data.totalPages,
       }
-      tableData.value = success.data.items as Record<string, any>[]
+      tableData.value = success.data.items as TableRowData[]
     },
     () => {
       useAppFlasher.genericError()
@@ -81,19 +85,7 @@ const setDateRange = (): void => {
   }
 }
 
-const tableData = ref<Record<string, any>[]>([])
-
-const publicMethods: DynamicTableAPI = {
-  refresh: loadAndRender,
-  reset: reloadTable,
-}
-
-const { columns, hasActions, isEmptyCellValue, rows } = useTable(
-  tableData,
-  toRef(props, "tableColumns"),
-  toRef(props, "tableActions"),
-  publicMethods
-)
+const tableData = ref<TableRowData[]>([])
 
 const currentSort = ref(
   props.tableOptions.defaultSort ? props.tableOptions.defaultSort : ""
@@ -144,6 +136,71 @@ const dateSearchProps = computed((): DateRangeProps => {
 const hasContent = computed((): boolean => {
   return rows.value.length ? true : false
 })
+
+const deselectAll = () => {
+  selected.value = []
+}
+
+const selected = defineModel<number[]>("selected", {
+  required: false,
+  default: [],
+})
+
+const selectedData = computed<TableRowData[]>(() => {
+  return tableData.value.filter((data) => {
+    return selected.value.includes(data.id)
+  })
+})
+
+const bulkActions = computed(() => {
+  return props.tableBulkActions.actions
+    .filter((action) => {
+      return action.show ?? true
+    })
+    .map((action) => {
+      return {
+        ...action,
+        disabled: selected.value.length === 0 || action.disabled,
+        onClick: () =>
+          action.onClick.apply(undefined, [
+            selected.value,
+            selectedData.value,
+            publicMethods,
+          ]),
+      }
+    })
+})
+
+const hasBulkActions = computed(() => bulkActions.value.length > 0)
+
+const selectableIds = computed(() => {
+  return tableData.value
+    .filter((row) => {
+      if (props.tableBulkActions.isSelectable === undefined) {
+        return true
+      }
+
+      if (props.tableBulkActions.isSelectable(row)) {
+        return true
+      }
+
+      return false
+    })
+    .map((d) => d["id"])
+})
+
+const publicMethods: DynamicTableAPI = {
+  deselectAll: deselectAll,
+  refresh: loadAndRender,
+  reset: reloadTable,
+}
+
+const { columns, hasActions, isEmptyCellValue, rows } = useTable(
+  tableData,
+  toRef(props, "tableColumns"),
+  toRef(props, "tableActions"),
+  publicMethods
+)
 
 watch(
   () => props.tableOptions.refreshTrigger,
@@ -237,6 +294,27 @@ loadAndRender()
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-100">
           <tr>
+            <th v-if="hasBulkActions" scope="col" class="pl-6 w-4 leading-none">
+              <input
+                :class="[
+                  'h-4 w-4 rounded cursor-pointer',
+                  'disabled:bg-gray-100 disabled:border-gray-200  disabled:cursor-not-allowed disabled:opacity-100',
+                  'checked:disabled:bg-xy-blue checked:disabled:border-xy-blue checked:disabled:opacity-50',
+                  'border-gray-300 focus:ring-xy-blue-500',
+                ]"
+                :checked="selected.length === selectableIds.length"
+                :indeterminate="
+                  selected.length > 0 && selected.length < selectableIds.length
+                "
+                type="checkbox"
+                @change="
+                  selected = ($event.target as HTMLInputElement).checked
+                    ? selectableIds.map((id) => id)
+                    : []
+                "
+              />
+            </th>
+
             <th
               v-for="(col, idx) in columns"
               :key="idx"
@@ -303,6 +381,19 @@ loadAndRender()
               class="px-6 py-3 text-xs font-medium tracking-wider text-gray-900 uppercase leading-4"
             />
           </tr>
+
+          <tr v-if="selected.length > 0">
+            <td colspan="100%" class="px-6 py-3 border-t bg-neutral-50">
+              <div class="flex items-center space-x-3">
+                <div class="text-sm font-semibold">
+                  {{ selected.length }}
+                  selected
+                </div>
+
+                <TableActionButtons :actions="bulkActions" />
+              </div>
+            </td>
+          </tr>
         </thead>
 
         <tbody class="bg-white">
@@ -312,6 +403,21 @@ loadAndRender()
             class="even:bg-gray-50"
             @click="$emit('click:row', row.rowData)"
           >
+            <td v-if="hasBulkActions" class="pl-6 w-4 leading-none">
+              <input
+                v-model="selected"
+                :class="[
+                  'h-4 w-4 rounded cursor-pointer',
+                  'disabled:bg-gray-100 disabled:border-gray-200  disabled:cursor-not-allowed disabled:opacity-100',
+                  'checked:disabled:bg-xy-blue checked:disabled:border-xy-blue checked:disabled:opacity-50',
+                  'border-gray-300 focus:ring-xy-blue-500',
+                ]"
+                :disabled="!selectableIds.includes(row.rowData.id)"
+                type="checkbox"
+                :value="row.rowData.id"
+              />
+            </td>
+
             <template v-for="(cell, cellIdx) in row.cells" :key="cellIdx">
               <component
                 :is="'td'"

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -424,19 +424,21 @@ loadAndRender()
           </tr>
 
           <tr v-if="hasBulkActions && selected.length > 0">
-            <td colspan="100%" class="px-6 py-3 border-t bg-neutral-50">
-              <div class="flex items-center space-x-3">
+            <td colspan="100%" class="px-6 py-2.5 border-t bg-neutral-50">
+              <div class="flex items-center gap-x-3">
+                <div class="text-sm shrink-0">
+                  Selected
+                  <span class="font-medium">{{ selectedOnPage.length }}</span>
+                  of
+                  <span class="font-medium">{{ selectable.length }}</span>
+                  <span v-if="selectionsPersisted">
+                    /
+                    <span class="font-medium">{{ selected.length }}</span>
+                    total
+                  </span>
+                </div>
+
                 <TableActionButtons :actions="bulkActions" />
-
-                <div v-if="selectionsPersisted" class="text-sm font-semibold">
-                  You've selected {{ selectedOnPage.length }} on this page and
-                  {{ selected.length }} across all pages.
-                </div>
-
-                <div v-else class="text-sm font-semibold">
-                  {{ selected.length }}
-                  selected
-                </div>
               </div>
             </td>
           </tr>

--- a/src/lib-components/navigation/ActionsDropdown.vue
+++ b/src/lib-components/navigation/ActionsDropdown.vue
@@ -5,13 +5,16 @@ import type { ActionItem } from "@/composables/nav"
 import { useActionItems } from "@/composables/useActionItems"
 import { toRef, useTemplateRef } from "vue"
 import { useFloating, autoUpdate } from "@floating-ui/vue"
+import type { Placement } from "@floating-ui/vue"
 
 const props = withDefaults(
   defineProps<{
     actions?: ActionItem[]
+    placement?: Placement
   }>(),
   {
     actions: () => [],
+    placement: "bottom-end",
   }
 )
 
@@ -22,7 +25,7 @@ const { actions, hasActions } = useActionItems(toRef(props, "actions"))
 const triggerRef = useTemplateRef<InstanceType<typeof MenuButton>>("trigger")
 const wrapperRef = useTemplateRef<HTMLElement | null>("wrapper")
 const { floatingStyles } = useFloating(triggerRef, wrapperRef, {
-  placement: "bottom-end",
+  placement: props.placement,
   strategy: "fixed",
   whileElementsMounted: autoUpdate,
 })

--- a/src/lib-components/navigation/TablePaginator.vue
+++ b/src/lib-components/navigation/TablePaginator.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { Pagination } from "@/composables/nav"
+import { debounceFn } from "@/entry"
+import { NumberInput, Select } from "@/lib-components"
+import { computed } from "vue"
+
+const props = defineProps<{
+  pageOptions?: { label: string; value: number }[]
+}>()
+
+const pagination = defineModel<Pagination>({ required: true })
+
+const page = computed({
+  get: () => pagination.value.page,
+  set: (v: number) => {
+    pagination.value = {
+      ...pagination.value,
+      page: v,
+    }
+  },
+})
+
+const perPage = computed({
+  get: () => pagination.value.perPage,
+  set: (v: number) => {
+    pagination.value = {
+      ...pagination.value,
+      perPage: v,
+    }
+  },
+})
+
+const pageSelectOpts = computed(() => {
+  if (props.pageOptions) {
+    return props.pageOptions
+  }
+
+  return [
+    { label: "5 per page", value: 5 },
+    { label: "10 per page", value: 10 },
+    { label: "20 per page", value: 20 },
+    { label: "50 per page", value: 50 },
+  ]
+})
+
+const debouncePageInput = debounceFn((val: number | null) => {
+  if (val === null) {
+    return
+  }
+
+  if (val === page.value) {
+    return
+  }
+
+  page.value = val
+}, 350)
+
+const onDown = debounceFn(() => {
+  if (page.value <= 1) {
+    return
+  }
+
+  page.value = page.value - 1
+}, 250)
+
+const onUp = debounceFn(() => {
+  if (page.value >= pagination.value.totalPages) {
+    return
+  }
+
+  page.value = page.value + 1
+}, 250)
+
+const range = computed(() => {
+  const { page, perPage, totalItems } = pagination.value
+  return {
+    start: totalItems > 0 ? (page - 1) * perPage + 1 : 0,
+    end: Math.min(page * perPage, totalItems),
+  }
+})
+</script>
+
+<template>
+  <div
+    class="flex flex-col items-center space-y-3.5 sm:flex-row sm:space-y-0 sm:gap-x-3 sm:justify-center"
+  >
+    <!--Range details-->
+    <div
+      class="text-center text-sm font-medium text-neutral-600 sm:text-left sm:mr-auto"
+    >
+      Showing {{ range.start }}-{{ range.end }} of
+      {{ pagination.totalItems }} results
+    </div>
+
+    <!--Pager-->
+    <div class="flex gap-3 items-center justify-center shrink-0">
+      <button
+        class="xy-btn-neutral"
+        :disabled="page <= 1"
+        type="button"
+        @click.prevent="page--"
+      >
+        &larr; <span class="sr-only">Previous</span>
+      </button>
+
+      <div class="max-w-[50px]">
+        <NumberInput
+          :model-value="page"
+          :min="1"
+          :max="pagination.totalPages"
+          type="number"
+          @update:model-value="debouncePageInput"
+          @keydown.down="onDown"
+          @keydown.up="onUp"
+        />
+      </div>
+
+      <div class="text-sm font-semibold">of {{ pagination.totalPages }}</div>
+
+      <button
+        class="xy-btn-neutral"
+        :disabled="page >= pagination.totalPages"
+        type="button"
+        @click.prevent="page++"
+      >
+        <span class="sr-only">Next</span> &rarr;
+      </button>
+    </div>
+
+    <!--Per Page Selector-->
+    <div class="max-w-[150px] sm:ml-auto">
+      <Select v-model="perPage" :options="pageSelectOpts" />
+    </div>
+  </div>
+</template>

--- a/src/lib-components/navigation/TablePaginator.vue
+++ b/src/lib-components/navigation/TablePaginator.vue
@@ -85,7 +85,9 @@ const range = computed(() => {
     class="flex flex-col items-center space-y-3.5 sm:flex-row sm:space-y-0 sm:gap-x-3 sm:justify-center"
   >
     <!--Range details-->
-    <p class="text-center text-sm text-neutral-700 sm:text-left sm:mr-auto">
+    <p
+      class="text-center text-sm text-neutral-700 sm:text-left sm:mr-auto sm:w-1/3"
+    >
       Showing
       <span class="font-medium">{{ range.start }}</span>
       to
@@ -95,46 +97,50 @@ const range = computed(() => {
       results
     </p>
 
-    <!--Pager-->
-    <div class="flex gap-3 items-center justify-center shrink-0">
-      <button
-        class="xy-btn-neutral"
-        :disabled="page <= 1"
-        type="button"
-        @click.prevent="page--"
-      >
-        &larr; <span class="sr-only">Previous</span>
-      </button>
+    <div
+      class="flex flex-col items-center space-y-3.5 sm:flex-row sm:space-y-0 sm:gap-x-3 sm:flex-1"
+    >
+      <!--Pager-->
+      <div class="flex gap-3 items-center justify-center shrink-0 md:w-1/2">
+        <button
+          class="xy-btn-neutral"
+          :disabled="page <= 1"
+          type="button"
+          @click.prevent="page--"
+        >
+          &larr; <span class="sr-only">Previous</span>
+        </button>
 
-      <div class="max-w-[50px]">
-        <NumberInput
-          :model-value="page"
-          :min="1"
-          :max="pagination.totalPages"
-          type="number"
-          @update:model-value="debouncePageInput"
-          @keydown.down="onDown"
-          @keydown.up="onUp"
-        />
+        <div class="max-w-[50px]">
+          <NumberInput
+            :model-value="page"
+            :min="1"
+            :max="pagination.totalPages"
+            type="number"
+            @update:model-value="debouncePageInput"
+            @keydown.down.prevent="onDown"
+            @keydown.up.prevent="onUp"
+          />
+        </div>
+
+        <div class="text-sm">
+          of <span class="font-medium">{{ pagination.totalPages }}</span>
+        </div>
+
+        <button
+          class="xy-btn-neutral"
+          :disabled="page >= pagination.totalPages"
+          type="button"
+          @click.prevent="page++"
+        >
+          <span class="sr-only">Next</span> &rarr;
+        </button>
       </div>
 
-      <div class="text-sm">
-        of <span class="font-medium">{{ pagination.totalPages }}</span>
+      <!--Per Page Selector-->
+      <div class="max-w-[150px] sm:ml-auto">
+        <Select v-model="perPage" :options="pageSelectOpts" />
       </div>
-
-      <button
-        class="xy-btn-neutral"
-        :disabled="page >= pagination.totalPages"
-        type="button"
-        @click.prevent="page++"
-      >
-        <span class="sr-only">Next</span> &rarr;
-      </button>
-    </div>
-
-    <!--Per Page Selector-->
-    <div class="max-w-[150px] sm:ml-auto">
-      <Select v-model="perPage" :options="pageSelectOpts" />
     </div>
   </div>
 </template>

--- a/src/lib-components/navigation/TablePaginator.vue
+++ b/src/lib-components/navigation/TablePaginator.vue
@@ -85,12 +85,15 @@ const range = computed(() => {
     class="flex flex-col items-center space-y-3.5 sm:flex-row sm:space-y-0 sm:gap-x-3 sm:justify-center"
   >
     <!--Range details-->
-    <div
-      class="text-center text-sm font-medium text-neutral-600 sm:text-left sm:mr-auto"
-    >
-      Showing {{ range.start }}-{{ range.end }} of
-      {{ pagination.totalItems }} results
-    </div>
+    <p class="text-center text-sm text-neutral-700 sm:text-left sm:mr-auto">
+      Showing
+      <span class="font-medium">{{ range.start }}</span>
+      to
+      <span class="font-medium">{{ range.end }}</span>
+      of
+      <span class="font-medium">{{ pagination.totalItems }}</span>
+      results
+    </p>
 
     <!--Pager-->
     <div class="flex gap-3 items-center justify-center shrink-0">
@@ -115,7 +118,9 @@ const range = computed(() => {
         />
       </div>
 
-      <div class="text-sm font-semibold">of {{ pagination.totalPages }}</div>
+      <div class="text-sm">
+        of <span class="font-medium">{{ pagination.totalPages }}</span>
+      </div>
 
       <button
         class="xy-btn-neutral"


### PR DESCRIPTION
# What this does

- adds bulk action support on `DynamicTable`
- adds a `TablePaginator` component to replace the existing `Paginator` on tables to allow larger table views and aid in larger bulk selections
- adds `placement` support to `ActionsDropdown` - I did not end up using this, but left it for the future.

### What this doesn't do

I need to find a stopping point on this one since its usage is still pretty narrow and what's here should give us something to work with for the existing use cases and some new ones.

- ~~the bulk action callback does not include the full row data, it only includes the `ids`, persistent mode makes this just a hair more difficult to add, but it's a small add when there is a little more time~~
- a unique `id` key is assumed to be on the resource record - this can be flexible in the future if needed, but doesn't seem useful enough right now
- persistent mode has been removed for now as it seems more likely to be difficult to maintain than it is useful

### Notes

- checkout https://github.com/xy-planning-network/college-try/pull/1899 for a more functional demo
- I'm interested in alternative thoughts on the default `perPage` options in the `TablePaginator` - these seemed reasonable and common, but I did not give them a lot of thought
- The `keydown` handling on the `TablePaginator` was cheap, so I threw it in.  It's far from perfect with the debouncing, but seems like a nice, subtle feature and gives us something to look at for `NumerberInput`
- A dynamic table will show the bulk selection checkboxes anytime you have available bulk actions, i.e. you can compute show: false to disable bulk actions on shared table components.
- `v-model:selected` is available on the table to persist selections across `v-if` scenarios