### PR TITLE
[DEV-3650] reset page param when perPage mutates, add red badge

### DIFF
--- a/dev/pages/Elements.vue
+++ b/dev/pages/Elements.vue
@@ -8,6 +8,7 @@ import { InputOption } from "@/composables/forms"
 const badgePrimary = ref<HTMLElement>()
 const badgeInfo = ref<HTMLElement>()
 const badgeSuccess = ref<HTMLElement>()
+const badgeWarn = ref<HTMLElement>()
 const badgeAlert = ref<HTMLElement>()
 const links = ref<HTMLElement>()
 const extraFlairCopy = `<h1 class="xy-h1-extra-flair">Header1 Bold</h1>`
@@ -184,10 +185,19 @@ const alertProps = [
 
       <div>
         <label class="block text-sm font-medium text-gray-700">
+          <ClickToCopy :value="badgeWarn?.outerHTML" />
+        </label>
+        <div class="mt-1">
+          <span ref="badgeWarn" class="xy-badge-yellow">Warn</span>
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700">
           <ClickToCopy :value="badgeAlert?.outerHTML" />
         </label>
         <div class="mt-1">
-          <span ref="badgeAlert" class="xy-badge-yellow">Alert</span>
+          <span ref="badgeAlert" class="xy-badge-red">Alert</span>
         </div>
       </div>
     </ComponentLayout>

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,10 @@
     @apply inline-flex justify-center items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-800;
   }
 
+  .xy-badge-red {
+    @apply inline-flex justify-center items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-red-100 text-red-800;
+  }
+
   /*
     Button classes
 

--- a/src/lib-components/navigation/TablePaginator.vue
+++ b/src/lib-components/navigation/TablePaginator.vue
@@ -25,6 +25,7 @@ const perPage = computed({
   set: (v: number) => {
     pagination.value = {
       ...pagination.value,
+      page: 1,
       perPage: v,
     }
   },


### PR DESCRIPTION
# What this does

- Table pagination should reset to page 1 when the perPage variable is mutated to avoid ending up viewing the current page with no results and a hidden paginator
- add a red badge for good measure while I'm here, because it's pretty standard and we have state displays that could use it