### PR TITLE
mount the date range picker flyout menu inside the wrapper

### DIFF
--- a/dev/pages/Forms.vue
+++ b/dev/pages/Forms.vue
@@ -7,6 +7,7 @@ import {
   numericInputTypes,
   textInputTypes,
 } from "@/composables/forms"
+import Slideover from "@/lib-components/overlays/Slideover.vue"
 
 const options: InputOption[] = [
   {
@@ -175,6 +176,8 @@ const toggleProps = [
   { name: "label", required: false, type: "string" },
   { name: "help", required: false, type: "string" },
 ]
+
+const slideoverOpen = ref(false)
 </script>
 
 <template>
@@ -448,6 +451,23 @@ const toggleProps = [
               label="Hydrated Range"
               help="Initialized with { minDate: 1725148800, maxDate: 1727740799 }"
             />
+          </div>
+
+          <div class="mt-4">
+            <h5 class="mb-2">Date Range Picker Inside A Dialog</h5>
+            <button class="xy-btn-sm" @click="slideoverOpen = !slideoverOpen">
+              Open Slideover
+            </button>
+            <Slideover
+              v-model="slideoverOpen"
+              header="Forms"
+              description="Ensure this element is accessible inside a slideover."
+            >
+              <DateRangePicker
+                v-model="inputVals['dateRangePicker']"
+                label="Select a Date Range"
+              />
+            </Slideover>
           </div>
           <PropsTable :props="dateRangeInputProps" />
         </div>

--- a/src/lib-components/forms/DateRangePicker.vue
+++ b/src/lib-components/forms/DateRangePicker.vue
@@ -4,7 +4,7 @@ import InputHelp from "./InputHelp.vue"
 import InputError from "./InputError.vue"
 import flatpickr from "flatpickr"
 import "flatpickr/dist/flatpickr.min.css"
-import { onMounted } from "vue"
+import { onMounted, useTemplateRef } from "vue"
 import {
   defaultInputProps,
   defaultModelOpts,
@@ -17,7 +17,7 @@ defineOptions({
 })
 
 // maxDate/startDate should be used or maxRange.
-// The props combination of maxDate/startDate and maxRange 
+// The props combination of maxDate/startDate and maxRange
 // will have unexpected results.
 const props = withDefaults(defineProps<DateRangeInput>(), {
   ...defaultInputProps,
@@ -38,9 +38,12 @@ const updateModelState = (value: { minDate: number; maxDate: number }) => {
   modelState.value = value
 }
 
+const wrapper = useTemplateRef("wrapper")
+
 onMounted(() => {
   const opts: flatpickr.Options.Options = {
     allowInput: true,
+    appendTo: wrapper.value || undefined,
     dateFormat: "m-d-Y",
     mode: "range",
     maxDate: props.maxDate,
@@ -60,6 +63,7 @@ onMounted(() => {
         })
       }
     },
+    static: true,
   }
 
   // Handle initial values if set
@@ -100,7 +104,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div>
+  <div ref="wrapper">
     <InputLabel
       :id="aria.labelledby"
       class="mb-2"
@@ -130,3 +134,9 @@ onMounted(() => {
     <InputError :id="aria.errormessage" class="mt-0.5" :text="errorState" />
   </div>
 </template>
+
+<style lang="postcss">
+.flatpickr-wrapper {
+  display: block;
+}
+</style>


### PR DESCRIPTION
# What this does

This change has the date pickers fly out menu element appended to our inputs wrapper to keep the fly out elements context within whatever other element the input is placed.  This should resolve issues where a date range picker placed in a modal or slideover is inaccessible as currently Flatpickr will append the fly out to the body and Headless UI's focus traps will prevent interaction with it.

I've added a `DateRangePicker` inside a `Slideover` in the docs for a quick test.