### PR TITLE
[DEV-3709] minor form layout fixes

### DIFF
--- a/src/lib-components/forms/FieldsetLegend.vue
+++ b/src/lib-components/forms/FieldsetLegend.vue
@@ -37,7 +37,7 @@ const labelDisplay = computed((): string => {
     class="block text-sm leading-6 font-semibold text-gray-800"
     v-bind="$attrs"
   >
-    {{ labelDisplay }}
-    <span v-if="props.required" class="text-red-700/80">*</span>
+    {{ labelDisplay
+    }}<span v-if="props.required" class="text-red-700/80">*</span>
   </component>
 </template>

--- a/src/lib-components/forms/InputLabel.vue
+++ b/src/lib-components/forms/InputLabel.vue
@@ -37,7 +37,7 @@ const labelDisplay = computed((): string => {
     class="block text-sm leading-snug font-medium text-gray-800"
     v-bind="$attrs"
   >
-    {{ labelDisplay }}
-    <span v-if="props.required" class="text-red-700/80" aria-hidden>*</span>
+    {{ labelDisplay
+    }}<span v-if="props.required" class="text-red-700/80" aria-hidden>*</span>
   </component>
 </template>

--- a/src/lib-components/forms/RadioCards.vue
+++ b/src/lib-components/forms/RadioCards.vue
@@ -53,23 +53,26 @@ const onUpdate = (val: unknown) => {
 <template>
   <RadioGroup
     v-model="modelState"
+    class="space-y-6"
     :disabled="isDisabled"
     :aria-invalid="errorState ? 'true' : null"
     :aria-errormessage="aria.errormessage"
     @update:model-value="onUpdate"
   >
-    <RadioGroupLabel v-if="label" class="block">
-      <FieldsetLegend tag="div" :label="label" :required="isRequired" />
-    </RadioGroupLabel>
+    <div v-if="label || help || errorState">
+      <RadioGroupLabel v-if="label" class="block">
+        <FieldsetLegend tag="div" :label="label" :required="isRequired" />
+      </RadioGroupLabel>
 
-    <RadioGroupDescription v-if="help" class="mt-1">
-      <InputHelp :text="help" />
-    </RadioGroupDescription>
+      <RadioGroupDescription v-if="help" class="mt-1">
+        <InputHelp :text="help" />
+      </RadioGroupDescription>
 
-    <InputError :id="aria.errormessage" class="mt-1" :text="errorState" />
+      <InputError :id="aria.errormessage" class="mt-1" :text="errorState" />
+    </div>
 
     <div
-      class="mt-6 grid grid-cols-1 gap-y-5 gap-x-4 relative"
+      class="grid grid-cols-1 gap-y-5 gap-x-4 relative"
       :class="{
         'sm:grid-cols-2': columns === 2,
         'sm:grid-cols-3': columns === 3,


### PR DESCRIPTION
# What this does

- fixes unnecessary margin on RadioCards when no copy precedes the card layout
- removes white space from required field indicators which can cause the indicator to wrap on to it's own line