### PR TITLE
add after-leave event to overlays

### DIFF
--- a/dev/pages/Overlays.vue
+++ b/dev/pages/Overlays.vue
@@ -109,6 +109,7 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
           <ContentModal
             v-model="contentModalOpen"
             title="Good Job!"
+            @after-leave="$log('bye bye!')"
             @close="$log('ContentModal close event triggered!')"
             @update:model-value="
               $log(`v-model update event for ContentModal: ${$event}`)
@@ -190,6 +191,7 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
             :destructive="true"
             submit-text="Remove"
             title="Remove Thing"
+            @after-leave="$log('bye bye!')"
             @close="$log('Modal close event triggered!')"
             @submit="open = false"
             @update:model-value="
@@ -255,6 +257,7 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
             v-model="slideoverOpen"
             header="Slideover Header"
             description="A very helpful slideover description"
+            @after-leave="$log('bye bye!')"
             @close="$log('Slideover close event triggered!')"
             @update:model-value="
               $log(`v-model update event for Slideover: ${$event}`)
@@ -316,9 +319,7 @@ const tooltipCopy = `<Tooltip>Here's something subtly helpful.</Tooltip>`
                 :key="n"
                 class="flex items-center p-4 border-b"
               >
-                <ExclamationTriangleIcon
-                  class="w-7 h-7 mr-2 text-yellow-500"
-                />
+                <ExclamationTriangleIcon class="w-7 h-7 mr-2 text-yellow-500" />
                 <div>
                   You see that post on
                   <a

--- a/src/lib-components/overlays/ContentModal.vue
+++ b/src/lib-components/overlays/ContentModal.vue
@@ -22,6 +22,7 @@ withDefaults(
 const open = defineModel<boolean>({ required: true })
 
 const emit = defineEmits<{
+  (e: "afterLeave"): void
   (e: "close"): void
 }>()
 
@@ -71,6 +72,7 @@ watch(open, (isOpen) => {
           leave="ease-in duration-200"
           leave-from="opacity-100 translate-y-0 sm:scale-100"
           leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+          @after-leave="emit('afterLeave')"
         >
           <div
             class="inline-block align-bottom bg-white rounded-xy px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-md sm:w-full sm:p-8 sm:rounded-xy-lg"

--- a/src/lib-components/overlays/Modal.vue
+++ b/src/lib-components/overlays/Modal.vue
@@ -29,6 +29,7 @@ const props = withDefaults(
 const open = defineModel<boolean>({ required: true })
 
 const emit = defineEmits<{
+  (e: "afterLeave"): void
   (e: "close"): void
   (e: "submit"): void
 }>()
@@ -89,6 +90,7 @@ watch(open, (isOpen) => {
           leave="ease-in duration-200"
           leave-from="opacity-100 translate-y-0 sm:scale-100"
           leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+          @after-leave="emit('afterLeave')"
         >
           <div
             class="inline-block align-bottom text-left overflow-y-visible transform transition-all w-full sm:my-8 sm:align-middle"

--- a/src/lib-components/overlays/Slideover.vue
+++ b/src/lib-components/overlays/Slideover.vue
@@ -43,6 +43,7 @@ const layout = computed(() => {
 const open = defineModel<boolean>({ required: true })
 
 const emit = defineEmits<{
+  (e: "afterLeave"): void
   (e: "close"): void
 }>()
 
@@ -73,6 +74,7 @@ watch(open, (isOpen) => {
             leave="transform transition ease-in-out duration-500 sm:duration-700"
             leave-from="translate-x-0"
             leave-to="translate-x-full"
+            @after-leave="emit('afterLeave')"
           >
             <div :class="['w-screen', layout.maxWidth]">
               <div


### PR DESCRIPTION
# What this does

- exposes an `after-leave` event on `Slideover`, `Modal`, and `ContentModal`, so callers know when the close animation has completed.  Currently, I use hacky setTimeouts to avoid component destruction before the animation is over.