### PR TITLE
conditionally set the q param based on existance of search bar

### DIFF
--- a/src/lib-components/lists/DynamicTable.vue
+++ b/src/lib-components/lists/DynamicTable.vue
@@ -45,7 +45,7 @@ const loadAndRender = (): void => {
     perPage: pagination.value.perPage,
     sort: currentSort.value,
     sortDir: currentSortDirection.value,
-    q: query.value,
+    q: props.tableOptions.search ? query.value : undefined,
   }
 
   clearSelections()


### PR DESCRIPTION
[DEV-4711](https://app.notion.com/p/xylabs/DynamicTable-only-set-q-param-when-search-is-enabled-371d6eba0f7b8010996bd560479b7ea9) - avoids duplicate `q` params when the search bar is not in use.  There are some edge cases that could come up with this, but I think this is what everyone would expect until we dig into filtering further.