### PR TITLE
don't seralize date range params when unset

### DIFF
--- a/src/lib-components/lists/DetailList.vue
+++ b/src/lib-components/lists/DetailList.vue
@@ -75,8 +75,8 @@ const sortDir = ref(props.defaultSortDir)
 
 const loadAndRender = (): void => {
   const params: Record<string, unknown> = {
-    maxDate: dateRange.value.maxDate,
-    minDate: dateRange.value.minDate,
+    maxDate: dateRange.value.maxDate || null,
+    minDate: dateRange.value.minDate || null,
     page: pagination.value.page,
     perPage: pagination.value.perPage,
     q: "",

--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -36,8 +36,8 @@ defineEmits<{
 
 const loadAndRender = (): void => {
   const params = {
-    minDate: dateRange.value.minDate,
-    maxDate: dateRange.value.maxDate,
+    minDate: dateRange.value.minDate || null,
+    maxDate: dateRange.value.maxDate || null,
     page: pagination.value.page,
     perPage: pagination.value.perPage,
     sort: currentSort.value,


### PR DESCRIPTION
# What this does

- sets minDate and maxDate to null when the dateRange value is 0 (unset) to avoid serializing `minDate=0&maxDate=0`

### Notes

When you bring your own date range filtering to a `DynamicTable` or `DynamicList` there can be a conflict in query params where `minDate` and `maxDate` are set twice.  There are quite a few ways to think about this and deal with it, but this looks the most straightforward for now as `CommonParams` will set `MinDate/MaxDate` fields to their 0 value.  Could present some issues later if you had required date range params, but the components lack enforcement of that anyway and more would need to be done to support that.